### PR TITLE
Add dead code detection with knip

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://unpkg.com/knip@latest/schema.json",
+  "entry": [
+    "js/main.js",
+    "sw.js",
+    "scripts/*.mjs",
+    "eslint.config.js"
+  ],
+  "project": [
+    "js/**/*.js",
+    "scripts/**/*.mjs"
+  ],
+  "ignore": [
+    "js/**/*.test.js"
+  ],
+  "ignoreDependencies": [
+    "live-server"
+  ],
+  "ignoreBinaries": [
+    "eslint"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "start": "live-server --port=5391 --open=/ --ignore=scripts,.github,.claude,hars,node_modules --ignorePattern=\"\\\\.md$|package.*\\\\.json$|screenshot\\\\.png$\"",
     "test": "node --test",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "dead-code": "knip"
   },
   "devDependencies": {
     "@adobe/eslint-config-helix": "^3.0.16",
     "canvas": "3.2.1",
+    "knip": "^5.82.1",
     "live-server": "^1.2.2"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

Add **knip** for dead code detection, addressing the Agent Readiness signal for dead code detection.

## Changes

- Add `knip` as dev dependency
- Create `knip.json` with project-specific configuration:
  - Entry points: `js/main.js`, `sw.js`, `scripts/*.mjs`, `eslint.config.js`
  - Ignores test files (`*.test.js`)
  - Ignores `live-server` (used by `npm start` but not imported)
- Add `npm run dead-code` script

## Verification

Running `npm run dead-code` now identifies:
- 57 unused exports across the codebase
- 1 unused dependency (`puppeteer-core`)
- 1 unlisted dependency (`globals` - transitive)

These findings can be incrementally addressed to reduce maintenance burden.

## Testing

- `npm test` - all 46 tests pass
- `npm run lint` - no new warnings
- `npm run dead-code` - successfully runs and reports findings