### PR TITLE
fix: let all browser shortcuts with modifier keys pass through

### DIFF
--- a/js/keyboard.js
+++ b/js/keyboard.js
@@ -324,6 +324,9 @@ export function initKeyboardNavigation({ toggleFacetMode, reloadDashboard } = {}
 
   // Main keydown handler
   document.addEventListener('keydown', (e) => {
+    // Don't capture browser shortcuts (Cmd+L, Cmd+R, Cmd+T, Ctrl+C, etc.)
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+
     // Ignore if in input field or dialog is open
     if (e.target.matches('input, textarea, select')) return;
     if (document.querySelector('dialog[open]:not(#keyboardHelp):not(#facetPalette)')) return;
@@ -454,15 +457,11 @@ export function initKeyboardNavigation({ toggleFacetMode, reloadDashboard } = {}
         break;
       case '+':
       case '=': // Unshifted + on most keyboards
-        // Don't override browser zoom (Cmd/Ctrl + +)
-        if (e.metaKey || e.ctrlKey) return;
         e.preventDefault();
         // Zoom in: to most prominent anomaly, or most recent section if none
         zoomToAnomaly();
         break;
       case '-':
-        // Don't override browser zoom (Cmd/Ctrl + -)
-        if (e.metaKey || e.ctrlKey) return;
         e.preventDefault();
         // Zoom out: expand to next larger predefined period
         if (zoomOut()) {


### PR DESCRIPTION
## Summary

PR #24 added `metaKey`/`ctrlKey` guards to the `+` and `-` keyboard shortcuts to avoid overriding browser zoom. However, all other single-letter shortcuts (`l`, `r`, `t`, `b`, `g`, `o`, `p`, `d`, `f`, etc.) had no such guard, so browser shortcuts like **Cmd+L** (address bar), **Cmd+R** (reload), **Cmd+T** (new tab), and others were being captured by the dashboard's keyboard handler.

This moves the modifier key check to the very top of the keydown handler so that any keypress with Cmd, Ctrl, or Alt passes through to the browser unconditionally. The per-key checks on `+`/`-` become redundant and are removed.

## Testing Done

- Verified `npm run lint` passes with no new errors
- Confirmed Cmd+L, Cmd+R, Cmd+T, Cmd+B, Ctrl+C all pass through to browser
- Confirmed bare `l`, `r`, `t`, `+`, `-` still work as dashboard shortcuts

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)