### PR TITLE
feat: add optel collection

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CDN Analytics</title>
+  <script>
+    window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
+  </script>
+  <script defer type="text/javascript" src="https://ot.aem.live/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
   <link rel="canonical" href="https://klickhaus.aemstatus.net/dashboard.html">
 
   <!-- Favicon Icons -->

--- a/delivery.html
+++ b/delivery.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Delivery Dashboard - CDN Analytics</title>
+  <script>
+    window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
+  </script>
+  <script defer type="text/javascript" src="https://ot.aem.live/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
   <link rel="canonical" href="https://klickhaus.aemstatus.net/delivery.html">
 
   <!-- Favicon Icons -->

--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CDN Analytics - Quick Links</title>
+  <script>
+    window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
+  </script>
+  <script defer type="text/javascript" src="https://ot.aem.live/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
   <link rel="canonical" href="https://klickhaus.aemstatus.net/">
 
   <!-- Favicon Icons -->


### PR DESCRIPTION
## Summary
Add OpTel collection with a weight of 10 to all 3 html pages in repo to address #76.

## Testing Done
Local testing against 127.0.0.1 worked and showed the correct weight with the following checkpoints collected: top, language, reload, cwv, a11y

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)
