### PR TITLE
feat: simplify header layout and keep chart visible with logs

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -30,8 +30,7 @@ body.header-fixed header {
   z-index: 100;
 }
 
-body.header-fixed main,
-body.header-fixed #logsView {
+body.header-fixed main {
   padding-top: 70px;
 }
 
@@ -51,10 +50,6 @@ body.header-fixed #logsView {
   overflow: hidden;
   -webkit-mask-image: linear-gradient(to right, black 90%, transparent 100%);
   mask-image: linear-gradient(to right, black 90%, transparent 100%);
-}
-
-.header-center {
-  flex-shrink: 0;
 }
 
 .header-right {
@@ -97,9 +92,8 @@ header h1 {
     display: none;
   }
 
-  /* Flatten header on mobile: menu | hostFilter | timeRange | Logs | logout */
+  /* Flatten header on mobile: menu | hostFilter | timeRange | more */
   .header-left,
-  .header-center,
   .header-right {
     display: contents;
   }
@@ -111,9 +105,8 @@ header h1 {
 
   #menuBtn { order: 1; }
   #hostFilter { order: 2; flex: 1; min-width: 0; width: auto; }
-  #logsBtn { order: 3; }
-  #timeRange { order: 4; flex: 1; min-width: 0; width: auto; }
-  #logoutBtn { order: 5; }
+  #timeRange { order: 3; flex: 1; min-width: 0; width: auto; }
+  #moreBtn { order: 4; }
 
   /* Hide these on mobile */
   #topN,
@@ -147,27 +140,6 @@ header h1 {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-  }
-
-  /* First button (menu) touches left edge */
-  header .menu-btn {
-    margin-left: -12px;
-    padding-left: 12px;
-    padding-right: 10px;
-    width: auto;
-    border-left: none;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-
-  /* Last button (logout) touches right edge */
-  header #logoutBtn {
-    margin-right: -12px;
-    padding-right: 12px;
-    padding-left: 10px;
-    border-right: none;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
   }
 }
 

--- a/css/logs.css
+++ b/css/logs.css
@@ -1,44 +1,22 @@
 /*
  * Logs View
- * Logs button, logs table, log entries
+ * Logs table, log entries
  */
 
-/* Logs Button */
-.logs-btn {
-  padding: 8px 24px;
-  font-size: 14px;
-  background: var(--card-bg);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.logs-btn:hover {
-  background: var(--bg);
-}
-
-.logs-btn.ready {
-  border-color: var(--primary);
-}
-
-.logs-btn.active {
-  background: var(--bg);
-}
-
-/* Logs View */
+/* Filters and Logs Views */
+#filtersView,
 #logsView {
   display: none;
-  padding: 24px;
 }
 
+#filtersView.visible,
 #logsView.visible {
   display: block;
 }
 
