### PR TITLE
fix: align chart fill bounds with bucket steps

### DIFF
--- a/js/chart-state.js
+++ b/js/chart-state.js
@@ -279,11 +279,20 @@ export function getAnomalyAtX(x) {
  * @returns {Date|null} Time at position or null
  */
 export function getTimeAtX(x) {
-  if (!chartLayout || !lastChartData || lastChartData.length < 2) return null;
-  const { padding, chartWidth } = chartLayout;
+  if (!chartLayout) return null;
+  const {
+    padding, chartWidth, intendedStartTime, intendedEndTime,
+  } = chartLayout;
   const xRatio = (x - padding.left) / chartWidth;
   if (xRatio < 0 || xRatio > 1) return null;
 
+  if (Number.isFinite(intendedStartTime)
+    && Number.isFinite(intendedEndTime)
+    && intendedEndTime > intendedStartTime) {
+    return new Date(intendedStartTime + xRatio * (intendedEndTime - intendedStartTime));
+  }
+
+  if (!lastChartData || lastChartData.length < 2) return null;
   const startTime = parseUTC(lastChartData[0].t).getTime();
   const endTime = parseUTC(lastChartData[lastChartData.length - 1].t).getTime();
   const time = new Date(startTime + xRatio * (endTime - startTime));

--- a/js/releases.js
+++ b/js/releases.js
@@ -34,13 +34,25 @@ export async function getReleasesInRange(startTime, endTime) {
 }
 
 // Render ship symbols on the chart canvas
-export function renderReleaseShips(ctx, releases, data, chartDimensions) {
-  if (!releases || releases.length === 0 || !data || data.length < 2) return [];
+export function renderReleaseShips(ctx, releases, data, chartDimensions, timeRange = null) {
+  if (!releases || releases.length === 0) return [];
 
   const { padding, chartWidth } = chartDimensions;
-  const startTime = parseUTC(data[0].t).getTime();
-  const endTime = parseUTC(data[data.length - 1].t).getTime();
-  const timeRange = endTime - startTime;
+  let startTime;
+  let endTime;
+  let timeRangeMs;
+
+  if (timeRange) {
+    startTime = timeRange.start;
+    endTime = timeRange.end;
+    timeRangeMs = endTime - startTime;
+  } else if (data && data.length >= 2) {
+    startTime = parseUTC(data[0].t).getTime();
+    endTime = parseUTC(data[data.length - 1].t).getTime();
+    timeRangeMs = endTime - startTime;
+  } else {
+    return [];
+  }
 
   // Get CSS variables for theming
   const styles = getComputedStyle(document.documentElement);
@@ -124,7 +136,7 @@ export function renderReleaseShips(ctx, releases, data, chartDimensions) {
 
   for (const release of releases) {
     const publishedTime = parseUTC(release.published).getTime();
-    const xRatio = (publishedTime - startTime) / timeRange;
+    const xRatio = (publishedTime - startTime) / timeRangeMs;
     const x = padding.left + (chartWidth * xRatio);
 
     // Draw at the very top of the chart


### PR DESCRIPTION
## Summary
- Align chart time range bounds with bucket steps used by WITH FILL and toStartOfInterval.
- Use aligned bounds for chart layout, scrubber/selection mapping, and release ship positioning.
- Fix release queries to receive Date ranges and add tests for fill-bound alignment.

## Testing
- npm test
- Manual (stubbed): `npm start` + `node debug/chart-fill.mjs`
- Manual (live, lars): `npm start` + `node debug/chart-fill-live.mjs`
