### PR TITLE
fix: resolve all ESLint errors and warnings

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -86,6 +86,7 @@ export async function loadHostAutocomplete() {
 
     populateHostDatalist(hosts);
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error('Failed to load host autocomplete:', err);
   }
 }

--- a/js/breakdowns/buckets.test.js
+++ b/js/breakdowns/buckets.test.js
@@ -44,7 +44,9 @@ describe('contentLengthBuckets', () => {
       const sql = contentLengthBuckets(n);
       const labels = extractBucketLabels(sql);
 
+      // eslint-disable-next-line no-console
       console.log(`  topN=${n}: got ${labels.length} buckets`);
+      // eslint-disable-next-line no-console
       console.log(`    labels: ${labels.join(', ')}`);
 
       assert.strictEqual(
@@ -120,7 +122,9 @@ describe('timeElapsedBuckets', () => {
       const sql = timeElapsedBuckets(n);
       const labels = extractBucketLabels(sql);
 
+      // eslint-disable-next-line no-console
       console.log(`  topN=${n}: got ${labels.length} buckets`);
+      // eslint-disable-next-line no-console
       console.log(`    labels: ${labels.join(', ')}`);
 
       assert.strictEqual(

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -253,6 +253,7 @@ export async function loadBreakdown(b, timeFilter, hostFilter) {
       hasActiveFilter ? null : b.filterOp,
     );
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error(`Breakdown error (${b.id}):`, err);
     renderBreakdownError(b.id, err.message);
   } finally {

--- a/js/chart-state.js
+++ b/js/chart-state.js
@@ -230,6 +230,21 @@ export function getDetectedAnomalies() {
 }
 
 /**
+ * Parse timestamp as UTC (ClickHouse returns UTC times without Z suffix)
+ * @param {string|Date} timestamp - Timestamp to parse
+ * @returns {Date} Parsed date
+ */
+export function parseUTC(timestamp) {
+  const str = String(timestamp);
+  // If already has Z suffix, parse directly
+  if (str.endsWith('Z')) {
+    return new Date(str);
+  }
+  // Otherwise, normalize and append Z to treat as UTC
+  return new Date(`${str.replace(' ', 'T')}Z`);
+}
+
+/**
  * Get the time range for the most recent section (last 20% of timeline)
  * @returns {Object|null} Time range { start, end } or null
  */
@@ -256,21 +271,6 @@ export function getAnomalyAtX(x) {
     }
   }
   return null;
-}
-
-/**
- * Parse timestamp as UTC (ClickHouse returns UTC times without Z suffix)
- * @param {string|Date} timestamp - Timestamp to parse
- * @returns {Date} Parsed date
- */
-export function parseUTC(timestamp) {
-  const str = String(timestamp);
-  // If already has Z suffix, parse directly
-  if (str.endsWith('Z')) {
-    return new Date(str);
-  }
-  // Otherwise, normalize and append Z to treat as UTC
-  return new Date(`${str.replace(' ', 'T')}Z`);
 }
 
 /**

--- a/js/facet-palette.js
+++ b/js/facet-palette.js
@@ -273,6 +273,7 @@ async function loadSavedQueries() {
     paletteState.savedQueriesLoading = false;
     return queries;
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.warn('Failed to load saved queries:', err);
     paletteState.savedQueriesLoading = false;
     paletteState.savedQueries = [];
@@ -584,6 +585,7 @@ export function initFacetPalette() {
   const dialog = document.getElementById('facetPalette');
 
   if (!input || !list || !dialog) {
+    // eslint-disable-next-line no-console
     console.warn('Facet palette elements not found');
     return;
   }

--- a/js/logs.js
+++ b/js/logs.js
@@ -258,6 +258,7 @@ export function copyLogRow(rowIdx) {
     // Brief visual feedback
     showCopyFeedback();
   }).catch((err) => {
+    // eslint-disable-next-line no-console
     console.error('Failed to copy:', err);
   });
 }
@@ -399,6 +400,7 @@ async function loadMoreLogs() {
     // Check if there might be more data
     hasMoreLogs = result.data.length === PAGE_SIZE;
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error('Load more logs error:', err);
   } finally {
     loadingMore = false;
@@ -498,6 +500,7 @@ export async function loadLogs() {
     hasMoreLogs = result.data.length === PAGE_SIZE;
     logsOffset = result.data.length;
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error('Logs error:', err);
     renderLogsError(err.message);
   } finally {

--- a/js/main.js
+++ b/js/main.js
@@ -17,7 +17,8 @@ import {
   setElements, handleLogin, handleLogout, showDashboard,
 } from './auth.js';
 import {
-  loadStateFromURL, saveStateToURL, syncUIFromState, setUrlStateElements, setOnStateRestored,
+  loadStateFromURL, saveStateToURL, syncUIFromState, setUrlStateElements,
+  setOnStateRestored, setOnBeforeRestore,
 } from './url-state.js';
 import {
   queryTimestamp, setQueryTimestamp, clearCustomTimeRange, getTimeFilter, getHostFilter,
@@ -47,7 +48,8 @@ import {
 import { initFacetPalette } from './facet-palette.js';
 import { initFacetSearch, openFacetSearch } from './ui/facet-search.js';
 import {
-  investigateAnomalies, reapplyHighlightsIfCached, hasCachedInvestigation, invalidateInvestigationCache,
+  investigateAnomalies, reapplyHighlightsIfCached,
+  hasCachedInvestigation, invalidateInvestigationCache,
 } from './anomaly-investigation.js';
 import { populateTimeRangeSelect, populateTopNSelect, updateTimeRangeLabels } from './ui/selects.js';
 import {
@@ -176,7 +178,8 @@ setOnShowFiltersView(() => {
 // Set up filter callbacks to avoid circular dependencies
 setFilterCallbacks(saveStateToURL, loadDashboard);
 
-// Set up callback for browser back/forward navigation
+// Set up callbacks for browser back/forward navigation
+setOnBeforeRestore(() => invalidateInvestigationCache());
 setOnStateRestored(loadDashboard);
 
 // Move facets between pinned/normal/hidden sections based on state
@@ -313,6 +316,7 @@ async function init() {
     } catch (err) {
       // Invalid JSON in localStorage, clear it
       localStorage.removeItem('clickhouse_credentials');
+      // eslint-disable-next-line no-console
       console.log('Invalid credentials in localStorage');
     }
   }

--- a/js/releases.js
+++ b/js/releases.js
@@ -27,6 +27,7 @@ export async function getReleasesInRange(startTime, endTime) {
     const result = await query(sql, { cacheTtl: 300 });
     return result.data || [];
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error('Failed to fetch releases:', err);
     return [];
   }

--- a/js/step-detection.test.js
+++ b/js/step-detection.test.js
@@ -114,6 +114,7 @@ describe('detectStep', () => {
     // The spike starts at index 8 (21:12) where 4xx jumps from 12309 to 28932
     assert.strictEqual(result.startIndex, 8, 'Spike should start at index 8');
 
+    // eslint-disable-next-line no-console
     console.log('Detected step:', result);
   });
 
@@ -178,6 +179,7 @@ describe('detectStep', () => {
     assert.strictEqual(result.category, 'success', 'Should be in success category');
     assert.strictEqual(result.startIndex, 5, 'Drop should be at index 5');
 
+    // eslint-disable-next-line no-console
     console.log('Detected drop:', result);
   });
 
@@ -206,6 +208,7 @@ describe('detectStep', () => {
       'Should prioritize error spike over success drop',
     );
 
+    // eslint-disable-next-line no-console
     console.log('Detected (prioritized):', result);
   });
 
@@ -244,6 +247,7 @@ describe('CDN operational requirements', () => {
     // Green spikes can be highlighted if there's nothing more important
     if (result && result.category === 'success' && result.type === 'spike') {
       // This is acceptable - green spikes are low priority but can be shown
+      // eslint-disable-next-line no-console
       console.log('Green spike detected (low priority):', result);
     }
   });

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -14,7 +14,6 @@ import {
   queryTimestamp, setQueryTimestamp, customTimeRange, setCustomTimeRange, clearCustomTimeRange,
 } from './time.js';
 import { renderActiveFilters } from './filters.js';
-import { invalidateInvestigationCache } from './anomaly-investigation.js';
 import {
   DEFAULT_TIME_RANGE, DEFAULT_TOP_N, TIME_RANGES, TOP_N_OPTIONS,
 } from './constants.js';
@@ -27,6 +26,13 @@ let lastSavedURL = null;
 
 // Callback to reload dashboard (set by main.js)
 let onStateRestored = null;
+
+// Callback to run before restoring state (e.g., invalidate caches)
+let onBeforeRestore = null;
+
+export function setOnBeforeRestore(callback) {
+  onBeforeRestore = callback;
+}
 
 export function setOnStateRestored(callback) {
   onStateRestored = callback;
@@ -164,6 +170,7 @@ export function loadStateFromURL() {
           });
       }
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.error('Failed to parse filters from URL:', e);
     }
   }
@@ -267,8 +274,8 @@ window.addEventListener('popstate', () => {
   // Clear custom time range before loading (will be restored if in URL)
   clearCustomTimeRange();
 
-  // Clear investigation cache - anomalies will be re-detected for new time range
-  invalidateInvestigationCache();
+  // Clear caches before restoring state (e.g., investigation cache)
+  if (onBeforeRestore) onBeforeRestore();
 
   // Reload state from the new URL
   loadStateFromURL();


### PR DESCRIPTION
## Summary
- Break the dependency cycle (`anomaly-investigation` → `chart-state` → `url-state` → `anomaly-investigation`) by replacing the direct import in `url-state.js` with a `setOnBeforeRestore` callback pattern, wired up from `main.js`
- Move `parseUTC` function definition above its first usage in `chart-state.js` to fix `no-use-before-define`
- Fix `max-len` violation in `main.js` import statement
- Add `eslint-disable-next-line no-console` to 18 legitimate console statements in error handlers and test diagnostics

## Test plan
- [x] `npm run lint` passes with 0 errors and 0 warnings
- [x] `npm test` passes all 46 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)