### PR TITLE
fix: 't' keyboard shortcut now correctly toggles logs view

### DIFF
--- a/js/keyboard.js
+++ b/js/keyboard.js
@@ -434,7 +434,7 @@ export function initKeyboardNavigation({ toggleFacetMode, reloadDashboard } = {}
         break;
       case 't':
         e.preventDefault();
-        document.getElementById('logsBtn').click();
+        document.getElementById('viewToggleBtn').click();
         break;
       case '1':
       case '2':


### PR DESCRIPTION
## Summary

Fixes the `t` keyboard shortcut which was supposed to toggle the logs view but did nothing. The handler in `keyboard.js` was calling `document.getElementById('logsBtn').click()`, but no element with ID `logsBtn` exists — the actual button ID is `viewToggleBtn`.

Fixes #41

## Testing Done

- Verified `viewToggleBtn` is the correct ID in `dashboard.html`
- Confirmed `eslint js/keyboard.js` passes with no errors

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)