### PR TITLE
fix: use time-based exclusion for anomaly detection

### DIFF
--- a/js/step-detection-multi.test.js
+++ b/js/step-detection-multi.test.js
@@ -50,4 +50,33 @@ describe('detectSteps', () => {
       }
     }
   });
+
+  it('respects custom endMargin via options', () => {
+    // 15 points with a spike at the very end (index 13-14)
+    const data = [];
+    for (let i = 0; i < 15; i += 1) {
+      data.push({ ok: 100, client: 10, server: 1 });
+    }
+    // Spike at indices 13-14: excluded by default endMargin=2 (valid range 2-12)
+    data[13] = { ok: 100, client: 80, server: 20 };
+    data[14] = { ok: 100, client: 70, server: 15 };
+    const series = toSeries(data);
+
+    // Default endMargin=2 excludes indices 13-14
+    const resultsDefault = detectSteps(series, 5);
+    const defaultHitsSpike = resultsDefault.some(
+      (r) => r.endIndex >= 13,
+    );
+    assert.ok(
+      !defaultHitsSpike,
+      'Default endMargin should exclude last 2 points',
+    );
+
+    // endMargin=0 should include the spike
+    const resultsNoMargin = detectSteps(series, 5, { endMargin: 0 });
+    const noMarginHitsSpike = resultsNoMargin.some(
+      (r) => r.endIndex >= 13,
+    );
+    assert.ok(noMarginHitsSpike, 'endMargin=0 should include last points');
+  });
 });


### PR DESCRIPTION
## Summary
- Anomaly detection previously excluded a fixed number of trailing data points (`endMargin=2`) to avoid false positives from incomplete ingestion data. This was unreliable because bucket duration varies with the selected time range (e.g., 2 periods = 2 minutes for 1-hour views but 30 minutes for 24-hour views).
- Now computes the end margin based on actual timestamps vs `Date.now()`, excluding data points within the last 3 minutes regardless of bucket size.
- `detectStep`/`detectSteps` accept an `options.endMargin` parameter, allowing callers to provide a time-based margin instead of relying on the fixed default.

## Testing Done
- Added unit tests for custom `endMargin` option in both `detectStep` and `detectSteps`
- All 285 existing tests pass
- Lint passes (also fixed pre-existing max-lines issue in chart.js by condensing anomaly rendering code)

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)