### PR TITLE
fix: chart zero values using WITH FILL (comparison)

### DIFF
--- a/js/chart-state.js
+++ b/js/chart-state.js
@@ -21,11 +21,7 @@ import {
   queryTimestamp,
   setCustomTimeRange,
   setQueryTimestamp,
-  customTimeRange,
-  isCustomTimeRange,
 } from './time.js';
-import { TIME_RANGES } from './constants.js';
-import { state } from './state.js';
 import { saveStateToURL } from './url-state.js';
 
 // Status range column for filtering
@@ -439,8 +435,8 @@ export function hexToRgba(hex, alpha) {
  */
 export function roundToNice(val) {
   if (val === 0) return 0;
-  if (val < 1) return Math.ceil(val); // Always round up to at least 1
-  
+  if (val < 1) return Math.ceil(val);
+
   const magnitude = 10 ** Math.floor(Math.log10(val));
   const normalized = val / magnitude;
   let nice;
@@ -449,53 +445,14 @@ export function roundToNice(val) {
   else if (normalized <= 3.5) nice = 2.5;
   else if (normalized <= 7.5) nice = 5;
   else nice = 10;
-  
+
   const result = nice * magnitude;
-  
+
   // If the result is less than 10, always return an integer
   // This ensures small scales (1, 2, 3, etc.) never have decimals like 2.5
   if (result < 10) {
     return Math.round(result);
   }
-  
+
   return result;
-}
-
-/**
- * Get the bucket interval in milliseconds based on current time range
- * @returns {number} Bucket interval in milliseconds
- */
-export function getBucketIntervalMs() {
-  // For custom time range, calculate based on duration
-  if (isCustomTimeRange()) {
-    const range = customTimeRange();
-    const durationMs = range.end - range.start;
-    const durationMinutes = durationMs / 60000;
-
-    // Match bucket sizes from time.js getTimeBucket()
-    if (durationMinutes <= 15) {
-      return 5 * 1000; // 5 seconds
-    } else if (durationMinutes <= 60) {
-      return 10 * 1000; // 10 seconds
-    } else if (durationMinutes <= 720) {
-      return 60 * 1000; // 1 minute
-    } else if (durationMinutes <= 1440) {
-      return 5 * 60 * 1000; // 5 minutes
-    } else {
-      return 10 * 60 * 1000; // 10 minutes
-    }
-  }
-
-  // For predefined time ranges, extract from bucket expression
-  const timeRange = TIME_RANGES[state.timeRange];
-  if (!timeRange) return 60 * 1000; // Default to 1 minute
-
-  const bucket = timeRange.bucket;
-  if (bucket.includes('5 SECOND')) return 5 * 1000;
-  if (bucket.includes('10 SECOND')) return 10 * 1000;
-  if (bucket.includes('toStartOfMinute')) return 60 * 1000;
-  if (bucket.includes('toStartOfFiveMinutes')) return 5 * 60 * 1000;
-  if (bucket.includes('toStartOfTenMinutes')) return 10 * 60 * 1000;
-
-  return 60 * 1000; // Default fallback
 }

--- a/js/chart.js
+++ b/js/chart.js
@@ -25,6 +25,7 @@ import {
   getHostFilter,
   getTable,
   getTimeBucket,
+  getTimeBucketStep,
   getTimeFilter,
   setCustomTimeRange,
 } from './time.js';
@@ -56,9 +57,7 @@ import {
   zoomToAnomalyByRank,
   getShipNearX,
   hexToRgba,
-  roundToNice,
   parseUTC,
-  getBucketIntervalMs,
 } from './chart-state.js';
 
 // Re-export state functions for external use
@@ -136,23 +135,9 @@ export function renderChart(data) {
   const totals = data.map((_, i) => series.ok[i] + series.client[i] + series.server[i]);
   const dataMax = Math.max(...totals);
   const minValue = 0;
-  
-  // Adjust maxValue to be a nice round number that divides evenly by 4
-  // This ensures all grid lines land on whole numbers
-  let maxValue;
-  if (dataMax === 0) {
-    maxValue = 4; // Minimum scale
-  } else {
-    // Round up to next value that divides evenly by 4
-    const candidateMax = Math.ceil(dataMax);
-    if (candidateMax <= 4) {
-      maxValue = 4;
-    } else if (candidateMax % 4 === 0) {
-      maxValue = candidateMax;
-    } else {
-      maxValue = Math.ceil(candidateMax / 4) * 4;
-    }
-  }
+
+  // Round up to a multiple of 4 so all 4 grid lines land on whole numbers
+  const maxValue = Math.max(4, Math.ceil(Math.ceil(dataMax) / 4) * 4);
 
   // Colors from CSS variables
   const okColor = cssVar('--status-ok');
@@ -174,11 +159,6 @@ export function renderChart(data) {
   ctx.moveTo(padding.left, height - padding.bottom);
   ctx.lineTo(width - padding.right, height - padding.bottom);
   ctx.stroke();
-
-  // Y axis labels (inside chart, above grid lines, skip zero)
-  ctx.fillStyle = cssVar('--text-secondary');
-  ctx.font = '11px -apple-system, sans-serif';
-  ctx.textAlign = 'left';
 
   // Y axis labels (inside chart, above grid lines, skip zero)
   ctx.fillStyle = cssVar('--text-secondary');
@@ -988,64 +968,12 @@ export function setupChartNavigation(callback) {
   });
 }
 
-/**
- * Fill in missing time buckets with zero values
- * @param {Array} data - Chart data with potential gaps
- * @param {number} bucketMs - Bucket interval in milliseconds
- * @returns {Array} Data with all buckets filled
- */
-function fillMissingBuckets(data, bucketMs) {
-  if (data.length < 2) return data;
-
-  const filled = [];
-  const parseTime = (t) => {
-    const str = String(t);
-    // If already has Z suffix, parse directly
-    if (str.endsWith('Z')) {
-      return new Date(str).getTime();
-    }
-    // Otherwise, normalize and append Z to treat as UTC
-    return new Date(`${str.replace(' ', 'T')}Z`).getTime();
-  };
-
-  const formatTime = (timestamp) => {
-    const d = new Date(timestamp);
-    return d.toISOString().replace('T', ' ').slice(0, 19);
-  };
-
-  for (let i = 0; i < data.length; i += 1) {
-    filled.push(data[i]);
-
-    // Check if there's a gap to the next data point
-    if (i < data.length - 1) {
-      const currentTime = parseTime(data[i].t);
-      const nextTime = parseTime(data[i + 1].t);
-      const gap = nextTime - currentTime;
-
-      // If gap is larger than one bucket, fill with zeros
-      if (gap > bucketMs * 1.5) {
-        let fillTime = currentTime + bucketMs;
-        while (fillTime < nextTime) {
-          filled.push({
-            t: formatTime(fillTime),
-            cnt_ok: '0',
-            cnt_4xx: '0',
-            cnt_5xx: '0',
-          });
-          fillTime += bucketMs;
-        }
-      }
-    }
-  }
-
-  return filled;
-}
-
 export async function loadTimeSeries() {
   const timeFilter = getTimeFilter();
   const hostFilter = getHostFilter();
   const facetFilters = getFacetFilters();
   const bucket = getTimeBucket();
+  const step = getTimeBucketStep();
 
   const sql = `
     SELECT
@@ -1056,16 +984,13 @@ export async function loadTimeSeries() {
     FROM ${DATABASE}.${getTable()}
     WHERE ${timeFilter} ${hostFilter} ${facetFilters}
     GROUP BY t
-    ORDER BY t
+    ORDER BY t WITH FILL STEP ${step}
   `;
 
   try {
     const result = await query(sql);
-    // Get bucket interval and fill missing buckets with zeros
-    const bucketMs = getBucketIntervalMs();
-    const filledData = fillMissingBuckets(result.data, bucketMs);
-    state.chartData = filledData;
-    renderChart(filledData);
+    state.chartData = result.data;
+    renderChart(result.data);
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error('Chart error:', err);

--- a/js/constants.js
+++ b/js/constants.js
@@ -18,6 +18,7 @@
  * @property {string} interval - ClickHouse interval literal.
  * @property {string} bucket - ClickHouse bucket expression.
  * @property {number} periodMs - Duration in milliseconds.
+ * @property {string} step - ClickHouse interval for WITH FILL STEP.
  * @property {number} cacheTtl - Query cache TTL in seconds.
  */
 
@@ -31,6 +32,7 @@ export const TIME_RANGES = {
     shortLabel: '15m',
     interval: 'INTERVAL 15 MINUTE',
     bucket: 'toStartOfInterval(timestamp, INTERVAL 5 SECOND)',
+    step: 'INTERVAL 5 SECOND',
     periodMs: 15 * 60 * 1000,
     cacheTtl: 60,
   },
@@ -39,6 +41,7 @@ export const TIME_RANGES = {
     shortLabel: '1h',
     interval: 'INTERVAL 1 HOUR',
     bucket: 'toStartOfInterval(timestamp, INTERVAL 10 SECOND)',
+    step: 'INTERVAL 10 SECOND',
     periodMs: 60 * 60 * 1000,
     cacheTtl: 300,
   },
@@ -47,6 +50,7 @@ export const TIME_RANGES = {
     shortLabel: '12h',
     interval: 'INTERVAL 12 HOUR',
     bucket: 'toStartOfMinute(timestamp)',
+    step: 'INTERVAL 1 MINUTE',
     periodMs: 12 * 60 * 60 * 1000,
     cacheTtl: 600,
   },
@@ -55,6 +59,7 @@ export const TIME_RANGES = {
     shortLabel: '24h',
     interval: 'INTERVAL 24 HOUR',
     bucket: 'toStartOfFiveMinutes(timestamp)',
+    step: 'INTERVAL 5 MINUTE',
     periodMs: 24 * 60 * 60 * 1000,
     cacheTtl: 900,
   },
@@ -63,6 +68,7 @@ export const TIME_RANGES = {
     shortLabel: '7d',
     interval: 'INTERVAL 7 DAY',
     bucket: 'toStartOfTenMinutes(timestamp)',
+    step: 'INTERVAL 10 MINUTE',
     periodMs: 7 * 24 * 60 * 60 * 1000,
     cacheTtl: 1800,
   },

--- a/js/time.js
+++ b/js/time.js
@@ -107,6 +107,21 @@ export function getTimeBucket() {
   return TIME_RANGES[state.timeRange]?.bucket;
 }
 
+export function getTimeBucketStep() {
+  if (timeState.customTimeRange) {
+    const durationMs = timeState.customTimeRange.end - timeState.customTimeRange.start;
+    const durationMinutes = durationMs / 60000;
+
+    if (durationMinutes <= 15) return 'INTERVAL 5 SECOND';
+    if (durationMinutes <= 60) return 'INTERVAL 10 SECOND';
+    if (durationMinutes <= 720) return 'INTERVAL 1 MINUTE';
+    if (durationMinutes <= 1440) return 'INTERVAL 5 MINUTE';
+    return 'INTERVAL 10 MINUTE';
+  }
+
+  return TIME_RANGES[state.timeRange]?.step;
+}
+
 export function getTimeFilter() {
   // For custom time range, use explicit start/end timestamps
   if (timeState.customTimeRange) {


### PR DESCRIPTION
## Summary

- Comparison PR for #25: uses ClickHouse `WITH FILL STEP` for zero-filling instead of client-side `fillMissingBuckets()`
- Same y-axis integer label fixes as #25
- **Known issue**: WITH FILL creates spiky charts for sparse data (too many zero-filled buckets)

This PR exists for side-by-side comparison with #25. See preview deployments on both PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)