### PR TITLE
Simplify facet filter toggle UX

### DIFF
--- a/css/facets.css
+++ b/css/facets.css
@@ -550,17 +550,17 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   /* Ensure tap targets are large enough on mobile */
   .breakdown-table .dim.dim-clickable {
     min-height: 44px;
-    position: relative;
-    padding-right: 68px;
+    display: flex;
+    align-items: center;
   }
 
-  .breakdown-table .mobile-actions {
+  .breakdown-table tr.touch-active .filter-tag-indicator {
+    display: none;
+  }
+
+  .breakdown-table tr.touch-active .mobile-actions {
     display: inline-flex;
     gap: 6px;
-    position: absolute;
-    right: 6px;
-    top: 50%;
-    transform: translateY(-50%);
   }
 
   .breakdown-table .mobile-action-btn {
@@ -572,6 +572,16 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
     background: var(--bg);
     color: var(--text-secondary);
     cursor: pointer;
+  }
+
+  .breakdown-table .mobile-action-btn.filter-btn {
+    border-color: var(--primary);
+    color: var(--primary);
+  }
+
+  .breakdown-table .mobile-action-btn.filter-btn.active {
+    background: var(--primary);
+    color: white;
   }
 
   .breakdown-table .mobile-action-btn.exclude-btn {

--- a/css/facets.css
+++ b/css/facets.css
@@ -433,10 +433,21 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   border-radius: 1px;
 }
 
-/* Active/exclude states: colored background, white text, show icon, hide color bar */
+/* Active/exclude states: colored background, contrasting text, show icon, hide color bar */
 .breakdown-table .filter-tag-indicator.active,
 .breakdown-table .filter-tag-indicator.exclude {
   color: white;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+/* Ensure text contrast in dark mode with light backgrounds */
+@media (prefers-color-scheme: dark) {
+  .breakdown-table .filter-tag-indicator.active,
+  .breakdown-table .filter-tag-indicator.exclude {
+    /* Add a darker overlay to ensure contrast */
+    background-blend-mode: multiply;
+    box-shadow: inset 0 0 0 1000px rgba(0, 0, 0, 0.4);
+  }
 }
 
 .breakdown-table .filter-tag-indicator.active .filter-icon,

--- a/css/facets.css
+++ b/css/facets.css
@@ -559,39 +559,34 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
   }
 
   .breakdown-table tr.touch-active .mobile-actions {
-    display: inline-flex;
-    gap: 6px;
+    display: flex;
+    gap: 8px;
+    width: 100%;
   }
 
   .breakdown-table .mobile-action-btn {
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    padding: 2px 6px;
-    font-size: 10px;
-    line-height: 1;
-    background: var(--bg);
-    color: var(--text-secondary);
+    flex: 1;
+    border: none;
+    border-radius: 4px;
+    padding: 6px 8px;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1.2;
+    color: white;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
     cursor: pointer;
   }
 
   .breakdown-table .mobile-action-btn.filter-btn {
-    border-color: var(--primary);
-    color: var(--primary);
-  }
-
-  .breakdown-table .mobile-action-btn.filter-btn.active {
     background: var(--primary);
-    color: white;
   }
 
   .breakdown-table .mobile-action-btn.exclude-btn {
-    border-color: var(--error);
-    color: var(--error);
+    background: var(--error);
   }
 
-  .breakdown-table .mobile-action-btn.exclude-btn.active {
-    background: var(--error);
-    color: white;
+  .breakdown-table .mobile-action-btn:active {
+    transform: translateY(1px);
   }
 }
 

--- a/css/facets.css
+++ b/css/facets.css
@@ -566,23 +566,27 @@ body[data-topn="100"] .breakdown-card:not(.facet-hidden) { min-height: 2164px; }
 
   .breakdown-table .mobile-action-btn {
     flex: 1;
-    border: none;
+    border: 1px solid var(--filter-tag-border);
     border-radius: 4px;
     padding: 6px 8px;
     font-size: 11px;
     font-weight: 600;
     line-height: 1.2;
-    color: white;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+    background: var(--filter-tag-bg);
+    color: var(--filter-tag-color);
     cursor: pointer;
   }
 
   .breakdown-table .mobile-action-btn.filter-btn {
-    background: var(--primary);
+    background: var(--filter-tag-bg);
+    border-color: var(--filter-tag-border);
+    color: var(--filter-tag-color);
   }
 
   .breakdown-table .mobile-action-btn.exclude-btn {
-    background: var(--error);
+    background: var(--bar-bg);
+    border-color: var(--error);
+    color: var(--error);
   }
 
   .breakdown-table .mobile-action-btn:active {

--- a/dashboard.html
+++ b/dashboard.html
@@ -230,7 +230,7 @@
         <div class="key-desc">Next value (wraps to next facet)</div>
 
         <div class="key-group"><kbd>i</kbd> <kbd>c</kbd> <kbd>Space</kbd></div>
-        <div class="key-desc">Toggle filter on value</div>
+        <div class="key-desc">Toggle filter on value (Shift+click for exclude)</div>
 
         <div class="key-group"><kbd>e</kbd> <kbd>x</kbd></div>
         <div class="key-desc">Toggle exclude on value</div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -230,7 +230,7 @@
         <div class="key-desc">Next value (wraps to next facet)</div>
 
         <div class="key-group"><kbd>i</kbd> <kbd>c</kbd> <kbd>Space</kbd></div>
-        <div class="key-desc">Toggle filter on value (Shift+click for exclude, or tap Exclude on touch)</div>
+        <div class="key-desc">Toggle filter on value (Shift+click for exclude; tap value to reveal Filter/Exclude on touch)</div>
 
         <div class="key-group"><kbd>e</kbd> <kbd>x</kbd></div>
         <div class="key-desc">Toggle exclude on value</div>

--- a/delivery.html
+++ b/delivery.html
@@ -230,7 +230,7 @@
         <div class="key-desc">Next value (wraps to next facet)</div>
 
         <div class="key-group"><kbd>i</kbd> <kbd>c</kbd> <kbd>Space</kbd></div>
-        <div class="key-desc">Toggle filter on value</div>
+        <div class="key-desc">Toggle filter on value (Shift+click for exclude)</div>
 
         <div class="key-group"><kbd>e</kbd> <kbd>x</kbd></div>
         <div class="key-desc">Toggle exclude on value</div>

--- a/delivery.html
+++ b/delivery.html
@@ -230,7 +230,7 @@
         <div class="key-desc">Next value (wraps to next facet)</div>
 
         <div class="key-group"><kbd>i</kbd> <kbd>c</kbd> <kbd>Space</kbd></div>
-        <div class="key-desc">Toggle filter on value (Shift+click for exclude, or tap Exclude on touch)</div>
+        <div class="key-desc">Toggle filter on value (Shift+click for exclude; tap value to reveal Filter/Exclude on touch)</div>
 
         <div class="key-group"><kbd>e</kbd> <kbd>x</kbd></div>
         <div class="key-desc">Toggle exclude on value</div>

--- a/js/templates/breakdown-table.js
+++ b/js/templates/breakdown-table.js
@@ -164,7 +164,7 @@ export function buildBreakdownRow({
   const filterTag = '<span class="filter-tag-indicator'
     + `${stateClass}"${tagStyle}>${indicatorSlot}${textHtml}</span>`;
 
-  // Cycle filter state: none -> include -> exclude -> none
+  // Toggle filter state: click to add/remove, Shift+click for exclude
   const dimAction = (isIncluded || isExcluded)
     ? 'remove-filter-value' : 'add-filter';
   const dimExclude = isExcluded ? 'true' : 'false';

--- a/js/templates/breakdown-table.js
+++ b/js/templates/breakdown-table.js
@@ -167,6 +167,24 @@ function buildFilterAttrs(col, rowDim, filterCol, filterValueFn, filterOp) {
   ].join(' ');
 }
 
+function buildMobileActions(isIncluded, isExcluded, filterAttrs) {
+  const filterAction = isIncluded ? 'remove-filter-value' : 'add-filter';
+  const filterLabel = isIncluded ? 'Clear' : 'Filter';
+  const filterAriaLabel = isIncluded ? 'Clear filter' : 'Filter value';
+  const filterButtonClass = `mobile-action-btn filter-btn${isIncluded ? ' active' : ''}`;
+  const excludeAction = isExcluded ? 'remove-filter-value' : 'add-filter';
+  const excludeLabel = isExcluded ? 'Clear' : 'Exclude';
+  const excludeAriaLabel = isExcluded ? 'Clear exclude filter' : 'Exclude value';
+  const excludeButtonClass = `mobile-action-btn exclude-btn${isExcluded ? ' active' : ''}`;
+
+  return `
+        <span class="mobile-actions">
+          <button class="${filterButtonClass}" type="button" data-action="${filterAction}" ${filterAttrs} data-exclude="false" aria-label="${escapeHtml(filterAriaLabel)}">${filterLabel}</button>
+          <button class="${excludeButtonClass}" type="button" data-action="${excludeAction}" ${filterAttrs} data-exclude="true" aria-label="${escapeHtml(excludeAriaLabel)}">${excludeLabel}</button>
+        </span>
+      `;
+}
+
 export function buildBreakdownRow({
   row, col, maxCount, columnFilters, valueFormatter,
   linkPrefix, linkSuffix, linkFn, dimPrefixes, dimFormatFn,
@@ -204,15 +222,7 @@ export function buildBreakdownRow({
   const bgAttr = escapeHtml(bgColor || 'var(--text)');
   const ariaSelected = (isIncluded || isExcluded) ? 'true' : 'false';
   const dimExclude = isExcluded ? 'true' : 'false';
-  const excludeAction = isExcluded ? 'remove-filter-value' : 'add-filter';
-  const excludeLabel = isExcluded ? 'Clear' : 'Exclude';
-  const excludeAriaLabel = isExcluded ? 'Clear exclude filter' : 'Exclude value';
-  const excludeButtonClass = `mobile-action-btn exclude-btn${isExcluded ? ' active' : ''}`;
-  const mobileActions = `
-        <span class="mobile-actions">
-          <button class="${excludeButtonClass}" type="button" data-action="${excludeAction}" ${filterAttrs} data-exclude="true" aria-label="${escapeHtml(excludeAriaLabel)}">${excludeLabel}</button>
-        </span>
-      `;
+  const mobileActions = buildMobileActions(isIncluded, isExcluded, filterAttrs);
 
   return `
     <tr class="${rowClass}" tabindex="0" role="option" aria-selected="${ariaSelected}" data-value-index="${rowIndex}" data-dim="${dimDataAttr}">

--- a/js/ui/actions.js
+++ b/js/ui/actions.js
@@ -54,8 +54,8 @@ export function initActionHandlers(handlers) {
       }
       case 'add-filter': {
         event.stopPropagation();
-        // Shift+click skips straight to exclude
-        const exclude = event.shiftKey || target.dataset.exclude === 'true';
+        // Shift+click adds as exclude filter, regular click adds as include filter
+        const exclude = event.shiftKey;
         handlers.addFilter?.(
           target.dataset.col || '',
           target.dataset.value || '',
@@ -79,23 +79,8 @@ export function initActionHandlers(handlers) {
         const col = target.dataset.col || '';
         const value = target.dataset.value || '';
 
-        // Cycle: include → exclude → none
-        const existingFilter = handlers.getFilterForValue?.(col, value);
-        if (existingFilter && !existingFilter.exclude) {
-          // Include → Exclude: remove then add as exclude in a single reload
-          handlers.removeFilterByValue?.(col, value, true);
-          handlers.addFilter?.(
-            col,
-            value,
-            true,
-            target.dataset.filterCol,
-            target.dataset.filterValue,
-            target.dataset.filterOp,
-          );
-        } else {
-          // Exclude → None (or fallback)
-          handlers.removeFilterByValue?.(col, value);
-        }
+        // Simple toggle: remove the filter (whether include or exclude)
+        handlers.removeFilterByValue?.(col, value);
         break;
       }
       case 'clear-facet': {

--- a/js/ui/mobile.js
+++ b/js/ui/mobile.js
@@ -39,9 +39,7 @@ export function initMobileTouchSupport() {
   if (!('ontouchstart' in window)) return;
 
   document.addEventListener('click', (e) => {
-    const row = e.target.closest('.breakdown-table tr:not(.other-row)');
     const isActionBtn = e.target.closest('.mobile-action-btn');
-
     if (isActionBtn) {
       setTimeout(() => {
         document.querySelectorAll('.breakdown-table tr.touch-active').forEach((r) => {
@@ -51,7 +49,10 @@ export function initMobileTouchSupport() {
       return;
     }
 
-    if (row) {
+    const row = e.target.closest('.breakdown-table tr:not(.other-row)');
+    const dimCell = e.target.closest('.breakdown-table td.dim.dim-clickable');
+
+    if (row && dimCell) {
       const wasActive = row.classList.contains('touch-active');
       document.querySelectorAll('.breakdown-table tr.touch-active').forEach((r) => {
         r.classList.remove('touch-active');
@@ -59,13 +60,15 @@ export function initMobileTouchSupport() {
       if (!wasActive) {
         row.classList.add('touch-active');
       }
+      e.preventDefault();
+      e.stopPropagation();
       return;
     }
 
     document.querySelectorAll('.breakdown-table tr.touch-active').forEach((r) => {
       r.classList.remove('touch-active');
     });
-  });
+  }, true);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "klickhaus",
       "version": "1.0.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "puppeteer-core": "24.36.1"
-      },
       "devDependencies": {
         "@adobe/eslint-config-helix": "^3.0.16",
         "@playwright/cli": "^0.0.63",
@@ -22,7 +19,8 @@
         "jscpd": "^4.0.5",
         "knip": "^5.82.1",
         "lint-staged": "^16.2.7",
-        "live-server": "^1.2.2"
+        "live-server": "^1.2.2",
+        "puppeteer-core": "24.36.1"
       }
     },
     "node_modules/@adobe/eslint-config-helix": {
@@ -828,6 +826,7 @@
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.2.tgz",
       "integrity": "sha512-GBY0+2lI9fDrjgb5dFL9+enKXqyOPok9PXg/69NVkjW3bikbK9RQrNrI3qccQXmDNN7ln4j/yL89Qgvj/tfqrw==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
@@ -848,6 +847,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -859,6 +859,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
       "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "dev": true,
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -872,6 +873,7 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
       "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -1285,7 +1287,8 @@
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -1509,7 +1512,7 @@
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
       "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
-      "devOptional": true,
+      "dev": true,
       "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1584,6 +1587,7 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -2201,6 +2205,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -2241,6 +2246,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2249,6 +2255,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2505,6 +2512,7 @@
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -2581,6 +2589,7 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
       "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -2618,6 +2627,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2631,6 +2641,7 @@
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.3.tgz",
       "integrity": "sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -2655,6 +2666,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
       "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "dev": true,
       "optional": true,
       "engines": {
         "bare": ">=1.14.0"
@@ -2664,6 +2676,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
@@ -2673,6 +2686,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
       "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "streamx": "^2.21.0"
@@ -2694,6 +2708,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
       "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -2765,6 +2780,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
       "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -2898,6 +2914,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -3188,6 +3205,7 @@
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.0.1.tgz",
       "integrity": "sha512-c+RLxH0Vg2x2syS9wPw378oJgiJNXtYXUvnVAldUlt5uaHekn0CCU7gPksNgHjrH1qFhmjVXQj4esvuthuC7OQ==",
+      "dev": true,
       "dependencies": {
         "mitt": "^3.0.1",
         "zod": "^3.24.1"
@@ -3334,6 +3352,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -3398,6 +3417,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3408,7 +3428,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -3657,6 +3678,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -3723,6 +3745,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3912,6 +3935,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -3971,6 +3995,7 @@
       "version": "0.0.1551306",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
       "integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
+      "dev": true,
       "peer": true
     },
     "node_modules/diff": {
@@ -4043,7 +4068,8 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -4058,6 +4084,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -4235,6 +4262,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4261,6 +4289,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -4498,6 +4527,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -4534,6 +4564,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -4549,6 +4580,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4587,6 +4619,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
       "dependencies": {
         "bare-events": "^2.7.0"
       }
@@ -4728,6 +4761,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -4752,7 +4786,8 @@
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -4898,6 +4933,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -5175,6 +5211,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -5233,6 +5270,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -5264,6 +5302,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
       "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -5604,6 +5643,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -5616,6 +5656,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -5775,6 +5816,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
       "engines": {
         "node": ">= 12"
       }
@@ -6056,6 +6098,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7226,6 +7269,7 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -7481,7 +7525,8 @@
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
@@ -7561,7 +7606,8 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/nan": {
       "version": "2.25.0",
@@ -7691,6 +7737,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -7947,6 +7994,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8154,6 +8202,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -8172,6 +8221,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -8278,7 +8328,8 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8435,6 +8486,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -8452,6 +8504,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -8469,7 +8522,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/proxy-middleware": {
       "version": "0.15.0",
@@ -8608,6 +8662,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -8626,6 +8681,7 @@
       "version": "24.36.1",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.36.1.tgz",
       "integrity": "sha512-L7ykMWc3lQf3HS7ME3PSjp7wMIjJeW6+bKfH/RSTz5l6VUDGubnrC2BKj3UvM28Y5PMDFW0xniJOZHBZPpW1dQ==",
+      "dev": true,
       "dependencies": {
         "@puppeteer/browsers": "2.11.2",
         "chromium-bidi": "13.0.1",
@@ -8867,6 +8923,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9622,6 +9679,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -9749,6 +9807,7 @@
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -9762,6 +9821,7 @@
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -9775,6 +9835,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9929,6 +9990,7 @@
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
       "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dev": true,
       "dependencies": {
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
@@ -9958,6 +10020,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10027,6 +10090,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10158,6 +10222,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
       "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
       "dependencies": {
         "b4a": "^1.6.4"
       }
@@ -10276,7 +10341,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -10439,7 +10505,8 @@
     "node_modules/typed-query-selector": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "dev": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -10487,7 +10554,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/union-value": {
       "version": "1.0.1",
@@ -10681,7 +10748,8 @@
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
-      "integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA=="
+      "integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -10874,6 +10942,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -10889,12 +10958,14 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10915,6 +10986,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -10939,6 +11011,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -10956,6 +11029,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -10964,6 +11038,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -10995,6 +11070,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "jscpd": "^4.0.5",
     "knip": "^5.82.1",
     "lint-staged": "^16.2.7",
-    "live-server": "^1.2.2"
+    "live-server": "^1.2.2",
+    "puppeteer-core": "24.36.1"
   },
   "keywords": [
     "clickhouse",
@@ -36,8 +37,5 @@
     "*.{js,mjs}": [
       "eslint --fix"
     ]
-  },
-  "dependencies": {
-    "puppeteer-core": "24.36.1"
   }
 }


### PR DESCRIPTION
## Summary
- Replace 3-state rotation (None → Include → Exclude → None) with simpler 2-state toggle (None ↔ Include)
- Preserve Shift+click for exclude filters when needed
- Update keyboard help documentation to mention Shift+click

## Motivation

The exclude filter state is rarely used, so cycling through it on every click added unnecessary complexity to the common workflow. Users could accidentally cycle into exclude mode when they just wanted to clear a filter.

## Changes

### Behavior Changes

**Before:**
- Click: None → Include
- Click again: Include → Exclude  
- Click again: Exclude → None

**After:**
- Click: None ↔ Include (simple toggle)
- Shift+Click: None ↔ Exclude (preserved existing shortcut)

### Code Changes

- **`js/ui/actions.js`**: Simplified `remove-filter-value` action from 3-state cycle to simple removal
- **`js/templates/breakdown-table.js`**: Updated comment to reflect new toggle behavior
- **`dashboard.html` & `delivery.html`**: Updated keyboard help to document Shift+click

## Benefits

1. **Simpler common case**: One click to filter, one click to clear (no cycling)
2. **Fewer accidental excludes**: Can't accidentally cycle into exclude state
3. **Preserved functionality**: Shift+click still works for exclude (existing feature)
4. **Better documentation**: Now explicitly mentioned in keyboard help dialog

## Testing Done

- [x] Syntax validation passed
- [ ] Manual testing needed:
  - Click on facet value filters to that value
  - Click again clears the filter
  - Shift+click excludes that value
  - Shift+click again clears the exclude
  - Keyboard shortcuts (i/c/Space, e/x) still work

## Checklist

- [x] Code follows naming conventions
- [x] Comments updated to reflect behavior
- [x] Documentation updated (keyboard help)
- [ ] Manual testing in browser