### PR TITLE
Add CODEOWNERS file for code review assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# CODEOWNERS for klickhaus - ClickHouse CDN Analytics Dashboard
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @trieloff
+
+# JavaScript application code
+/js/ @trieloff
+
+# SQL queries and database schema
+/sql/ @trieloff
+
+# User management scripts
+/scripts/ @trieloff
+
+# GitHub Actions workflows
+/.github/workflows/ @trieloff
+
+# Dashboard HTML and CSS
+*.html @trieloff
+*.css @trieloff
+/css/ @trieloff
+
+# Configuration files
+eslint.config.js @trieloff
+package.json @trieloff
+manifest.json @trieloff


### PR DESCRIPTION
## Summary

This PR adds a CODEOWNERS file to enable automatic reviewer assignment on pull requests.

## Changes

- Added `.github/CODEOWNERS` with meaningful ownership patterns:
  - Default owner (`@trieloff`) for all repository files
  - Specific ownership for JavaScript code (`/js/`)
  - Specific ownership for SQL queries and schemas (`/sql/`)
  - Specific ownership for user management scripts (`/scripts/`)
  - Specific ownership for GitHub Actions workflows (`/.github/workflows/`)
  - Specific ownership for dashboard HTML/CSS files
  - Specific ownership for configuration files

## Why

This improves the repository's readiness for autonomous AI agents and collaborative development by:
- Ensuring all PRs have designated reviewers
- Clearly defining code ownership for different parts of the codebase
- Enabling GitHub's required reviews feature based on ownership

## Testing

The CODEOWNERS file uses valid GitHub syntax with documented patterns.