### PR TITLE
feat: add log detail modal on row click

### DIFF
--- a/css/logs.css
+++ b/css/logs.css
@@ -118,7 +118,7 @@
 }
 
 .logs-table tbody tr {
-  cursor: copy;
+  cursor: pointer;
 }
 
 .logs-table tr:hover td {

--- a/css/modals.css
+++ b/css/modals.css
@@ -231,3 +231,154 @@
   background: var(--border);
   margin: 4px 0;
 }
+
+/* Log Detail Modal */
+#logDetailModal {
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--card-bg);
+  color: var(--text);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  max-width: 800px;
+  width: 90vw;
+  max-height: 85vh;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
+}
+
+#logDetailModal[open] {
+  display: flex;
+  flex-direction: column;
+}
+
+#logDetailModal::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.log-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  border-radius: 12px 12px 0 0;
+  flex-shrink: 0;
+}
+
+.log-detail-header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.log-detail-content {
+  padding: 16px 20px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.log-detail-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.log-detail-table tr {
+  border-bottom: 1px solid var(--border);
+}
+
+.log-detail-table tr:last-child {
+  border-bottom: none;
+}
+
+.log-detail-table th {
+  text-align: left;
+  padding: 10px 12px 10px 0;
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  vertical-align: top;
+  width: 200px;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+  font-size: 12px;
+}
+
+.log-detail-table td {
+  padding: 10px 0;
+  word-break: break-all;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+  font-size: 12px;
+}
+
+.log-detail-table td.empty-value {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.log-detail-table .status-ok {
+  color: var(--status-ok);
+  font-weight: 600;
+}
+
+.log-detail-table .status-4xx {
+  color: var(--status-client-error);
+  font-weight: 600;
+}
+
+.log-detail-table .status-5xx {
+  color: var(--status-server-error);
+  font-weight: 600;
+}
+
+.log-detail-table .log-color {
+  display: inline-block;
+  width: 3px;
+  height: 12px;
+  margin-right: 6px;
+  border-radius: 1px;
+  vertical-align: middle;
+}
+
+.log-detail-group {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 2px solid var(--border);
+}
+
+.log-detail-group:first-child {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
+}
+
+.log-detail-group-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--primary);
+  margin-bottom: 12px;
+}
+
+@media (max-width: 600px) {
+  #logDetailModal {
+    width: 100vw;
+    max-width: 100vw;
+    height: 100vh;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+
+  .log-detail-header {
+    border-radius: 0;
+  }
+
+  .log-detail-table th {
+    width: 120px;
+  }
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -294,6 +294,17 @@
     </div>
   </dialog>
 
+  <!-- Log Detail Modal -->
+  <dialog id="logDetailModal" role="dialog" aria-labelledby="logDetailTitle">
+    <div class="log-detail-header">
+      <h2 id="logDetailTitle">Log Entry Details</h2>
+      <button class="modal-close" data-action="close-log-detail">&times;</button>
+    </div>
+    <div class="log-detail-content">
+      <table class="log-detail-table" id="logDetailTable"></table>
+    </div>
+  </dialog>
+
   <!-- Facet Command Palette (VS Code-style goto) -->
   <dialog id="facetPalette" role="dialog" aria-labelledby="facetPaletteTitle">
     <div class="palette-header">


### PR DESCRIPTION
## Summary

- Clicking a log row now opens a modal displaying all fields in a structured table format
- Fields are grouped by category: Core, Request, Response, CDN, Client, Helix
- Includes color coding for status codes and color indicators matching the log table
- Mobile-responsive with full-screen layout on small screens
- Modal can be closed via X button, clicking outside, or pressing Escape

## Test plan

- [ ] Open the logs view and click on any log row
- [ ] Verify the modal opens with all log entry fields displayed
- [ ] Verify fields are grouped by category with section headers
- [ ] Verify status codes show appropriate colors (green/orange/red)
- [ ] Verify modal closes when clicking X, outside, or pressing Escape
- [ ] Test on mobile viewport to verify full-screen layout

Made with [Cursor](https://cursor.com)