### PR TITLE
chore: keyboard conflicts with standard browser shortcuts

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -259,10 +259,10 @@
         <div class="key-desc">Zoom to anomaly by rank</div>
 
         <div class="key-group"><kbd>+</kbd></div>
-        <div class="key-desc">Zoom to most prominent anomaly</div>
+        <div class="key-desc">Zoom timeframe to most prominent anomaly</div>
 
         <div class="key-group"><kbd>-</kbd></div>
-        <div class="key-desc">Zoom out to larger period</div>
+        <div class="key-desc">Zoom timeframe out to larger period</div>
 
         <div class="key-group"><kbd>?</kbd></div>
         <div class="key-desc">Show this help</div>

--- a/js/keyboard.js
+++ b/js/keyboard.js
@@ -454,11 +454,15 @@ export function initKeyboardNavigation({ toggleFacetMode, reloadDashboard } = {}
         break;
       case '+':
       case '=': // Unshifted + on most keyboards
+        // Don't override browser zoom (Cmd/Ctrl + +)
+        if (e.metaKey || e.ctrlKey) return;
         e.preventDefault();
         // Zoom in: to most prominent anomaly, or most recent section if none
         zoomToAnomaly();
         break;
       case '-':
+        // Don't override browser zoom (Cmd/Ctrl + -)
+        if (e.metaKey || e.ctrlKey) return;
         e.preventDefault();
         // Zoom out: expand to next larger predefined period
         if (zoomOut()) {


### PR DESCRIPTION
Don't override browser zoom shortcuts (Cmd/Ctrl +/-). The unmodified +/- keys still zoom the timeframe as intended.