### PR TITLE
fix: deselect time range preset after manual chart zoom

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -21,7 +21,8 @@ import {
   setOnStateRestored, setOnBeforeRestore,
 } from './url-state.js';
 import {
-  queryTimestamp, setQueryTimestamp, clearCustomTimeRange, getTimeFilter, getHostFilter,
+  queryTimestamp, setQueryTimestamp, clearCustomTimeRange, isCustomTimeRange,
+  getTimeFilter, getHostFilter,
 } from './time.js';
 import {
   startQueryTimer, stopQueryTimer, hasVisibleUpdatingFacets, initFacetObservers,
@@ -137,6 +138,17 @@ async function loadDashboardQueries(timeFilter, hostFilter) {
   }
 }
 
+// Update keyboard hint for time range to show next option number
+function updateTimeRangeHint() {
+  const hint = document.getElementById('timeRangeHint');
+  const select = document.getElementById('timeRange');
+  if (!hint || !select) return;
+
+  // Show next option number (wraps to 1 if at last option)
+  const nextIndex = (select.selectedIndex + 1) % select.options.length;
+  hint.textContent = nextIndex + 1;
+}
+
 // Load Dashboard Data
 async function loadDashboard(refresh = false) {
   setForceRefresh(refresh);
@@ -149,6 +161,15 @@ async function loadDashboard(refresh = false) {
     setQueryTimestamp(new Date());
   }
   saveStateToURL();
+
+  // Sync time range dropdown with current state (custom zoom vs preset)
+  if (isCustomTimeRange()) {
+    elements.timeRangeSelect.value = 'custom';
+  } else {
+    elements.timeRangeSelect.value = state.timeRange;
+  }
+  updateTimeRangeHint();
+
   startQueryTimer();
   resetFacetTimings();
 
@@ -221,17 +242,6 @@ function reorderFacets(toggledFacetId = null) {
 
 // Set up callback for facet order changes
 setOnFacetOrderChange(reorderFacets);
-
-// Update keyboard hint for time range to show next option number
-function updateTimeRangeHint() {
-  const hint = document.getElementById('timeRangeHint');
-  const select = document.getElementById('timeRange');
-  if (!hint || !select) return;
-
-  // Show next option number (wraps to 1 if at last option)
-  const nextIndex = (select.selectedIndex + 1) % select.options.length;
-  hint.textContent = nextIndex + 1;
-}
 
 // Increase topN and reload breakdowns
 function increaseTopN() {


### PR DESCRIPTION
## Summary

When a user zooms into a custom time range on the chart (via drag-select, anomaly click, or keyboard shortcut), the time range dropdown previously kept showing the last selected preset (e.g. "1h"). This was misleading because the actual displayed range no longer matched the dropdown.

This PR syncs the dropdown in `loadDashboard()` — the common code path for all zoom operations — so it shows "Custom" when a custom zoom range is active, and reverts to the preset label when zooming out or selecting a preset.

**Changes in `js/main.js`:**
- Import `isCustomTimeRange` from `time.js`
- Add dropdown sync logic in `loadDashboard()` that sets the select value to `'custom'` (a pre-existing hidden option) or the current preset
- Move `updateTimeRangeHint()` definition above `loadDashboard()` to satisfy `no-use-before-define` lint rule

Fixes #32

## Testing Done

- `npm test` — all 48 tests pass
- `npm run lint` — no new lint errors (pre-existing errors in other files unchanged)
- Verified all zoom code paths (chart drag, anomaly rank zoom, anomaly auto-zoom, zoom out) flow through `loadDashboard()`

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)