### PR TITLE
fix: add touch-friendly filter/exclude buttons for mobile devices

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -350,6 +350,13 @@ header {
   gap: 16px;
 }
 
+@media (max-width: 600px) {
+  header {
+    padding: 12px;
+    gap: 8px;
+  }
+}
+
 .header-left {
   flex: 1;
   min-width: 0;
@@ -470,11 +477,23 @@ main {
   padding: 0 24px 24px 24px;
 }
 
+@media (max-width: 600px) {
+  main {
+    padding: 0 12px 16px 12px;
+  }
+}
+
 /* Chart Section */
 .chart-section {
   background: var(--chart-bg);
   padding: 20px 0;
   margin: 0 -24px 24px -24px;
+}
+
+@media (max-width: 600px) {
+  .chart-section {
+    margin: 0 -12px 16px -12px;
+  }
 }
 
 .chart-container {
@@ -565,6 +584,24 @@ main {
 @media (max-width: 600px) {
   .breakdowns {
     grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  /* Remove card chrome on mobile - use horizontal separators instead */
+  .breakdown-card {
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    padding: 12px 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .breakdown-card:last-child {
+    border-bottom: none;
+  }
+
+  .breakdown-card h3 {
+    margin-bottom: 8px;
   }
 }
 

--- a/dashboard.css
+++ b/dashboard.css
@@ -850,6 +850,95 @@ main {
   color: var(--error);
 }
 
+/* Mobile touch support - show action buttons on tap */
+.breakdown-table tr.touch-active .count .value {
+  display: none;
+}
+
+.breakdown-table tr.touch-active .count .action-btn {
+  display: block;
+}
+
+.breakdown-table tr.touch-active .bar .bar-inner {
+  display: none;
+}
+
+.breakdown-table tr.touch-active .bar .action-btn {
+  display: block;
+}
+
+/* On touch screens, show compact action icons inline */
+@media (hover: none), (pointer: coarse) {
+  .breakdown-table .count .value,
+  .breakdown-table .bar .bar-inner {
+    display: block !important;
+  }
+
+  .breakdown-table .count .action-btn,
+  .breakdown-table .bar .action-btn {
+    display: none !important;
+  }
+
+  /* Show mobile action buttons container */
+  .breakdown-table .mobile-actions {
+    display: flex !important;
+    gap: 4px;
+    padding-left: 8px;
+  }
+
+  .breakdown-table .mobile-action-btn {
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    font-size: 16px;
+    font-weight: bold;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    background: var(--card-bg);
+    cursor: pointer;
+    color: var(--text);
+    flex-shrink: 0;
+  }
+
+  .breakdown-table .mobile-action-btn:active {
+    background: var(--bg);
+  }
+
+  .breakdown-table .mobile-action-btn.exclude {
+    color: var(--error);
+  }
+
+  .breakdown-table .mobile-action-btn.active {
+    background: var(--primary);
+    color: white;
+    border-color: var(--primary);
+  }
+
+  .breakdown-table .mobile-action-btn.active.exclude {
+    background: var(--error);
+    border-color: var(--error);
+  }
+}
+
+/* On very small screens, hide bar and adjust dim width */
+@media (max-width: 400px) and (hover: none), (max-width: 400px) and (pointer: coarse) {
+  .breakdown-table .bar {
+    display: none;
+  }
+
+  .breakdown-table .dim {
+    max-width: 100px;
+  }
+}
+
+/* Hide mobile actions on desktop */
+.breakdown-table .mobile-actions {
+  display: none;
+}
+
 .breakdown-table tr.other-row {
   cursor: pointer;
   opacity: 0.7;

--- a/js/breakdowns/render.js
+++ b/js/breakdowns/render.js
@@ -138,6 +138,14 @@ export function renderBreakdownTable(id, data, totals, col, linkPrefix, linkSuff
       ? `<button class="action-btn" onclick="removeFilterByValue('${colEscaped}', '${dimEscaped}')">Clear</button>`
       : `<button class="action-btn exclude" onclick="addFilter('${colEscaped}', '${dimEscaped}', true)">Exclude</button>`;
 
+    // Mobile action buttons (always visible on touch devices)
+    const mobileFilterBtn = isIncluded
+      ? `<button class="mobile-action-btn active" onclick="removeFilterByValue('${colEscaped}', '${dimEscaped}')" title="Remove filter">✓</button>`
+      : `<button class="mobile-action-btn" onclick="addFilter('${colEscaped}', '${dimEscaped}', false)" title="Filter to this value">+</button>`;
+    const mobileExcludeBtn = isExcluded
+      ? `<button class="mobile-action-btn exclude active" onclick="removeFilterByValue('${colEscaped}', '${dimEscaped}')" title="Remove exclusion">✗</button>`
+      : `<button class="mobile-action-btn exclude" onclick="addFilter('${colEscaped}', '${dimEscaped}', true)" title="Exclude this value">−</button>`;
+
     html += `
       <tr class="${rowClass}">
         <td class="dim" title="${escapeHtml(dim)}">${dimContent}</td>
@@ -153,6 +161,7 @@ export function renderBreakdownTable(id, data, totals, col, linkPrefix, linkSuff
           </div>
           ${excludeBtn}
         </td>
+        <td class="mobile-actions">${mobileFilterBtn}${mobileExcludeBtn}</td>
       </tr>
     `;
   }
@@ -185,6 +194,7 @@ export function renderBreakdownTable(id, data, totals, col, linkPrefix, linkSuff
             <div class="bar-segment bar-ok" style="width: ${pctOk}%"></div>
           </div>
         </td>
+        <td class="mobile-actions"></td>
       </tr>
     `;
   }


### PR DESCRIPTION
On touch devices (iPhone, iPad, etc.), hover doesn't work reliably.
This adds dedicated mobile action buttons (+/−) that are always visible
on touch screens using CSS media queries (hover: none, pointer: coarse).

- Desktop: hover to reveal Filter/Exclude buttons (unchanged)
- Mobile: always-visible +/− buttons next to each breakdown row
- Active filters show ✓/✗ icons with colored backgrounds
- On very small screens (<400px), hides bar column to save space

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add touch-friendly filter and exclude buttons (+/−) to breakdown rows so mobile users can act without hover. Desktop behavior is unchanged, and small screens get a more compact layout.

- **New Features**
  - Always-visible mobile buttons (+ filter, − exclude); show ✓/✗ when active.
  - Gated by media queries (hover: none, pointer: coarse); added a mobile-actions cell; hide bar column under 400px.
  - Compact layout under 600px: reduced header/main padding, removed card borders/background, and set facet grid gap to 0.

<sup>Written for commit 4991a55361810a5d8f19a32e251ab7bf846464c4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

