### PR TITLE
fix: prevent layout shift and double reload in filter tag UI

### DIFF
--- a/css/facets.css
+++ b/css/facets.css
@@ -463,8 +463,8 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   text-decoration: none;
 }
 
-.breakdown-table .dim.dim-clickable:hover .filter-tag-indicator {
-  transform: scale(1.02);
+.breakdown-table .dim.dim-clickable:hover {
+  background: var(--bg);
 }
 
 .breakdown-table .dim a {

--- a/css/facets.css
+++ b/css/facets.css
@@ -453,10 +453,9 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   opacity: 0.6;
 }
 
-/* Disable links in active/exclude filter state */
+/* Style links in active/exclude filter state (navigation blocked via JS) */
 .breakdown-table .filter-tag-indicator.active a,
 .breakdown-table .filter-tag-indicator.exclude a {
-  pointer-events: none;
   color: inherit;
   text-decoration: none;
 }

--- a/css/facets.css
+++ b/css/facets.css
@@ -368,19 +368,6 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   border-bottom: none;
 }
 
-.breakdown-table tr.filter-included .dim {
-  text-decoration: underline;
-  text-decoration-color: var(--text);
-  text-underline-offset: 3px;
-}
-
-.breakdown-table tr.filter-excluded .dim {
-  text-decoration: underline;
-  text-decoration-color: var(--error);
-  text-underline-offset: 3px;
-  opacity: 0.6;
-}
-
 /* Filtered values shown outside of topN - subtle separator */
 .breakdown-table tr.filtered-value-row:first-of-type {
   border-top: 1px dashed var(--border);
@@ -404,6 +391,49 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Clickable dimension cells for filter cycling */
+.breakdown-table .dim.dim-clickable {
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Filter tag indicators - inverted style */
+.breakdown-table .filter-tag-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 7px;
+  border-radius: 4px;
+  transition: all 0.15s ease;
+  color: white;
+  font-weight: 500;
+}
+
+.breakdown-table .filter-tag-indicator.active {
+  /* Background set inline from status color, defaults to var(--text) */
+}
+
+.breakdown-table .filter-tag-indicator.exclude {
+  /* Background set inline from status color, defaults to var(--text) */
+  opacity: 0.6;
+}
+
+.breakdown-table .filter-tag-indicator .filter-icon {
+  font-size: 11px;
+  font-weight: bold;
+  line-height: 1;
+}
+
+.breakdown-table .dim.dim-clickable:hover .filter-tag-indicator {
+  transform: scale(1.02);
+}
+
+@media (prefers-color-scheme: dark) {
+  .breakdown-table .filter-tag-indicator {
+    /* Keep colors vibrant in dark mode */
+  }
 }
 
 .breakdown-table .dim .status-color {
@@ -443,20 +473,9 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   display: block;
 }
 
+/* Remove old action buttons - now using clickable dim cells */
 .breakdown-table .count .action-btn {
   display: none;
-  position: absolute;
-  top: 50%;
-  right: 0;
-  transform: translateY(-50%);
-}
-
-.breakdown-table tr:hover .count .value {
-  display: none;
-}
-
-.breakdown-table tr:hover .count .action-btn {
-  display: block;
 }
 
 .breakdown-table .bar {
@@ -473,20 +492,9 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   display: flex;
 }
 
+/* Remove old action buttons - now using clickable dim cells */
 .breakdown-table .bar .action-btn {
   display: none;
-  position: absolute;
-  top: 50%;
-  left: 8px;
-  transform: translateY(-50%);
-}
-
-.breakdown-table tr:hover .bar .bar-inner {
-  display: none;
-}
-
-.breakdown-table tr:hover .bar .action-btn {
-  display: block;
 }
 
 .breakdown-table .bar-segment {
@@ -511,104 +519,13 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   border-radius: 4px;
 }
 
-.breakdown-table .action-btn {
-  padding: 2px 8px;
-  font-size: 11px;
-  border-radius: 4px;
-  border: 1px solid var(--border);
-  background: var(--card-bg);
-  cursor: pointer;
-  color: var(--text);
-  white-space: nowrap;
-}
-
-.breakdown-table .action-btn:hover {
-  background: var(--bg);
-}
-
-.breakdown-table .action-btn.exclude {
-  color: var(--error);
-}
-
-/* Mobile touch support - tap to reveal action buttons */
-/* Hide mobile actions by default everywhere */
-.breakdown-table .mobile-actions {
-  display: none;
-}
-
-/* On touch screens, use tap-to-reveal pattern */
+/* Mobile touch support - use clickable dim cells everywhere */
 @media (hover: none), (pointer: coarse) {
-  /* Disable desktop hover behavior */
-  .breakdown-table tr:hover .count .value,
-  .breakdown-table tr:hover .bar .bar-inner {
-    display: block;
-  }
-
-  .breakdown-table tr:hover .count .action-btn,
-  .breakdown-table tr:hover .bar .action-btn {
-    display: none;
-  }
-
-  /* When row is tapped (touch-active), show mobile actions and hide bar */
-  .breakdown-table tr.touch-active .bar {
-    display: none;
-  }
-
-  .breakdown-table tr.touch-active .mobile-actions {
-    display: table-cell;
-    text-align: right;
-    white-space: nowrap;
-    vertical-align: middle;
-  }
-
-  .breakdown-table .mobile-action-btn {
-    position: relative;
-    display: inline-flex;
+  /* Ensure tap targets are large enough on mobile */
+  .breakdown-table .dim.dim-clickable {
+    min-height: 44px;
+    display: flex;
     align-items: center;
-    justify-content: center;
-    width: 18px;
-    height: 18px;
-    padding: 0;
-    font-size: 12px;
-    font-weight: 600;
-    line-height: 1;
-    border-radius: 3px;
-    border: 1px solid var(--border);
-    background: var(--card-bg);
-    cursor: pointer;
-    color: var(--text);
-    box-sizing: border-box;
-    margin-left: 6px;
-    vertical-align: middle;
-  }
-
-  /* Expanded touch target */
-  .breakdown-table .mobile-action-btn::before {
-    content: '';
-    position: absolute;
-    top: -10px;
-    left: -10px;
-    right: -10px;
-    bottom: -10px;
-  }
-
-  .breakdown-table .mobile-action-btn:active {
-    background: var(--bg);
-  }
-
-  .breakdown-table .mobile-action-btn.exclude {
-    color: var(--error);
-  }
-
-  .breakdown-table .mobile-action-btn.active {
-    background: var(--primary);
-    color: white;
-    border-color: var(--primary);
-  }
-
-  .breakdown-table .mobile-action-btn.active.exclude {
-    background: var(--error);
-    border-color: var(--error);
   }
 }
 

--- a/css/facets.css
+++ b/css/facets.css
@@ -399,50 +399,72 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   user-select: none;
 }
 
-/* Filter tag indicators - inverted style */
+/* Filter tag container - consistent sizing in all states to prevent layout shift */
 .breakdown-table .filter-tag-indicator {
   display: inline-flex;
   align-items: center;
   gap: 3px;
   padding: 2px 7px;
   border-radius: 4px;
-  transition: all 0.15s ease;
-  color: white;
-  font-weight: 500;
+  transition: background 0.15s ease, color 0.15s ease;
 }
 
-.breakdown-table .filter-tag-indicator.active {
-  /* Background set inline from status color, defaults to var(--text) */
+/* Indicator slot: fixed width, shows icon OR color bar */
+.breakdown-table .filter-indicator-slot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 11px;
+  flex-shrink: 0;
+  overflow: hidden;
 }
 
-.breakdown-table .filter-tag-indicator.exclude {
-  /* Background set inline from status color, defaults to var(--text) */
-  opacity: 0.6;
-}
-
-.breakdown-table .filter-tag-indicator .filter-icon {
+/* Icon: hidden by default, shown in active/exclude states */
+.breakdown-table .filter-icon {
+  display: none;
   font-size: 11px;
   font-weight: bold;
   line-height: 1;
 }
 
-.breakdown-table .dim.dim-clickable:hover .filter-tag-indicator {
-  transform: scale(1.02);
-}
-
-@media (prefers-color-scheme: dark) {
-  .breakdown-table .filter-tag-indicator {
-    /* Keep colors vibrant in dark mode */
-  }
-}
-
-.breakdown-table .dim .status-color {
+/* Color bar inside indicator slot */
+.breakdown-table .filter-indicator-slot .status-color {
   display: inline-block;
   width: 3px;
   height: 12px;
-  margin-right: 6px;
   border-radius: 1px;
-  vertical-align: middle;
+}
+
+/* Active/exclude states: colored background, white text, show icon, hide color bar */
+.breakdown-table .filter-tag-indicator.active,
+.breakdown-table .filter-tag-indicator.exclude {
+  color: white;
+}
+
+.breakdown-table .filter-tag-indicator.active .filter-icon,
+.breakdown-table .filter-tag-indicator.exclude .filter-icon {
+  display: inline;
+}
+
+.breakdown-table .filter-tag-indicator.active .status-color,
+.breakdown-table .filter-tag-indicator.exclude .status-color {
+  display: none;
+}
+
+.breakdown-table .filter-tag-indicator.exclude {
+  opacity: 0.6;
+}
+
+/* Disable links in active/exclude filter state */
+.breakdown-table .filter-tag-indicator.active a,
+.breakdown-table .filter-tag-indicator.exclude a {
+  pointer-events: none;
+  color: inherit;
+  text-decoration: none;
+}
+
+.breakdown-table .dim.dim-clickable:hover .filter-tag-indicator {
+  transform: scale(1.02);
 }
 
 .breakdown-table .dim a {
@@ -473,10 +495,6 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   display: block;
 }
 
-/* Remove old action buttons - now using clickable dim cells */
-.breakdown-table .count .action-btn {
-  display: none;
-}
 
 .breakdown-table .bar {
   width: 60px;
@@ -492,10 +510,6 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   display: flex;
 }
 
-/* Remove old action buttons - now using clickable dim cells */
-.breakdown-table .bar .action-btn {
-  display: none;
-}
 
 .breakdown-table .bar-segment {
   height: 100%;

--- a/css/facets.css
+++ b/css/facets.css
@@ -413,10 +413,8 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
 .breakdown-table .filter-indicator-slot {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
   width: 11px;
   flex-shrink: 0;
-  overflow: hidden;
 }
 
 /* Icon: hidden by default, shown in active/exclude states */

--- a/css/keyboard.css
+++ b/css/keyboard.css
@@ -53,26 +53,9 @@ body.keyboard-mode .breakdown-card.kbd-focused {
   }
 }
 
-/* Focused row - show as hovered (with filter/exclude buttons visible) */
+/* Focused row - highlight background */
 body.keyboard-mode .breakdown-table tr.kbd-focused td.dim {
   background: var(--bg);
-}
-
-/* Show action buttons on focused row (same as hover) */
-body.keyboard-mode .breakdown-table tr.kbd-focused .count .value {
-  display: none;
-}
-
-body.keyboard-mode .breakdown-table tr.kbd-focused .count .action-btn {
-  display: block;
-}
-
-body.keyboard-mode .breakdown-table tr.kbd-focused .bar .bar-inner {
-  display: none;
-}
-
-body.keyboard-mode .breakdown-table tr.kbd-focused .bar .action-btn {
-  display: block;
 }
 
 /* Adjacent row hints for h/l navigation - positioned in left margin */

--- a/js/breakdowns/render.js
+++ b/js/breakdowns/render.js
@@ -245,7 +245,7 @@ export function renderBreakdownTable(
 
     const indicatorSlot = `<span class="filter-indicator-slot"><span class="filter-icon">${iconChar}</span>${colorIndicator}</span>`;
     const textHtml = linkUrl
-      ? `<a href="${linkUrl}" target="_blank" rel="noopener" onclick="event.stopPropagation()">${formattedDim}</a>`
+      ? `<a href="${linkUrl}" target="_blank" rel="noopener">${formattedDim}</a>`
       : formattedDim;
     const filterTag = `<span class="filter-tag-indicator${stateClass}"${tagStyle}>${indicatorSlot}${textHtml}</span>`;
 

--- a/js/breakdowns/render.js
+++ b/js/breakdowns/render.js
@@ -219,43 +219,47 @@ export function renderBreakdownTable(
     // Get color indicator using unified color system (already skips synthetic buckets)
     const colorIndicator = getColorIndicatorHtml(col, row.dim);
 
-    if (linkUrl) {
-      dimContent = `${colorIndicator}<a href="${linkUrl}" target="_blank" rel="noopener">${formattedDim}</a>`;
-    } else {
-      dimContent = `${colorIndicator}${formattedDim}`;
-    }
-
     // Compute filter attributes (may differ from display col/value for grouped facets)
     const actualFilterCol = filterCol || col;
     const actualFilterValue = filterValueFn ? filterValueFn(row.dim || '') : (row.dim || '');
     const actualFilterOp = filterOp || '=';
     const filterAttrs = `data-col="${escapeHtml(col)}" data-value="${escapeHtml(row.dim || '')}" data-filter-col="${escapeHtml(actualFilterCol)}" data-filter-value="${escapeHtml(actualFilterValue)}" data-filter-op="${escapeHtml(actualFilterOp)}"`;
 
-    // Determine button actions based on current filter state
-    const filterBtn = isIncluded
-      ? `<button class="action-btn" data-action="remove-filter-value" ${filterAttrs}>Clear</button>`
-      : `<button class="action-btn" data-action="add-filter" ${filterAttrs} data-exclude="false">Filter</button>`;
-    const excludeBtn = isExcluded
-      ? `<button class="action-btn" data-action="remove-filter-value" ${filterAttrs}>Clear</button>`
-      : `<button class="action-btn exclude" data-action="add-filter" ${filterAttrs} data-exclude="true">Exclude</button>`;
+    // Build filter tag content based on state
+    let filterTag = '';
+    if (isIncluded) {
+      // Filter active - show inverted tag with checkmark before text
+      // Extract color from indicator for background if present
+      const colorMatch = colorIndicator.match(/background:\s*([^;"]+)/);
+      const bgColor = colorMatch ? colorMatch[1] : 'var(--text)';
+      filterTag = `<span class="filter-tag-indicator active" style="background: ${bgColor}"><span class="filter-icon">✓</span>${formattedDim}</span>`;
+    } else if (isExcluded) {
+      // Exclude active - show inverted tag with X before text and reduced opacity
+      const colorMatch = colorIndicator.match(/background:\s*([^;"]+)/);
+      const bgColor = colorMatch ? colorMatch[1] : 'var(--text)';
+      filterTag = `<span class="filter-tag-indicator exclude" style="background: ${bgColor}"><span class="filter-icon">×</span>${formattedDim}</span>`;
+    } else if (linkUrl) {
+      filterTag = `${colorIndicator}<a href="${linkUrl}" target="_blank" rel="noopener" onclick="event.stopPropagation()">${formattedDim}</a>`;
+    } else {
+      filterTag = `${colorIndicator}${formattedDim}`;
+    }
 
-    // Mobile action buttons (shown on tap) - using Unicode symbols
-    // ▼ for filter, × for exclude, ✓ for clear
-    const mobileFilterBtn = isIncluded
-      ? `<button class="mobile-action-btn active" data-action="remove-filter-value" ${filterAttrs} title="Remove filter">✓</button>`
-      : `<button class="mobile-action-btn" data-action="add-filter" ${filterAttrs} data-exclude="false" title="Filter to this value">▼</button>`;
-    const mobileExcludeBtn = isExcluded
-      ? `<button class="mobile-action-btn exclude active" data-action="remove-filter-value" ${filterAttrs} title="Remove exclusion">✓</button>`
-      : `<button class="mobile-action-btn exclude" data-action="add-filter" ${filterAttrs} data-exclude="true" title="Exclude this value">×</button>`;
+    // Make dim cell clickable to cycle filter state (none → filter → exclude → none)
+    const dimAction = isIncluded
+      ? 'remove-filter-value'
+      : isExcluded
+        ? 'remove-filter-value'
+        : 'add-filter';
+    const dimExclude = isIncluded ? 'false' : isExcluded ? 'true' : 'false';
+    // Cycle: none → filter (exclude=false) → exclude (exclude=true) → none (remove)
 
     const ariaSelected = isIncluded || isExcluded ? 'true' : 'false';
     const dimDataAttr = (row.dim || '').replace(/"/g, '&quot;');
     html += `
       <tr class="${rowClass}" tabindex="0" role="option" aria-selected="${ariaSelected}" data-value-index="${rowIndex}" data-dim="${dimDataAttr}">
-        <td class="dim" title="${escapeHtml(dim)}">${dimContent}</td>
+        <td class="dim dim-clickable" title="${escapeHtml(dim)}" data-action="${dimAction}" ${filterAttrs} data-exclude="${dimExclude}">${filterTag}</td>
         <td class="count">
           <span class="value">${valueFormatter(cnt)}</span>
-          ${filterBtn}
         </td>
         <td class="bar">
           <div class="bar-inner${overflowClass}" style="width: ${barWidth}%">
@@ -263,9 +267,7 @@ export function renderBreakdownTable(
             <div class="bar-segment bar-4xx" style="width: ${pct4xx}%"></div>
             <div class="bar-segment bar-ok" style="width: ${pctOk}%"></div>
           </div>
-          ${excludeBtn}
         </td>
-        <td class="mobile-actions">${mobileFilterBtn}${mobileExcludeBtn}</td>
       </tr>
     `;
     rowIndex += 1;

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -37,6 +37,7 @@ import {
 import { getNextTopN } from './breakdowns/render.js';
 import {
   addFilter, removeFilter, removeFilterByValue, clearFiltersForColumn, setFilterCallbacks,
+  getFilterForValue,
 } from './filters.js';
 import {
   loadLogs, toggleLogsView, setLogsElements, setOnShowFiltersView,
@@ -280,6 +281,7 @@ export function initDashboard(config = {}) {
       addFilter,
       removeFilter,
       removeFilterByValue,
+      getFilterForValue,
       clearFiltersForColumn,
       increaseTopN,
       toggleFacetPin: togglePinnedFacet,

--- a/js/filters.js
+++ b/js/filters.js
@@ -74,6 +74,105 @@ export function getFiltersForColumn(col) {
   return state.filters.filter((f) => f.col === col);
 }
 
+export function getFilterForValue(col, value) {
+  return state.filters.find((f) => f.col === col && f.value === value);
+}
+
+// Immediately update row styling when filter changes (before reload)
+// This prevents the old filter state from being visible during the blur
+function updateRowFilterStyling(col, value) {
+  // Find all facet cards
+  const cards = document.querySelectorAll('.breakdown-card');
+  
+  cards.forEach((card) => {
+    const table = card.querySelector('.breakdown-table');
+    if (!table) return;
+    
+    // Find rows matching this column and value
+    const rows = table.querySelectorAll(`tr[data-dim]`);
+    rows.forEach((row) => {
+      const rowValue = row.dataset.dim;
+      if (rowValue !== value) return;
+      
+      // Get the current filter state for this value
+      const filter = state.filters.find((f) => f.col === col && f.value === value);
+      const isIncluded = filter && !filter.exclude;
+      const isExcluded = filter && filter.exclude;
+      
+      // Update row classes
+      row.classList.remove('filter-included', 'filter-excluded');
+      if (isIncluded) {
+        row.classList.add('filter-included');
+      } else if (isExcluded) {
+        row.classList.add('filter-excluded');
+      }
+      
+      // Update the dim cell content to show new tag styling
+      const dimCell = row.querySelector('td.dim');
+      if (!dimCell) return;
+      
+      // Extract the color indicator and formatted text
+      const colorIndicator = dimCell.querySelector('.status-color');
+      const colorHtml = colorIndicator ? colorIndicator.outerHTML : '';
+      
+      // Get text content (without color indicator)
+      let textContent = '';
+      const textNodes = [];
+      const walker = document.createTreeWalker(dimCell, NodeFilter.SHOW_TEXT, null, false);
+      let node;
+      while ((node = walker.nextNode())) {
+        textNodes.push(node.textContent.trim());
+      }
+      textContent = textNodes.filter(t => t).join('');
+      
+      // Extract color from indicator for background
+      let bgColor = 'var(--text)';
+      if (colorIndicator) {
+        const style = colorIndicator.getAttribute('style') || '';
+        const match = style.match(/background:\s*([^;"]+)/);
+        if (match) bgColor = match[1];
+      }
+      
+      // Rebuild dim cell with new styling
+      if (isIncluded) {
+        dimCell.innerHTML = `<span class="filter-tag-indicator active" style="background: ${bgColor}"><span class="filter-icon">✓</span>${textContent}</span>`;
+      } else if (isExcluded) {
+        dimCell.innerHTML = `<span class="filter-tag-indicator exclude" style="background: ${bgColor}"><span class="filter-icon">×</span>${textContent}</span>`;
+      } else {
+        // Restore original content (no filter)
+        const link = row.querySelector('td.dim a');
+        if (link) {
+          dimCell.innerHTML = `${colorHtml}<a href="${link.href}" target="_blank" rel="noopener" onclick="event.stopPropagation()">${textContent}</a>`;
+        } else {
+          dimCell.innerHTML = `${colorHtml}${textContent}`;
+        }
+      }
+      
+      // Re-add the action attributes
+      dimCell.classList.add('dim-clickable');
+      const filterAttrs = row.querySelector('[data-filter-col]');
+      if (filterAttrs) {
+        dimCell.dataset.col = filterAttrs.dataset.col || col;
+        dimCell.dataset.value = filterAttrs.dataset.value || value;
+        dimCell.dataset.filterCol = filterAttrs.dataset.filterCol || '';
+        dimCell.dataset.filterValue = filterAttrs.dataset.filterValue || '';
+        dimCell.dataset.filterOp = filterAttrs.dataset.filterOp || '';
+        
+        if (isIncluded) {
+          dimCell.dataset.action = 'remove-filter-value';
+          dimCell.dataset.exclude = 'false';
+        } else if (isExcluded) {
+          dimCell.dataset.action = 'remove-filter-value';
+          dimCell.dataset.exclude = 'true';
+        } else {
+          dimCell.dataset.action = 'add-filter';
+          dimCell.dataset.exclude = 'false';
+        }
+      }
+    });
+  });
+}
+
 export function clearFiltersForColumn(col) {
   state.filters = state.filters.filter((f) => f.col !== col);
   renderActiveFilters();
@@ -116,6 +215,7 @@ export function addFilter(col, value, exclude, filterCol, filterValue, filterOp,
 
   state.filters.push(filter);
   renderActiveFilters();
+  updateRowFilterStyling(col, value); // Update UI immediately before reload
   if (!skipReload) {
     if (saveStateToURL) saveStateToURL();
     if (loadDashboard) loadDashboard();
@@ -132,6 +232,7 @@ export function removeFilter(index) {
 export function removeFilterByValue(col, value) {
   state.filters = state.filters.filter((f) => !(f.col === col && f.value === value));
   renderActiveFilters();
+  updateRowFilterStyling(col, value); // Update UI immediately before reload
   if (saveStateToURL) saveStateToURL();
   if (loadDashboard) loadDashboard();
 }

--- a/js/filters.js
+++ b/js/filters.js
@@ -85,6 +85,10 @@ function updateRowFilterStyling(col, value) {
   document.querySelectorAll('.breakdown-card .breakdown-table tr[data-dim]').forEach((row) => {
     if (row.dataset.dim !== value) return;
 
+    // Only update rows belonging to this facet column
+    const dimCell = row.querySelector('td.dim');
+    if (dimCell?.dataset.col !== col) return;
+
     const filter = state.filters.find((f) => f.col === col && f.value === value);
     const isIncluded = filter && !filter.exclude;
     const isExcluded = filter && filter.exclude;
@@ -101,7 +105,6 @@ function updateRowFilterStyling(col, value) {
     tag.classList.toggle('exclude', !!isExcluded);
 
     // Update background from stored color
-    const dimCell = row.querySelector('td.dim');
     const bgColor = dimCell?.dataset.bgColor || 'var(--text)';
     tag.style.background = (isIncluded || isExcluded) ? bgColor : '';
 

--- a/js/filters.js
+++ b/js/filters.js
@@ -78,98 +78,46 @@ export function getFilterForValue(col, value) {
   return state.filters.find((f) => f.col === col && f.value === value);
 }
 
-// Immediately update row styling when filter changes (before reload)
-// This prevents the old filter state from being visible during the blur
+// Immediately update row styling when filter changes (before reload).
+// Toggles classes and attributes on the existing DOM structure
+// (no innerHTML rebuild needed since the tag structure is consistent in all states).
 function updateRowFilterStyling(col, value) {
-  // Find all facet cards
-  const cards = document.querySelectorAll('.breakdown-card');
-  
-  cards.forEach((card) => {
-    const table = card.querySelector('.breakdown-table');
-    if (!table) return;
-    
-    // Find rows matching this column and value
-    const rows = table.querySelectorAll(`tr[data-dim]`);
-    rows.forEach((row) => {
-      const rowValue = row.dataset.dim;
-      if (rowValue !== value) return;
-      
-      // Get the current filter state for this value
-      const filter = state.filters.find((f) => f.col === col && f.value === value);
-      const isIncluded = filter && !filter.exclude;
-      const isExcluded = filter && filter.exclude;
-      
-      // Update row classes
-      row.classList.remove('filter-included', 'filter-excluded');
-      if (isIncluded) {
-        row.classList.add('filter-included');
-      } else if (isExcluded) {
-        row.classList.add('filter-excluded');
-      }
-      
-      // Update the dim cell content to show new tag styling
-      const dimCell = row.querySelector('td.dim');
-      if (!dimCell) return;
-      
-      // Extract the color indicator and formatted text
-      const colorIndicator = dimCell.querySelector('.status-color');
-      const colorHtml = colorIndicator ? colorIndicator.outerHTML : '';
-      
-      // Get text content (without color indicator)
-      let textContent = '';
-      const textNodes = [];
-      const walker = document.createTreeWalker(dimCell, NodeFilter.SHOW_TEXT, null, false);
-      let node;
-      while ((node = walker.nextNode())) {
-        textNodes.push(node.textContent.trim());
-      }
-      textContent = textNodes.filter(t => t).join('');
-      
-      // Extract color from indicator for background
-      let bgColor = 'var(--text)';
-      if (colorIndicator) {
-        const style = colorIndicator.getAttribute('style') || '';
-        const match = style.match(/background:\s*([^;"]+)/);
-        if (match) bgColor = match[1];
-      }
-      
-      // Rebuild dim cell with new styling
-      if (isIncluded) {
-        dimCell.innerHTML = `<span class="filter-tag-indicator active" style="background: ${bgColor}"><span class="filter-icon">✓</span>${textContent}</span>`;
-      } else if (isExcluded) {
-        dimCell.innerHTML = `<span class="filter-tag-indicator exclude" style="background: ${bgColor}"><span class="filter-icon">×</span>${textContent}</span>`;
-      } else {
-        // Restore original content (no filter)
-        const link = row.querySelector('td.dim a');
-        if (link) {
-          dimCell.innerHTML = `${colorHtml}<a href="${link.href}" target="_blank" rel="noopener" onclick="event.stopPropagation()">${textContent}</a>`;
-        } else {
-          dimCell.innerHTML = `${colorHtml}${textContent}`;
-        }
-      }
-      
-      // Re-add the action attributes
-      dimCell.classList.add('dim-clickable');
-      const filterAttrs = row.querySelector('[data-filter-col]');
-      if (filterAttrs) {
-        dimCell.dataset.col = filterAttrs.dataset.col || col;
-        dimCell.dataset.value = filterAttrs.dataset.value || value;
-        dimCell.dataset.filterCol = filterAttrs.dataset.filterCol || '';
-        dimCell.dataset.filterValue = filterAttrs.dataset.filterValue || '';
-        dimCell.dataset.filterOp = filterAttrs.dataset.filterOp || '';
-        
-        if (isIncluded) {
-          dimCell.dataset.action = 'remove-filter-value';
-          dimCell.dataset.exclude = 'false';
-        } else if (isExcluded) {
-          dimCell.dataset.action = 'remove-filter-value';
-          dimCell.dataset.exclude = 'true';
-        } else {
-          dimCell.dataset.action = 'add-filter';
-          dimCell.dataset.exclude = 'false';
-        }
-      }
-    });
+  document.querySelectorAll('.breakdown-card .breakdown-table tr[data-dim]').forEach((row) => {
+    if (row.dataset.dim !== value) return;
+
+    const filter = state.filters.find((f) => f.col === col && f.value === value);
+    const isIncluded = filter && !filter.exclude;
+    const isExcluded = filter && filter.exclude;
+
+    // Update row classes
+    row.classList.toggle('filter-included', !!isIncluded);
+    row.classList.toggle('filter-excluded', !!isExcluded);
+
+    // Update tag indicator state
+    const tag = row.querySelector('.filter-tag-indicator');
+    if (!tag) return;
+
+    tag.classList.toggle('active', !!isIncluded);
+    tag.classList.toggle('exclude', !!isExcluded);
+
+    // Update background from stored color
+    const dimCell = row.querySelector('td.dim');
+    const bgColor = dimCell?.dataset.bgColor || 'var(--text)';
+    tag.style.background = (isIncluded || isExcluded) ? bgColor : '';
+
+    // Update icon character
+    const icon = tag.querySelector('.filter-icon');
+    if (icon) {
+      if (isIncluded) icon.textContent = '✓';
+      else if (isExcluded) icon.textContent = '×';
+      else icon.textContent = '';
+    }
+
+    // Update dim cell action for next click cycle
+    if (dimCell) {
+      dimCell.dataset.action = (isIncluded || isExcluded) ? 'remove-filter-value' : 'add-filter';
+      dimCell.dataset.exclude = isExcluded ? 'true' : 'false';
+    }
   });
 }
 
@@ -229,10 +177,12 @@ export function removeFilter(index) {
   if (loadDashboard) loadDashboard();
 }
 
-export function removeFilterByValue(col, value) {
+export function removeFilterByValue(col, value, skipReload) {
   state.filters = state.filters.filter((f) => !(f.col === col && f.value === value));
   renderActiveFilters();
-  updateRowFilterStyling(col, value); // Update UI immediately before reload
-  if (saveStateToURL) saveStateToURL();
-  if (loadDashboard) loadDashboard();
+  updateRowFilterStyling(col, value);
+  if (!skipReload) {
+    if (saveStateToURL) saveStateToURL();
+    if (loadDashboard) loadDashboard();
+  }
 }

--- a/js/ui/actions.js
+++ b/js/ui/actions.js
@@ -46,10 +46,12 @@ export function initActionHandlers(handlers) {
       }
       case 'add-filter': {
         event.stopPropagation();
+        // Shift+click skips straight to exclude
+        const exclude = event.shiftKey || target.dataset.exclude === 'true';
         handlers.addFilter?.(
           target.dataset.col || '',
           target.dataset.value || '',
-          target.dataset.exclude === 'true',
+          exclude,
           target.dataset.filterCol,
           target.dataset.filterValue,
           target.dataset.filterOp,

--- a/js/ui/actions.js
+++ b/js/ui/actions.js
@@ -14,7 +14,8 @@
  * @property {(col: string) => void} togglePinnedColumn
  * @property {Function} addFilter - (col, value, exclude, filterCol?, filterValue?, filterOp?)
  * @property {(index: number) => void} removeFilter
- * @property {(col: string, value: string) => void} removeFilterByValue
+ * @property {(col: string, value: string, skipReload?: boolean) => void} removeFilterByValue
+ * @property {(col: string, value: string) => Object|undefined} getFilterForValue
  * @property {(col: string) => void} clearFiltersForColumn
  * @property {() => void} increaseTopN
  * @property {(facetId: string) => void} toggleFacetPin
@@ -32,6 +33,13 @@
  */
 export function initActionHandlers(handlers) {
   document.addEventListener('click', (event) => {
+    // Let links inside unfiltered filter tags navigate normally
+    if (event.target.closest('.filter-tag-indicator:not(.active):not(.exclude) a')) return;
+    // Block link navigation inside active/excluded filter tags
+    if (event.target.closest('.filter-tag-indicator.active a, .filter-tag-indicator.exclude a')) {
+      event.preventDefault();
+    }
+
     const target = event.target.closest('[data-action]');
     if (!target) return;
 


### PR DESCRIPTION
## Summary

Builds on #37 to fix issues identified during review. Closes #33.

- **No layout shift**: Uses a fixed-width indicator slot (`filter-indicator-slot`) that swaps between the color bar and ✓/× icon. The tag container always has the same padding, gap, and slot width in all states (none/include/exclude), so clicking to cycle filters causes zero geometry change.
- **Single reload on state cycling**: When transitioning include→exclude, `removeFilterByValue` now accepts `skipReload` so both operations happen in a single `loadDashboard()` call instead of two.
- **No duplicated render logic**: `updateRowFilterStyling` now toggles CSS classes and data attributes on the existing DOM structure instead of rebuilding innerHTML — which also fixes the broken link restoration bug (original `href` was lost after innerHTML replacement).
- **Cleanup**: Removed empty CSS rule bodies, dead `.action-btn` display rules, and leftover `<td class="mobile-actions">` from other/more rows.

## Test plan

- [ ] Click a facet dimension to add include filter — no visible layout jump
- [ ] Click again to cycle to exclude — no layout jump, single network reload
- [ ] Click again to clear — returns to original state cleanly
- [ ] Verify linkable dimensions (URLs, hostnames) still open in new tab when unfiltered
- [ ] Verify links are disabled (not clickable) when row has active filter
- [ ] Test on mobile viewport — tap targets remain accessible
- [ ] Verify keyboard navigation still highlights focused rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)