### PR TITLE
fix: include sql/ directory in production deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,7 +27,7 @@ jobs:
           echo "${{ secrets.GCP_SA_KEY_B64 }}" | base64 -d > /tmp/gcp-key.json
           gcloud auth activate-service-account --key-file=/tmp/gcp-key.json
           gsutil -m rsync -r -d \
-            -x 'node_modules/|\.git/|\.github/|debug/|hars/|scripts/|sql/|\.claude/|\.yolo/|.*\.local\.md|\.env.*|package-lock\.json|screenshot\.png|.*\.test\.js|eslint\.config\.js|knip\.json|\.jscpd\.json|\.releaserc\.json|renovate\.json|\.gitignore|AGENTS\.md|VIEW_MIGRATION\.md|CLAUDE\.md|README\.md' \
+            -x 'node_modules/|\.git/|\.github/|debug/|hars/|scripts/|\.claude/|\.yolo/|.*\.local\.md|\.env.*|package-lock\.json|screenshot\.png|.*\.test\.js|eslint\.config\.js|knip\.json|\.jscpd\.json|\.releaserc\.json|renovate\.json|\.gitignore|AGENTS\.md|VIEW_MIGRATION\.md|CLAUDE\.md|README\.md' \
             . gs://klickhaus-static
           rm /tmp/gcp-key.json
 

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,5 @@
+{
+  "mimeTypes": {
+    ".sql": "text/plain"
+  }
+}


### PR DESCRIPTION
## Summary
- SQL query templates (`sql/queries/*.sql`) were excluded from the GCS production deployment, causing 404 errors on `klickhaus.aemstatus.net` when the dashboard fetched them at runtime via `js/sql-loader.js`
- Preview deployments worked because they didn't exclude `sql/`
- Removed `sql/` from the GCS rsync `-x` exclusion pattern
- Added `staticwebapp.config.json` with `.sql` MIME type mapping for the Azure backup deployment (`maisonclic.aemstatus.net`)

## Testing Done
- Verified `curl` to `https://klickhaus.aemstatus.net/sql/queries/breakdown.sql` returns 404 (confirming the issue)
- Confirmed SQL files exist in repo and are needed at runtime by `js/sql-loader.js`

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)