### PR TITLE
fix: chart now respects full user-selected time range instead of contracting to data bounds

### DIFF
--- a/js/chart-state.js
+++ b/js/chart-state.js
@@ -279,8 +279,19 @@ export function getAnomalyAtX(x) {
  * @returns {Date|null} Time at position or null
  */
 export function getTimeAtX(x) {
-  if (!chartLayout || !lastChartData || lastChartData.length < 2) return null;
-  const { padding, chartWidth } = chartLayout;
+  if (!chartLayout) return null;
+  const { padding, chartWidth, intendedStartTime, intendedEndTime } = chartLayout;
+  
+  // Use intended time range if available (respects user's selected range)
+  if (intendedStartTime && intendedEndTime) {
+    const xRatio = (x - padding.left) / chartWidth;
+    if (xRatio < 0 || xRatio > 1) return null;
+    const time = new Date(intendedStartTime + xRatio * (intendedEndTime - intendedStartTime));
+    return time;
+  }
+  
+  // Fallback to data bounds (legacy behavior)
+  if (!lastChartData || lastChartData.length < 2) return null;
   const xRatio = (x - padding.left) / chartWidth;
   if (xRatio < 0 || xRatio > 1) return null;
 

--- a/js/releases.js
+++ b/js/releases.js
@@ -34,13 +34,27 @@ export async function getReleasesInRange(startTime, endTime) {
 }
 
 // Render ship symbols on the chart canvas
-export function renderReleaseShips(ctx, releases, data, chartDimensions) {
-  if (!releases || releases.length === 0 || !data || data.length < 2) return [];
+export function renderReleaseShips(ctx, releases, data, chartDimensions, timeRange = null) {
+  if (!releases || releases.length === 0) return [];
 
   const { padding, chartWidth } = chartDimensions;
-  const startTime = parseUTC(data[0].t).getTime();
-  const endTime = parseUTC(data[data.length - 1].t).getTime();
-  const timeRange = endTime - startTime;
+  
+  // Use provided time range (intended) or fall back to data bounds
+  let startTime;
+  let endTime;
+  let timeRangeMs;
+  
+  if (timeRange) {
+    startTime = timeRange.start;
+    endTime = timeRange.end;
+    timeRangeMs = endTime - startTime;
+  } else if (data && data.length >= 2) {
+    startTime = parseUTC(data[0].t).getTime();
+    endTime = parseUTC(data[data.length - 1].t).getTime();
+    timeRangeMs = endTime - startTime;
+  } else {
+    return [];
+  }
 
   // Get CSS variables for theming
   const styles = getComputedStyle(document.documentElement);
@@ -124,7 +138,7 @@ export function renderReleaseShips(ctx, releases, data, chartDimensions) {
 
   for (const release of releases) {
     const publishedTime = parseUTC(release.published).getTime();
-    const xRatio = (publishedTime - startTime) / timeRange;
+    const xRatio = (publishedTime - startTime) / timeRangeMs;
     const x = padding.left + (chartWidth * xRatio);
 
     // Draw at the very top of the chart

--- a/js/time.js
+++ b/js/time.js
@@ -145,6 +145,30 @@ export function getHostFilter() {
   return `AND (\`request.host\` LIKE '%${escaped}%' OR \`request.headers.x_forwarded_host\` LIKE '%${escaped}%')`;
 }
 
+// Get start time for WITH FILL FROM clause
+export function getTimeRangeStart() {
+  if (timeState.customTimeRange) {
+    const startIso = timeState.customTimeRange.start.toISOString().replace('T', ' ').slice(0, 19);
+    return `toDateTime('${startIso}')`;
+  }
+
+  const ts = timeState.queryTimestamp || new Date();
+  const isoTimestamp = ts.toISOString().replace('T', ' ').slice(0, 19);
+  return `toDateTime('${isoTimestamp}') - ${getInterval()}`;
+}
+
+// Get end time for WITH FILL TO clause
+export function getTimeRangeEnd() {
+  if (timeState.customTimeRange) {
+    const endIso = timeState.customTimeRange.end.toISOString().replace('T', ' ').slice(0, 19);
+    return `toDateTime('${endIso}')`;
+  }
+
+  const ts = timeState.queryTimestamp || new Date();
+  const isoTimestamp = ts.toISOString().replace('T', ' ').slice(0, 19);
+  return `toDateTime('${isoTimestamp}')`;
+}
+
 // Get period duration in milliseconds
 export function getPeriodMs() {
   if (timeState.customTimeRange) {


### PR DESCRIPTION
## Summary

Fixes #31 - Chart data points now align correctly with the user-selected time range.

## Problem

When there were very few data samples on the timeline chart, the chart would contract to only span the duration between the outermost samples, rather than respecting the user's selected time range. For example, with 2-3 samples over a 12-hour period, the chart would compress to just minutes instead of showing the full 12 hours.

## Solution

- Calculate the intended time range based on user selection (custom or preset period)
- Position data points by timestamp instead of array index for accurate time-based positioning
- Update SQL query to use `WITH FILL FROM ... TO ...` to ensure data fills the complete time range
- Update scrubber (`getTimeAtX()`) to use intended range for accurate hover/selection
- Update release ship positioning to respect intended time range

## Result

The chart now:
- Always displays the full time range the user selected
- Positions data points correctly at their actual timestamps
- Extends chart areas (lines and fills) all the way to both edges
- Fills gaps with zeros across the entire range