### PR TITLE
fix: widen chart nav zones and align filter selection highlight

### DIFF
--- a/css/chart.css
+++ b/css/chart.css
@@ -48,14 +48,24 @@
 }
 
 .chart-nav-zone {
-  flex: 0 0 20px;
+  flex: 0 0 60px;
   display: flex;
   align-items: center;
-  justify-content: center;
   pointer-events: auto;
   cursor: pointer;
   opacity: 0;
   transition: opacity 0.2s;
+}
+
+.chart-nav-left {
+  justify-content: flex-start;
+  padding-left: 8px;
+}
+
+.chart-nav-right {
+  justify-content: flex-end;
+  padding-right: 8px;
+  margin-left: auto;
 }
 
 .chart-nav-zone:hover {
@@ -224,20 +234,12 @@
   }
 }
 
-.chart-nav-left {
-  /* 20px width set on .chart-nav-zone */
-}
-
-.chart-nav-right {
-  margin-left: auto;
-  /* 20px width set on .chart-nav-zone */
-}
-
 .chart-nav-arrow {
-  font-size: 24px;
+  font-size: 18px;
   color: var(--text-secondary);
   opacity: 0.7;
   line-height: 1;
   display: flex;
   align-items: center;
 }
+

--- a/css/facets.css
+++ b/css/facets.css
@@ -401,7 +401,7 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
 
 /* Filter tag container - consistent sizing in all states to prevent layout shift */
 .breakdown-table .filter-tag-indicator {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 3px;
   padding: 2px 7px;


### PR DESCRIPTION
## Summary

### Chart arrow navigation zones (#63)
- Widen nav zones from `20px` to `60px` — comfortably above the 44px minimum touch target while only using ~10% of chart width
- Position arrow icons at the edges with `8px` padding
- Reduce arrow icon font size from `24px` to `18px` to stay proportional
- Consolidate `.chart-nav-left` / `.chart-nav-right` rules near the base rule

### Filter selection highlight (#65)
- Change `.filter-tag-indicator` from `inline-flex` to `flex` so the colored background spans the full cell width, matching the hover highlight style
- Fixes the visual mismatch where hover highlighted the full row but filter selection only highlighted the text

Fixes #63, Fixes #65

## Testing Done
- Verified nav zones render at correct width
- Verified filter tag background spans full cell width, consistent with hover
- Lint passes (no new errors)

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)