-#dashboardContent.hidden {
-  display: none;
+/* Logs View */
+#logsView {
+  padding: 16px 0 24px 0;
 }
 
 .logs-table-container {

--- a/css/modals.css
+++ b/css/modals.css
@@ -174,3 +174,60 @@
 .keyboard-help-grid .key-desc {
   color: var(--text-secondary);
 }
+
+/* More Actions Dropdown Menu */
+#moreMenu {
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card-bg);
+  color: var(--text);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  min-width: 200px;
+  margin: 0;
+  position: fixed;
+}
+
+#moreMenu::backdrop {
+  background: transparent;
+}
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.15s;
+  text-align: left;
+}
+
+.menu-item:hover {
+  background: var(--bg);
+}
+
+.menu-item-label {
+  flex: 1;
+}
+
+.menu-item-kbd {
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.menu-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -63,25 +63,20 @@
         <h1><span id="dashboardTitle">CDN Analytics</span> <span id="queryTimer" class="query-timer"></span></h1>
         <div id="activeFilters"></div>
       </div>
-      <div class="header-center">
-        <span class="kbd-control"><kbd class="kbd-hint">t</kbd><button id="logsBtn" class="logs-btn">Logs</button></span>
-      </div>
       <div class="header-right">
         <span class="kbd-control"><kbd class="kbd-hint" id="timeRangeHint">2</kbd><select id="timeRange"></select></span>
         <select id="topN"></select>
         <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by host..." list="hostSuggestions" autocomplete="off"></span>
         <datalist id="hostSuggestions"></datalist>
-        <span class="kbd-control"><kbd class="kbd-hint">r</kbd><button id="refreshBtn" class="btn btn-secondary"><span class="btn-icon">↻</span><span class="btn-text">Refresh</span></button></span>
-        <button id="logoutBtn" class="btn btn-secondary"><span class="btn-icon">⏻</span><span class="btn-text">Logout</span></button>
+        <button id="moreBtn" class="menu-btn" title="More actions">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <circle cx="10" cy="4" r="1.5"/>
+            <circle cx="10" cy="10" r="1.5"/>
+            <circle cx="10" cy="16" r="1.5"/>
+          </svg>
+        </button>
       </div>
     </header>
-
-    <!-- Logs View -->
-    <div id="logsView">
-      <div class="logs-table-container">
-        <div class="logs-loading"><div class="spinner"></div>Loading logs...</div>
-      </div>
-    </div>
 
     <main id="dashboardContent">
       <!-- Time Series Chart -->
@@ -92,9 +87,11 @@
         </div>
       </section>
 
-      <!-- Breakdown Tables -->
-      <section class="breakdowns breakdowns-pinned" id="breakdowns-pinned"></section>
-      <section class="breakdowns" id="breakdowns">
+      <!-- Filters View (Breakdowns) -->
+      <div id="filtersView" class="visible">
+        <!-- Breakdown Tables -->
+        <section class="breakdowns breakdowns-pinned" id="breakdowns-pinned"></section>
+        <section class="breakdowns" id="breakdowns">
         <div class="breakdown-card" id="breakdown-status-range">
           <h3>Status Range</h3>
           <div class="loading"><div class="spinner"></div>Loading...</div>
@@ -193,6 +190,14 @@
         </div>
       </section>
       <section class="breakdowns breakdowns-hidden" id="breakdowns-hidden"></section>
+      </div>
+
+      <!-- Logs View -->
+      <div id="logsView">
+        <div class="logs-table-container">
+          <div class="logs-loading"><div class="spinner"></div>Loading logs...</div>
+        </div>
+      </div>
     </main>
   </div>
 
@@ -203,6 +208,22 @@
       <button class="modal-close" data-action="close-quick-links">&times;</button>
     </div>
     <iframe id="quickLinksFrame" src="index.html"></iframe>
+  </dialog>
+
+  <!-- More Actions Menu -->
+  <dialog id="moreMenu" class="dropdown-menu">
+    <button id="viewToggleBtn" class="menu-item" data-kbd="t">
+      <span class="menu-item-label">View Logs</span>
+      <kbd class="menu-item-kbd">t</kbd>
+    </button>
+    <button id="refreshBtn" class="menu-item" data-kbd="r">
+      <span class="menu-item-label">Refresh</span>
+      <kbd class="menu-item-kbd">r</kbd>
+    </button>
+    <div class="menu-divider"></div>
+    <button id="logoutBtn" class="menu-item">
+      <span class="menu-item-label">Logout</span>
+    </button>
   </dialog>
 
   <!-- Keyboard Help Dialog -->

--- a/js/logs.js
+++ b/js/logs.js
@@ -193,8 +193,8 @@ function updatePinnedOffsets(container, pinned) {
 
 // DOM elements (set by main.js)
 let logsView = null;
-let logsBtn = null;
-let dashboardContent = null;
+let viewToggleBtn = null;
+let filtersView = null;
 
 // Pagination state
 const PAGE_SIZE = 500;
@@ -420,10 +420,10 @@ function handleLogsScroll() {
   }
 }
 
-export function setLogsElements(view, btn, content) {
+export function setLogsElements(view, toggleBtn, filtersViewEl) {
   logsView = view;
-  logsBtn = btn;
-  dashboardContent = content;
+  viewToggleBtn = toggleBtn;
+  filtersView = filtersViewEl;
 
   // Set up scroll listener for infinite scroll on window
   window.addEventListener('scroll', handleLogsScroll);
@@ -446,14 +446,12 @@ export function toggleLogsView(saveStateToURL) {
   state.showLogs = !state.showLogs;
   if (state.showLogs) {
     logsView.classList.add('visible');
-    dashboardContent.classList.add('hidden');
-    logsBtn.classList.add('active');
-    logsBtn.textContent = 'Filters';
+    filtersView.classList.remove('visible');
+    viewToggleBtn.querySelector('.menu-item-label').textContent = 'View Filters';
   } else {
     logsView.classList.remove('visible');
-    dashboardContent.classList.remove('hidden');
-    logsBtn.classList.remove('active');
-    logsBtn.textContent = 'Logs';
+    filtersView.classList.add('visible');
+    viewToggleBtn.querySelector('.menu-item-label').textContent = 'View Logs';
     // Redraw chart after view becomes visible
     if (onShowFiltersView) {
       requestAnimationFrame(() => onShowFiltersView());
@@ -466,7 +464,6 @@ export async function loadLogs() {
   if (state.logsLoading) return;
   state.logsLoading = true;
   state.logsReady = false;
-  logsBtn.classList.remove('ready');
 
   // Reset pagination state
   logsOffset = 0;
@@ -493,7 +490,6 @@ export async function loadLogs() {
     state.logsData = result.data;
     renderLogsTable(result.data);
     state.logsReady = true;
-    logsBtn.classList.add('ready');
     // Check if there might be more data
     hasMoreLogs = result.data.length === PAGE_SIZE;
     logsOffset = result.data.length;

--- a/js/main.js
+++ b/js/main.js
@@ -66,15 +66,16 @@ const elements = {
   hostFilterInput: document.getElementById('hostFilter'),
   refreshBtn: document.getElementById('refreshBtn'),
   logoutBtn: document.getElementById('logoutBtn'),
-  logsBtn: document.getElementById('logsBtn'),
+  viewToggleBtn: document.getElementById('viewToggleBtn'),
   logsView: document.getElementById('logsView'),
+  filtersView: document.getElementById('filtersView'),
   dashboardContent: document.getElementById('dashboardContent'),
 };
 
 // Pass elements to modules that need them
 setElements(elements);
 setUrlStateElements(elements);
-setLogsElements(elements.logsView, elements.logsBtn, elements.dashboardContent);
+setLogsElements(elements.logsView, elements.viewToggleBtn, elements.filtersView);
 
 // Load dashboard queries (chart and facets)
 async function loadDashboardQueries(timeFilter, hostFilter) {
@@ -380,7 +381,7 @@ async function init() {
     }
   });
 
-  elements.logsBtn.addEventListener('click', () => toggleLogsView(saveStateToURL));
+  elements.viewToggleBtn.addEventListener('click', () => toggleLogsView(saveStateToURL));
 
   // Listen for login success event from auth.js
   window.addEventListener('login-success', () => {

--- a/js/modal.js
+++ b/js/modal.js
@@ -10,7 +10,9 @@
  * governing permissions and limitations under the License.
  */
 let quickLinksModal = null;
+let moreMenu = null;
 let menuBtn = null;
+let moreBtn = null;
 
 export function openQuickLinksModal() {
   quickLinksModal.showModal();
@@ -20,9 +22,28 @@ export function closeQuickLinksModal() {
   quickLinksModal.close();
 }
 
+export function openMoreMenu() {
+  if (!moreBtn || !moreMenu) return;
+  
+  // Position the menu below the button
+  const rect = moreBtn.getBoundingClientRect();
+  moreMenu.style.top = `${rect.bottom + 4}px`;
+  moreMenu.style.left = `${rect.right - 200}px`; // Align right edge with button
+  
+  moreMenu.showModal();
+}
+
+export function closeMoreMenu() {
+  if (moreMenu) {
+    moreMenu.close();
+  }
+}
+
 export function initModal() {
   quickLinksModal = document.getElementById('quickLinksModal');
+  moreMenu = document.getElementById('moreMenu');
   menuBtn = document.getElementById('menuBtn');
+  moreBtn = document.getElementById('moreBtn');
 
   // Handle messages from the iframe
   window.addEventListener('message', (e) => {
@@ -33,7 +54,7 @@ export function initModal() {
     }
   });
 
-  // Close modal when clicking backdrop
+  // Close quick links modal when clicking backdrop
   quickLinksModal.addEventListener('click', (e) => {
     if (e.target === quickLinksModal) {
       closeQuickLinksModal();
@@ -53,4 +74,40 @@ export function initModal() {
   });
 
   menuBtn.addEventListener('click', openQuickLinksModal);
+
+  // More menu handling
+  if (moreBtn && moreMenu) {
+    moreBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      openMoreMenu();
+    });
+
+    // Close more menu when clicking backdrop or outside
+    moreMenu.addEventListener('click', (e) => {
+      if (e.target === moreMenu) {
+        closeMoreMenu();
+      }
+    });
+
+    // Close menu when clicking any menu item
+    moreMenu.querySelectorAll('.menu-item').forEach((item) => {
+      item.addEventListener('click', () => {
+        closeMoreMenu();
+      });
+    });
+
+    // Close more menu on Escape
+    moreMenu.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        closeMoreMenu();
+      }
+    });
+
+    // Close more menu when clicking outside
+    document.addEventListener('click', (e) => {
+      if (moreMenu.open && !moreMenu.contains(e.target) && e.target !== moreBtn) {
+        closeMoreMenu();
+      }
+    });
+  }
 }

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -228,11 +228,15 @@ export function syncUIFromState() {
     document.title = 'CDN Analytics';
   }
 
+  // Update view toggle based on state
   if (state.showLogs) {
     elements.logsView.classList.add('visible');
-    elements.dashboardContent.classList.add('hidden');
-    elements.logsBtn.classList.add('active');
-    elements.logsBtn.textContent = 'Filters';
+    elements.filtersView.classList.remove('visible');
+    elements.viewToggleBtn.querySelector('.menu-item-label').textContent = 'View Filters';
+  } else {
+    elements.logsView.classList.remove('visible');
+    elements.filtersView.classList.add('visible');
+    elements.viewToggleBtn.querySelector('.menu-item-label').textContent = 'View Logs';
   }
 
   // Apply hidden controls from URL
@@ -252,7 +256,7 @@ export function syncUIFromState() {
     elements.logoutBtn.style.display = 'none';
   }
   if (state.hiddenControls.includes('logs')) {
-    elements.logsBtn.style.display = 'none';
+    elements.viewToggleBtn.style.display = 'none';
   }
 }
 


### PR DESCRIPTION
Simplified header layout and improved view management:

- **Header**: Reduced from 3 sections to 2 (left/right), removing center section
- **Mobile**: Fixed overlap issues - only 4 items now (Menu | Host Filter | Time Range | More)
- **Chart visibility**: Chart now stays visible when viewing logs
- **View toggle**: Moved to overflow menu as "View Logs" / "View Filters" (keyboard: `t`)
- **Overflow menu**: Cleaned up - removed all icons/emojis for text-only design

The layout is cleaner with better space utilization on both desktop and mobile.