### PR TITLE
fix: facet counting issue

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -22,7 +22,20 @@
   <!-- Service Worker Registration -->
   <script>
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js');
+      const isLocalhost = ['localhost', '127.0.0.1'].includes(location.hostname);
+      
+      if (isLocalhost) {
+        // Unregister any existing service workers on localhost for easier development
+        navigator.serviceWorker.getRegistrations().then((registrations) => {
+          registrations.forEach((registration) => {
+            registration.unregister();
+            console.log('Service Worker unregistered on localhost');
+          });
+        });
+      } else {
+        // Register service worker in production
+        navigator.serviceWorker.register('/sw.js');
+      }
     }
   </script>
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,20 @@
   <!-- Service Worker Registration -->
   <script>
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js');
+      const isLocalhost = ['localhost', '127.0.0.1'].includes(location.hostname);
+      
+      if (isLocalhost) {
+        // Unregister any existing service workers on localhost for easier development
+        navigator.serviceWorker.getRegistrations().then((registrations) => {
+          registrations.forEach((registration) => {
+            registration.unregister();
+            console.log('Service Worker unregistered on localhost');
+          });
+        });
+      } else {
+        // Register service worker in production
+        navigator.serviceWorker.register('/sw.js');
+      }
     }
   </script>
 

--- a/js/breakdowns/definitions.js
+++ b/js/breakdowns/definitions.js
@@ -38,7 +38,7 @@ export function formatForwardedHost(dim) {
 
 export const allBreakdowns = [
   {
-    id: 'breakdown-status-range', col: "concat(toString(intDiv(`response.status`, 100)), 'xx')", summaryCountIf: '`response.status` >= 500', summaryLabel: 'error rate', summaryColor: 'error',
+    id: 'breakdown-status-range', col: "concat(toString(intDiv(`response.status`, 100)), 'xx')", summaryCountIf: '`response.status` >= 500', summaryLabel: 'error rate', summaryColor: 'error', modeToggle: 'contentTypeMode',
   },
   {
     id: 'breakdown-hosts', col: COLUMN_DEFS.host.facetCol, linkFn: hostLink, dimPrefixes: ['main--'], summaryCountIf: "`request.host` LIKE '%.aem.live'", summaryLabel: 'live', highCardinality: true,

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -159,7 +159,10 @@ export async function loadBreakdown(b, timeFilter, hostFilter) {
 
   const startTime = performance.now();
   try {
-    const result = await query(sql);
+    // Disable query cache for status facets due to intermittent projection mismatch
+    // causing 10x discrepancies (see CLAUDE.md projections section)
+    const skipCache = b.id === 'breakdown-status-range' || b.id === 'breakdown-status';
+    const result = await query(sql, { skipCache });
     // Prefer actual network time from Resource Timing API, fallback to wall clock
     const elapsed = result.networkTime ?? (performance.now() - startTime);
     facetTimings[b.id] = elapsed; // Track timing for slowest detection


### PR DESCRIPTION
## Fix: Intermittent 10x Discrepancy Between Status Range and Status Codes Facets

<img width="361" height="498" alt="Attached_image" src="https://github.com/user-attachments/assets/70c66797-6a2a-4527-a7fd-37b4c429f471" />

### Problem
Status Range and Status Codes facets intermittently showed values differing by exactly 10x (e.g., 34M vs 3.4M). This was inconsistent - sometimes they matched, sometimes one was 10x off.

### Root Cause
**ClickHouse Query Cache + Projection Mismatch**

Both facets query identical data with identical WHERE clauses, but ClickHouse was intermittently returning different totals:
- Status Range: 57.1M requests ✅
- Status Codes: 5.77M requests ❌ (exactly 9.91x less)

Investigation revealed:
1. The `cdn_requests_v2` table has `SAMPLE BY sample_hash` configured (10% sampling for large scans)
2. Projections `proj_facet_status_range` and `proj_facet_status` exist for fast aggregation
3. ClickHouse's query cache was serving stale results from different execution paths (projection vs sampled table scan)

### Solution
**Disable query cache for both status facets** (`skipCache: true`)

This ensures both queries always:
- Execute fresh (no stale cache)
- Use consistent execution paths
- Return matching totals

### Additional Fixes
1. **Added `modeToggle: 'contentTypeMode'`** to Status Range - now both facets can toggle between count/bytes mode consistently
2. **Auto-unregister Service Worker on localhost** - prevents stale JS module caching during development

### Long-term Recommendation
The projection definition in ClickHouse should be updated to exactly match the dashboard query to ensure consistent projection usage:

-- Current projection (in ClickHouse)
concat(intDiv(response.status, 100), 'xx')

-- Dashboard query uses
concat(toString(intDiv(`response.status`, 100)), 'xx')
