### PR TITLE
Add release notes automation with Release Drafter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install semantic-release plugins
+        run: npm install --save-dev semantic-release @semantic-release/changelog @semantic-release/git
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,10 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds automated release notes generation using [semantic-release](https://semantic-release.gitbook.io/).

## Changes

- Added `.releaserc.json` - Configuration with standard plugins:
  - `@semantic-release/commit-analyzer` - Analyzes commits using conventional commits
  - `@semantic-release/release-notes-generator` - Generates release notes
  - `@semantic-release/changelog` - Updates CHANGELOG.md
  - `@semantic-release/npm` - Updates package.json version
  - `@semantic-release/github` - Creates GitHub releases

- Added `.github/workflows/release.yml` - GitHub Actions workflow that:
  - Runs on pushes to main
  - Can be triggered manually via workflow_dispatch
  - Uses semantic-release to automate versioning and changelog

## How it works

1. Use [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat:`, `fix:`, `docs:`)
2. When commits are pushed to main, semantic-release analyzes them
3. Automatically determines version bump (major/minor/patch)
4. Generates changelog and creates GitHub release

## Fixes

Addresses the Agent Readiness signal: Release Notes Automation