### PR TITLE
feat: display start and end times during chart time selection

### DIFF
--- a/css/chart.css
+++ b/css/chart.css
@@ -147,6 +147,28 @@
   font-size: 10px;
 }
 
+.scrubber-selection-arrow {
+  font-size: 10px;
+  color: var(--text-secondary);
+  opacity: 0.6;
+}
+
+.scrubber-selection-duration {
+  font-size: 10px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: rgba(59, 130, 246, 0.1);
+  color: rgba(59, 130, 246, 0.9);
+}
+
+@media (prefers-color-scheme: dark) {
+  .scrubber-selection-duration {
+    background: rgba(96, 165, 250, 0.15);
+    color: rgba(96, 165, 250, 0.9);
+  }
+}
+
 .scrubber-anomaly {
   font-weight: 500;
   padding: 2px 8px;

--- a/js/chart-state.js
+++ b/js/chart-state.js
@@ -300,6 +300,48 @@ export function getTimeAtX(x) {
 }
 
 /**
+ * Get x position on chart for a given time (inverse of getTimeAtX)
+ * @param {Date|number} time - Time as Date or milliseconds
+ * @returns {number} X coordinate
+ */
+export function getXAtTime(time) {
+  if (!chartLayout) return 0;
+  const {
+    padding, chartWidth, intendedStartTime, intendedEndTime,
+  } = chartLayout;
+  const timeMs = time instanceof Date ? time.getTime() : time;
+  const ratio = (timeMs - intendedStartTime) / (intendedEndTime - intendedStartTime);
+  return padding.left + ratio * chartWidth;
+}
+
+/**
+ * Calculate status bar inner element left position with edge easing.
+ * @param {number} x - Target center X coordinate
+ * @param {number} statusWidth - Status bar width
+ * @param {number} innerWidth - Inner content width
+ * @param {number} chartWidth - Full chart width
+ * @param {number} pad - CSS padding (default 24)
+ * @returns {number} Left margin value
+ */
+export function calcStatusBarLeft(x, statusWidth, innerWidth, chartWidth, pad = 24) {
+  const targetLeft = x - innerWidth / 2;
+  const minLeft = pad;
+  const maxLeft = statusWidth - innerWidth - pad;
+  const edgeZone = innerWidth / 2 + pad;
+  let finalLeft;
+  if (x < edgeZone) {
+    const t = x / edgeZone;
+    finalLeft = minLeft + (targetLeft - minLeft) * t;
+  } else if (x > chartWidth - edgeZone) {
+    const t = (chartWidth - x) / edgeZone;
+    finalLeft = maxLeft + (targetLeft - maxLeft) * t;
+  } else {
+    finalLeft = targetLeft;
+  }
+  return Math.max(minLeft, Math.min(maxLeft, finalLeft));
+}
+
+/**
  * Format time for scrubber display
  * @param {Date} time - Time to format
  * @returns {Object} Formatted time { timeStr, relativeStr }


### PR DESCRIPTION
## Summary
- Shows exact time range (start → end + duration) in the scrubber status bar while dragging a selection and after confirming it
- Refactors status bar positioning logic into reusable `calcStatusBarLeft` and adds `getXAtTime` utility
- Adds CSS styles for selection arrow and duration badge with dark mode support

Fixes #64

## Testing Done
- `npm test` — 285 tests pass
- `npm run lint` — no new lint issues (pre-existing warnings/errors in unrelated files)

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)