### PR TITLE
Refactor: reduce cyclomatic complexity

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -83,6 +83,15 @@ export default [
       ...recommended.rules,
       ...namingConventionRules,
       'max-lines': ['error', { max: 1000 }],
+      'max-len': ['error', 100, 2, {
+        ignoreUrls: true,
+        ignoreComments: false,
+        ignoreRegExpLiterals: true,
+        ignoreStrings: true,
+        ignoreTemplateLiterals: true,
+        ignorePattern: '^(async\\s+)?function\\s+\\w+\\(',
+      }],
+      'complexity': ['error', { max: 15 }],
       // Tech debt tracking: warn on TODO/FIXME comments
       // Use TODO(ISSUE-123) format to link to tracking issues
       'no-warning-comments': ['warn', {

--- a/js/anomaly-investigation.js
+++ b/js/anomaly-investigation.js
@@ -210,16 +210,19 @@ function addResultToHighlightMap(highlightMap, result, checkExisting) {
 function applyHighlightMapToDOM(highlightMap) {
   for (const [facetId, dimInfoMap] of highlightMap) {
     const card = document.getElementById(facetId);
-    if (!card) continue;
-    const rows = card.querySelectorAll('.breakdown-table tr');
-    if (rows.length === 0) continue;
-    for (const [expectedDim, info] of dimInfoMap) {
-      const row = findRowByDim(rows, expectedDim);
-      if (!row) continue;
-      row.classList.add('investigation-highlight', `investigation-${info.category}`);
-      const statusColor = row.querySelector('.status-color');
-      if (statusColor) {
-        statusColor.title = `+${info.shareChange}pp share of #${info.rank} ${info.anomalyId}`;
+    if (card) {
+      const rows = card.querySelectorAll('.breakdown-table tr');
+      if (rows.length > 0) {
+        for (const [expectedDim, info] of dimInfoMap) {
+          const row = findRowByDim(rows, expectedDim);
+          if (row) {
+            row.classList.add('investigation-highlight', `investigation-${info.category}`);
+            const statusColor = row.querySelector('.status-color');
+            if (statusColor) {
+              statusColor.title = `+${info.shareChange}pp share of #${info.rank} ${info.anomalyId}`;
+            }
+          }
+        }
       }
     }
   }
@@ -278,9 +281,10 @@ function updateProgressiveHighlights() {
  * @returns {Array|null} Cached results if valid and sufficient, null otherwise
  */
 function tryMemoryCache(cacheKey) {
-  if (cacheKey !== currentCacheKey || lastInvestigationResults.length === 0 || !currentCacheContext) {
-    return null;
-  }
+  const hasValidCache = cacheKey === currentCacheKey
+    && lastInvestigationResults.length > 0
+    && currentCacheContext;
+  if (!hasValidCache) return null;
   if (!isCacheEligible(currentCacheContext)) {
     // eslint-disable-next-line no-console
     console.log('Memory cache key matches but context changed, checking localStorage');

--- a/js/anomaly-investigation.js
+++ b/js/anomaly-investigation.js
@@ -168,10 +168,9 @@ function applyHighlightsFromContributors(contributors) {
 }
 
 /**
- * Apply visual highlights to all facet values
+ * Clear all investigation highlight classes from elements
  */
-function applyHighlights() {
-  // Remove existing highlights and reset titles
+function clearAllHighlightClasses() {
   document.querySelectorAll('.investigation-highlight').forEach((el) => {
     el.classList.remove(
       'investigation-highlight',
@@ -183,79 +182,68 @@ function applyHighlights() {
     const statusColor = el.querySelector('.status-color');
     if (statusColor) statusColor.removeAttribute('title');
   });
+}
 
-  const focusedId = getFocusedAnomalyId();
-
-  // Build a map of facetId -> dim -> { category, shareChange, anomalyId, rank }
-  const highlightMap = new Map();
-
-  // If we have a focused anomaly ID, try to get its results from the persistent map
-  if (focusedId) {
-    const persistedResult = investigationsByAnomalyId.get(focusedId);
-    if (persistedResult) {
-      const category = persistedResult.anomaly?.category || 'red';
-      const { anomalyId } = persistedResult;
-      const rank = persistedResult.anomaly?.rank || 1;
-      for (const [facetId, facetResults] of Object.entries(persistedResult.facets)) {
-        if (!highlightMap.has(facetId)) {
-          highlightMap.set(facetId, new Map());
-        }
-        for (const item of facetResults) {
-          highlightMap.get(facetId).set(item.dim, {
-            category,
-            shareChange: item.shareChange,
-            anomalyId,
-            rank,
-          });
-        }
-      }
-    }
-  } else {
-    // No specific focus - highlight from all current results (use highest share change per dim)
-    for (const result of lastInvestigationResults) {
-      const category = result.anomaly?.category || 'red';
-      const { anomalyId } = result;
-      const rank = result.anomaly?.rank || 1;
-      for (const [facetId, facetResults] of Object.entries(result.facets)) {
-        if (!highlightMap.has(facetId)) {
-          highlightMap.set(facetId, new Map());
-        }
-        for (const item of facetResults) {
-          const existing = highlightMap.get(facetId).get(item.dim);
-          // Keep the one with higher share change
-          if (!existing || item.shareChange > existing.shareChange) {
-            highlightMap.get(facetId).set(item.dim, {
-              category,
-              shareChange: item.shareChange,
-              anomalyId,
-              rank,
-            });
-          }
-        }
+/**
+ * Add facet results to highlight map
+ */
+function addResultToHighlightMap(highlightMap, result, checkExisting) {
+  const category = result.anomaly?.category || 'red';
+  const { anomalyId } = result;
+  const rank = result.anomaly?.rank || 1;
+  for (const [facetId, facetResults] of Object.entries(result.facets)) {
+    if (!highlightMap.has(facetId)) highlightMap.set(facetId, new Map());
+    for (const item of facetResults) {
+      const existing = highlightMap.get(facetId).get(item.dim);
+      if (!checkExisting || !existing || item.shareChange > existing.shareChange) {
+        highlightMap.get(facetId).set(item.dim, {
+          category, shareChange: item.shareChange, anomalyId, rank,
+        });
       }
     }
   }
+}
 
-  // Apply highlights to matching rows
+/**
+ * Apply highlight map to DOM elements
+ */
+function applyHighlightMapToDOM(highlightMap) {
   for (const [facetId, dimInfoMap] of highlightMap) {
     const card = document.getElementById(facetId);
-    if (card) {
-      const rows = card.querySelectorAll('.breakdown-table tr');
-      if (rows.length > 0) {
-        for (const [expectedDim, info] of dimInfoMap) {
-          const row = findRowByDim(rows, expectedDim);
-          if (row) {
-            row.classList.add('investigation-highlight', `investigation-${info.category}`);
-            const statusColor = row.querySelector('.status-color');
-            if (statusColor) {
-              const title = `+${info.shareChange}pp share of #${info.rank} ${info.anomalyId}`;
-              statusColor.title = title;
-            }
-          }
-        }
+    if (!card) continue;
+    const rows = card.querySelectorAll('.breakdown-table tr');
+    if (rows.length === 0) continue;
+    for (const [expectedDim, info] of dimInfoMap) {
+      const row = findRowByDim(rows, expectedDim);
+      if (!row) continue;
+      row.classList.add('investigation-highlight', `investigation-${info.category}`);
+      const statusColor = row.querySelector('.status-color');
+      if (statusColor) {
+        statusColor.title = `+${info.shareChange}pp share of #${info.rank} ${info.anomalyId}`;
       }
     }
   }
+}
+
+/**
+ * Apply visual highlights to all facet values
+ */
+function applyHighlights() {
+  clearAllHighlightClasses();
+
+  const focusedId = getFocusedAnomalyId();
+  const highlightMap = new Map();
+
+  if (focusedId) {
+    const persistedResult = investigationsByAnomalyId.get(focusedId);
+    if (persistedResult) addResultToHighlightMap(highlightMap, persistedResult, false);
+  } else {
+    for (const result of lastInvestigationResults) {
+      addResultToHighlightMap(highlightMap, result, true);
+    }
+  }
+
+  applyHighlightMapToDOM(highlightMap);
 }
 
 /**
@@ -285,97 +273,105 @@ function updateProgressiveHighlights() {
  * @param {Array} anomalies - Array of detected anomalies from detectSteps()
  * @param {Array} chartData - Time series data points
  */
+/**
+ * Try to use memory cache for investigation results
+ * @returns {Array|null} Cached results if valid and sufficient, null otherwise
+ */
+function tryMemoryCache(cacheKey) {
+  if (cacheKey !== currentCacheKey || lastInvestigationResults.length === 0 || !currentCacheContext) {
+    return null;
+  }
+  if (!isCacheEligible(currentCacheContext)) {
+    // eslint-disable-next-line no-console
+    console.log('Memory cache key matches but context changed, checking localStorage');
+    return null;
+  }
+  // eslint-disable-next-line no-console
+  console.log('Memory cache eligible, applying highlights');
+  let highlightCount = 0;
+  if (cachedTopContributors && cachedTopContributors.length > 0) {
+    highlightCount = applyHighlightsFromContributors(cachedTopContributors);
+    // eslint-disable-next-line no-console
+    console.log(`Applied ${highlightCount}/${HIGHLIGHT_TOP_N} highlights from memory cache`);
+  } else {
+    applyHighlights();
+    highlightCount = HIGHLIGHT_TOP_N;
+  }
+  if (highlightCount >= HIGHLIGHT_TOP_N) {
+    // eslint-disable-next-line no-console
+    console.log('Memory cache sufficient');
+    return lastInvestigationResults;
+  }
+  // eslint-disable-next-line no-console
+  console.log(`Only ${highlightCount}/${HIGHLIGHT_TOP_N} highlighted from memory cache, fetching fresh`);
+  currentCacheKey = null;
+  currentCacheContext = null;
+  return null;
+}
+
+/**
+ * Try to use localStorage cache for investigation results
+ * @returns {Array|null} Cached results if valid and sufficient, null otherwise
+ */
+function tryLocalStorageCache(cacheKey) {
+  const cached = loadCachedInvestigation(cacheKey);
+  if (!cached || !cached.results) return null;
+
+  currentCacheKey = cacheKey;
+  currentCacheContext = cached.context || getQueryContext();
+  lastInvestigationResults = cached.results;
+
+  // Restore anomaly ID mappings
+  for (const result of lastInvestigationResults) {
+    if (result.anomalyId) {
+      investigationsByAnomalyId.set(result.anomalyId, result);
+      if (result.anomaly?.rank) storeAnomalyIdOnStep(result.anomaly.rank, result.anomalyId);
+    }
+  }
+
+  let highlightedFromCache = 0;
+  if (cached.topContributors && cached.topContributors.length > 0) {
+    cachedTopContributors = cached.topContributors;
+    highlightedFromCache = applyHighlightsFromContributors(cachedTopContributors);
+    // eslint-disable-next-line no-console
+    console.log(`Applied ${highlightedFromCache}/${HIGHLIGHT_TOP_N} highlights from localStorage cache`);
+  } else {
+    cachedTopContributors = null;
+    applyHighlights();
+    highlightedFromCache = HIGHLIGHT_TOP_N;
+    // eslint-disable-next-line no-console
+    console.log('Applied highlights from old cache format');
+  }
+
+  if (highlightedFromCache >= HIGHLIGHT_TOP_N) {
+    // eslint-disable-next-line no-console
+    console.log('LocalStorage cache sufficient');
+    return lastInvestigationResults;
+  }
+  // eslint-disable-next-line no-console
+  console.log(`Only ${highlightedFromCache}/${HIGHLIGHT_TOP_N} highlighted, fetching fresh candidates`);
+  currentCacheKey = null;
+  currentCacheContext = null;
+  return null;
+}
+
 export async function investigateAnomalies(anomalies, chartData) {
   if (!anomalies || anomalies.length === 0) {
     clearHighlights();
     return [];
   }
 
-  // Generate cache key for current context
   const cacheKey = generateCacheKey();
   // eslint-disable-next-line no-console
   console.log(`Investigation cache key: ${cacheKey} (${window.location.pathname}${window.location.search})`);
 
-  // Check if we have cached results for this context (memory cache)
-  // Must also verify context eligibility (drill-in allowed, drill-out not)
-  if (cacheKey === currentCacheKey && lastInvestigationResults.length > 0 && currentCacheContext) {
-    if (isCacheEligible(currentCacheContext)) {
-      // eslint-disable-next-line no-console
-      console.log('Memory cache eligible, applying highlights');
-      // Use cached contributors if available, otherwise fall back to applyHighlights
-      let highlightCount = 0;
-      if (cachedTopContributors && cachedTopContributors.length > 0) {
-        highlightCount = applyHighlightsFromContributors(cachedTopContributors);
-        // eslint-disable-next-line no-console
-        console.log(`Applied ${highlightCount}/${HIGHLIGHT_TOP_N} highlights from memory cache`);
-      } else {
-        applyHighlights();
-        highlightCount = HIGHLIGHT_TOP_N; // Assume enough for old format
-      }
-      // If enough highlights, return cached results
-      if (highlightCount >= HIGHLIGHT_TOP_N) {
-        // eslint-disable-next-line no-console
-        console.log('Memory cache sufficient');
-        return lastInvestigationResults;
-      }
-      // Not enough highlights visible after drill-down, need fresh investigation
-      // eslint-disable-next-line no-console
-      console.log(`Only ${highlightCount}/${HIGHLIGHT_TOP_N} highlighted from memory cache, fetching fresh candidates`);
-      currentCacheKey = null;
-      currentCacheContext = null;
-      // Fall through to fresh investigation
-    } else {
-      // eslint-disable-next-line no-console
-      console.log('Memory cache key matches but context changed, checking localStorage');
-    }
-  }
+  // Try memory cache first
+  const memCached = tryMemoryCache(cacheKey);
+  if (memCached) return memCached;
 
-  // Check localStorage cache - apply immediately if available
-  const cached = loadCachedInvestigation(cacheKey);
-  if (cached && cached.results) {
-    currentCacheKey = cacheKey;
-    currentCacheContext = cached.context || getQueryContext();
-    lastInvestigationResults = cached.results;
-    // Restore the anomaly ID mappings
-    for (const result of lastInvestigationResults) {
-      if (result.anomalyId) {
-        investigationsByAnomalyId.set(result.anomalyId, result);
-        if (result.anomaly?.rank) {
-          storeAnomalyIdOnStep(result.anomaly.rank, result.anomalyId);
-        }
-      }
-    }
-    // Store top contributors for re-applying as facets load
-    // (keep all cached, function limits to HIGHLIGHT_TOP_N)
-    let highlightedFromCache = 0;
-    if (cached.topContributors && cached.topContributors.length > 0) {
-      cachedTopContributors = cached.topContributors;
-      // Apply highlights immediately (some facets may already be loaded)
-      highlightedFromCache = applyHighlightsFromContributors(cachedTopContributors);
-      // eslint-disable-next-line no-console
-      console.log(`Applied ${highlightedFromCache}/${HIGHLIGHT_TOP_N} highlights from cache`);
-    } else {
-      cachedTopContributors = null;
-      // Fallback for old cache format
-      applyHighlights();
-      highlightedFromCache = HIGHLIGHT_TOP_N; // Assume enough for old format
-      // eslint-disable-next-line no-console
-      console.log('Applied highlights from old cache format');
-    }
-
-    // If we couldn't highlight enough values (e.g., after drill-down filtered them out),
-    // fall through to run a fresh investigation which will create a new cache entry
-    if (highlightedFromCache >= HIGHLIGHT_TOP_N) {
-      // eslint-disable-next-line no-console
-      console.log('Cache sufficient, skipping fresh investigation');
-      return lastInvestigationResults;
-    }
-    // eslint-disable-next-line no-console
-    console.log(`Only ${highlightedFromCache}/${HIGHLIGHT_TOP_N} highlighted, fetching fresh candidates`);
-    // Clear stale cache data before fresh investigation
-    currentCacheKey = null;
-    currentCacheContext = null;
-  }
+  // Try localStorage cache
+  const storageCached = tryLocalStorageCache(cacheKey);
+  if (storageCached) return storageCached;
 
   // Get base context for stable IDs
   const baseTimeFilter = getTimeFilter();

--- a/js/breakdowns/render.js
+++ b/js/breakdowns/render.js
@@ -141,9 +141,18 @@ export function renderBreakdownTable(
   const isBytes = mode === 'bytes';
   const valueFormatter = isBytes ? formatBytes : formatNumber;
 
+  const headerParts = buildHeaderElements(
+    id,
+    elapsed,
+    modeToggle,
+    isBytes,
+    summaryRatio,
+    summaryLabel,
+    summaryColor,
+  );
   const {
     speedIndicator, modeToggleHtml, copyBtnHtml, summaryHtml,
-  } = buildHeaderElements(id, elapsed, modeToggle, isBytes, summaryRatio, summaryLabel, summaryColor);
+  } = headerParts;
 
   if (data.length === 0) {
     let html = `<h3>${speedIndicator}${title}${modeToggleHtml}${summaryHtml}`;

--- a/js/breakdowns/render.js
+++ b/js/breakdowns/render.js
@@ -27,6 +27,90 @@ export function getNextTopN() {
   return TOP_N_OPTIONS[currentIdx + 1];
 }
 
+/**
+ * Get speed class based on elapsed time (aligned with Google LCP thresholds)
+ */
+function getSpeedClass(elapsed) {
+  if (elapsed < 2500) return 'fast';
+  if (elapsed < 4000) return 'medium';
+  return 'slow';
+}
+
+/**
+ * Build header elements HTML for facet card
+ */
+function buildHeaderElements(id, elapsed, modeToggle, isBytes, summaryRatio, summaryLabel, summaryColor) {
+  const speedClass = getSpeedClass(elapsed);
+  const speedTitle = formatQueryTime(elapsed);
+  const isPinned = state.pinnedFacets.includes(id);
+  const pinTitle = isPinned ? 'Unpin facet' : 'Pin facet to top';
+
+  const speedIndicator = `<span class="speed-indicator ${speedClass}" title="${speedTitle} - ${pinTitle}" `
+    + `data-action="toggle-facet-pin" data-facet="${escapeHtml(id)}" role="button"></span>`;
+
+  const modeToggleHtml = modeToggle
+    ? `<button class="mode-toggle${isBytes ? ' active' : ''}" data-action="toggle-facet-mode" `
+      + `data-mode="${escapeHtml(modeToggle)}" title="Toggle between request count and bytes">`
+      + `${isBytes ? 'B' : '#'}</button>`
+    : '';
+
+  const copyBtnHtml = '<button class="copy-facet-btn" data-action="copy-facet-tsv" '
+    + `data-facet="${escapeHtml(id)}" title="Copy data as TSV">copy</button>`;
+
+  const summaryColorClass = summaryColor ? ` summary-${summaryColor}` : '';
+  const summaryHtml = (summaryRatio !== null && summaryLabel)
+    ? `<span class="summary-metric${summaryColorClass}" `
+      + `title="${(summaryRatio * 100).toFixed(1)}% ${summaryLabel}">${Math.round(summaryRatio * 100)}%</span>`
+    : '';
+
+  return {
+    speedIndicator, modeToggleHtml, copyBtnHtml, summaryHtml,
+  };
+}
+
+/**
+ * Store facet data on card element for copy functionality
+ */
+function storeFacetData(card, title, data, totals, isBytes) {
+  const el = card;
+  el.dataset.facetData = JSON.stringify({
+    title,
+    data: data.map((row) => ({
+      dim: row.dim || '(empty)',
+      cnt: parseInt(row.cnt, 10),
+      cnt_ok: parseInt(row.cnt_ok, 10) || 0,
+      cnt_4xx: parseInt(row.cnt_4xx, 10) || 0,
+      cnt_5xx: parseInt(row.cnt_5xx, 10) || 0,
+    })),
+    totals: totals ? {
+      cnt: parseInt(totals.cnt, 10),
+      cnt_ok: parseInt(totals.cnt_ok, 10) || 0,
+      cnt_4xx: parseInt(totals.cnt_4xx, 10) || 0,
+      cnt_5xx: parseInt(totals.cnt_5xx, 10) || 0,
+    } : null,
+    mode: isBytes ? 'bytes' : 'count',
+  });
+}
+
+/**
+ * Calculate "Other" row from totals minus top-K sum
+ */
+function calculateOtherRow(data, totals) {
+  if (!totals) return null;
+  const topKSum = {
+    cnt: data.reduce((sum, d) => sum + parseInt(d.cnt, 10), 0),
+    cnt_ok: data.reduce((sum, d) => sum + (parseInt(d.cnt_ok, 10) || 0), 0),
+    cnt_4xx: data.reduce((sum, d) => sum + (parseInt(d.cnt_4xx, 10) || 0), 0),
+    cnt_5xx: data.reduce((sum, d) => sum + (parseInt(d.cnt_5xx, 10) || 0), 0),
+  };
+  return {
+    cnt: parseInt(totals.cnt, 10) - topKSum.cnt,
+    cnt_ok: (parseInt(totals.cnt_ok, 10) || 0) - topKSum.cnt_ok,
+    cnt_4xx: (parseInt(totals.cnt_4xx, 10) || 0) - topKSum.cnt_4xx,
+    cnt_5xx: (parseInt(totals.cnt_5xx, 10) || 0) - topKSum.cnt_5xx,
+  };
+}
+
 export function renderBreakdownTable(
   id,
   data,
@@ -48,48 +132,18 @@ export function renderBreakdownTable(
   filterOp,
 ) {
   const card = document.getElementById(id);
-  // Store original title in data attribute, or read from h3 if first render
-  if (!card.dataset.title) {
-    card.dataset.title = card.querySelector('h3').textContent;
-  }
+  if (!card.dataset.title) card.dataset.title = card.querySelector('h3').textContent;
   const { title } = card.dataset;
 
-  // Get active filters for this column
   const columnFilters = getFiltersForColumn(col);
   const hasFilters = columnFilters.length > 0;
-
-  // Check mode for this facet (count vs bytes)
   const mode = modeToggle ? state[modeToggle] : 'count';
   const isBytes = mode === 'bytes';
   const valueFormatter = isBytes ? formatBytes : formatNumber;
 
-  // Speed indicator based on elapsed time (aligned with Google LCP thresholds)
-  let speedClass;
-  if (elapsed < 2500) {
-    speedClass = 'fast';
-  } else if (elapsed < 4000) {
-    speedClass = 'medium';
-  } else {
-    speedClass = 'slow';
-  }
-  const speedTitle = formatQueryTime(elapsed);
-  const isPinned = state.pinnedFacets.includes(id);
-  const pinTitle = isPinned ? 'Unpin facet' : 'Pin facet to top';
-  const speedIndicator = `<span class="speed-indicator ${speedClass}" title="${speedTitle} - ${pinTitle}" data-action="toggle-facet-pin" data-facet="${escapeHtml(id)}" role="button"></span>`;
-
-  // Mode toggle for facets that support it (e.g., content-types: count vs bytes)
-  const modeToggleHtml = modeToggle
-    ? `<button class="mode-toggle${isBytes ? ' active' : ''}" data-action="toggle-facet-mode" data-mode="${escapeHtml(modeToggle)}" title="Toggle between request count and bytes transferred">${isBytes ? 'B' : '#'}</button>`
-    : '';
-
-  // Copy to clipboard button (TSV format for spreadsheets)
-  const copyBtnHtml = `<button class="copy-facet-btn" data-action="copy-facet-tsv" data-facet="${escapeHtml(id)}" title="Copy data as TSV (paste into spreadsheet)">copy</button>`;
-
-  // Summary metric display (e.g., "87% efficiency")
-  const summaryColorClass = summaryColor ? ` summary-${summaryColor}` : '';
-  const summaryHtml = (summaryRatio !== null && summaryLabel)
-    ? `<span class="summary-metric${summaryColorClass}" title="${(summaryRatio * 100).toFixed(1)}% ${summaryLabel}">${Math.round(summaryRatio * 100)}%</span>`
-    : '';
+  const {
+    speedIndicator, modeToggleHtml, copyBtnHtml, summaryHtml,
+  } = buildHeaderElements(id, elapsed, modeToggle, isBytes, summaryRatio, summaryLabel, summaryColor);
 
   if (data.length === 0) {
     let html = `<h3>${speedIndicator}${title}${modeToggleHtml}${summaryHtml}`;
@@ -97,44 +151,16 @@ export function renderBreakdownTable(
       html += ` <button class="clear-facet-btn" data-action="clear-facet" data-col="${escapeHtml(col)}">Clear</button>`;
     }
     html += '</h3><div class="empty">No data</div>';
-    html += `<button class="facet-hide-btn" data-action="toggle-facet-hide" data-facet="${escapeHtml(id)}" title="Hide facet"></button>`;
+    html += '<button class="facet-hide-btn" data-action="toggle-facet-hide" '
+      + `data-facet="${escapeHtml(id)}" title="Hide facet"></button>`;
     card.innerHTML = html;
     card.classList.remove('facet-hidden');
     return;
   }
 
-  // Store data on card for copy functionality (stored as JSON for easy access)
-  card.dataset.facetData = JSON.stringify({
-    title,
-    data: data.map((row) => ({
-      dim: row.dim || '(empty)',
-      cnt: parseInt(row.cnt, 10),
-      cnt_ok: parseInt(row.cnt_ok, 10) || 0,
-      cnt_4xx: parseInt(row.cnt_4xx, 10) || 0,
-      cnt_5xx: parseInt(row.cnt_5xx, 10) || 0,
-    })),
-    totals: totals ? {
-      cnt: parseInt(totals.cnt, 10),
-      cnt_ok: parseInt(totals.cnt_ok, 10) || 0,
-      cnt_4xx: parseInt(totals.cnt_4xx, 10) || 0,
-      cnt_5xx: parseInt(totals.cnt_5xx, 10) || 0,
-    } : null,
-    mode: isBytes ? 'bytes' : 'count',
-  });
+  storeFacetData(card, title, data, totals, isBytes);
 
-  // Calculate "Other" from totals
-  const topKSum = {
-    cnt: data.reduce((sum, d) => sum + parseInt(d.cnt, 10), 0),
-    cnt_ok: data.reduce((sum, d) => sum + (parseInt(d.cnt_ok, 10) || 0), 0),
-    cnt_4xx: data.reduce((sum, d) => sum + (parseInt(d.cnt_4xx, 10) || 0), 0),
-    cnt_5xx: data.reduce((sum, d) => sum + (parseInt(d.cnt_5xx, 10) || 0), 0),
-  };
-  const otherRow = totals ? {
-    cnt: parseInt(totals.cnt, 10) - topKSum.cnt,
-    cnt_ok: (parseInt(totals.cnt_ok, 10) || 0) - topKSum.cnt_ok,
-    cnt_4xx: (parseInt(totals.cnt_4xx, 10) || 0) - topKSum.cnt_4xx,
-    cnt_5xx: (parseInt(totals.cnt_5xx, 10) || 0) - topKSum.cnt_5xx,
-  } : null;
+  const otherRow = calculateOtherRow(data, totals);
   const hasOther = otherRow && otherRow.cnt > 0 && getNextTopN();
 
   // Exclude synthetic buckets like (same), (empty) from maxCount calculation

--- a/js/chart.js
+++ b/js/chart.js
@@ -104,7 +104,7 @@ function initChartCanvas() {
  */
 function drawYAxis(ctx, chartDimensions, cssVar, minValue, maxValue) {
   const {
-    width, height, padding, chartWidth, chartHeight, labelInset,
+    width, height, padding, chartHeight, labelInset,
   } = chartDimensions;
   ctx.fillStyle = cssVar('--text-secondary');
   ctx.font = '11px -apple-system, sans-serif';
@@ -163,9 +163,7 @@ function drawXAxisLabels(ctx, data, chartDimensions, intendedStartTime, intended
  * Draw anomaly highlight for a detected step
  */
 function drawAnomalyHighlight(ctx, step, data, chartDimensions, getX, getY, stacks) {
-  const {
-    width, height, padding, chartWidth,
-  } = chartDimensions;
+  const { height, padding, chartWidth } = chartDimensions;
   const { stackedServer, stackedClient, stackedOk } = stacks;
 
   const startX = getX(step.startIndex);
@@ -636,7 +634,7 @@ export function setupChartNavigation(callback) {
     const chartLayout = getChartLayout();
     if (!chartLayout) return;
 
-    const { padding, width, height } = chartLayout;
+    const { padding, height } = chartLayout;
 
     // Position the scrubber line
     scrubberLine.style.left = `${x}px`;

--- a/js/colors/definitions.js
+++ b/js/colors/definitions.js
@@ -76,34 +76,30 @@ export const colorRules = {
     patterns: ['request_type'],
     getColor: (value) => {
       if (!value) return '';
-      const t = value.toLowerCase();
-      // Delivery category (blue) - main edge on *.aem.live
-      if (t === 'pipeline') return 'var(--rt-pipeline)';
-      if (t === 'static') return 'var(--rt-static)';
-      if (t === 'media') return 'var(--rt-media)';
-      if (t === 'rum') return 'var(--rt-rum)';
-      // Pipeline service category (violet) - pipeline.aem-fastly.page
-      if (t === 'html') return 'var(--rt-html)';
-      if (t === 'json') return 'var(--rt-json)';
-      if (t === 'md') return 'var(--rt-md)';
-      if (t === 'robots') return 'var(--rt-robots)';
-      // Static service category (teal) - static.aem-fastly.page
-      if (t === 'content') return 'var(--rt-content)';
-      if (t === 'code') return 'var(--rt-code)';
-      // Admin service category (orange/amber) - admin.hlx.page
-      if (t === 'job') return 'var(--rt-job)';
-      if (t === 'discover') return 'var(--rt-discover)';
-      if (t === 'preview') return 'var(--rt-preview)';
-      if (t === 'status') return 'var(--rt-status)';
-      if (t === 'sidekick') return 'var(--rt-sidekick)';
-      if (t === 'github-bot') return 'var(--rt-github-bot)';
-      if (t === 'live') return 'var(--rt-live)';
-      if (t === 'auth') return 'var(--rt-auth)';
-      // Config service category (green) - config.aem.page
-      if (t === 'admin') return 'var(--rt-admin)';
-      if (t === 'delivery') return 'var(--rt-delivery)';
-      if (t === 'config') return 'var(--rt-config)';
-      return '';
+      const REQUEST_TYPE_COLORS = {
+        pipeline: 'var(--rt-pipeline)',
+        static: 'var(--rt-static)',
+        media: 'var(--rt-media)',
+        rum: 'var(--rt-rum)',
+        html: 'var(--rt-html)',
+        json: 'var(--rt-json)',
+        md: 'var(--rt-md)',
+        robots: 'var(--rt-robots)',
+        content: 'var(--rt-content)',
+        code: 'var(--rt-code)',
+        job: 'var(--rt-job)',
+        discover: 'var(--rt-discover)',
+        preview: 'var(--rt-preview)',
+        status: 'var(--rt-status)',
+        sidekick: 'var(--rt-sidekick)',
+        'github-bot': 'var(--rt-github-bot)',
+        live: 'var(--rt-live)',
+        auth: 'var(--rt-auth)',
+        admin: 'var(--rt-admin)',
+        delivery: 'var(--rt-delivery)',
+        config: 'var(--rt-config)',
+      };
+      return REQUEST_TYPE_COLORS[value.toLowerCase()] || '';
     },
   },
 
@@ -111,28 +107,27 @@ export const colorRules = {
     patterns: ['backend_type'],
     getColor: (value) => {
       if (!value) return '';
-      const t = value.toLowerCase();
-      // Fastly services
-      if (t === 'fastly / aws') return 'var(--ts-fastly-aws)';
-      if (t === 'fastly / cloudflare') return 'var(--ts-fastly-cloudflare)';
-      if (t === 'fastly / image optimizer') return 'var(--ts-fastly-media)';
-      if (t === 'fastly / admin') return 'var(--ts-fastly-admin)';
-      if (t === 'fastly / api') return 'var(--ts-fastly-api)';
-      if (t === 'fastly / config') return 'var(--ts-fastly-config)';
-      if (t === 'fastly / pipeline') return 'var(--ts-fastly-pipeline)';
-      if (t === 'fastly / static') return 'var(--ts-fastly-static)';
-      if (t === 'fastly / www') return 'var(--ts-fastly-www)';
-      if (t === 'fastly / forms') return 'var(--ts-fastly-forms)';
-      if (t === 'fastly / other') return 'var(--ts-fastly-other)';
-      // Cloudflare services
-      if (t === 'cloudflare / r2') return 'var(--ts-cf-r2)';
-      if (t === 'cloudflare / da') return 'var(--ts-cf-da)';
-      if (t === 'cloudflare / helix') return 'var(--ts-cf-helix)';
-      if (t === 'cloudflare / workers') return 'var(--ts-cf-workers)';
-      // Legacy values (for historical data)
-      if (t === 'aws') return 'var(--ts-fastly-aws)';
-      if (t === 'cloudflare' || t === 'cloudflare (implied)') return 'var(--ts-cf-workers)';
-      return '';
+      const BACKEND_TYPE_COLORS = {
+        'fastly / aws': 'var(--ts-fastly-aws)',
+        'fastly / cloudflare': 'var(--ts-fastly-cloudflare)',
+        'fastly / image optimizer': 'var(--ts-fastly-media)',
+        'fastly / admin': 'var(--ts-fastly-admin)',
+        'fastly / api': 'var(--ts-fastly-api)',
+        'fastly / config': 'var(--ts-fastly-config)',
+        'fastly / pipeline': 'var(--ts-fastly-pipeline)',
+        'fastly / static': 'var(--ts-fastly-static)',
+        'fastly / www': 'var(--ts-fastly-www)',
+        'fastly / forms': 'var(--ts-fastly-forms)',
+        'fastly / other': 'var(--ts-fastly-other)',
+        'cloudflare / r2': 'var(--ts-cf-r2)',
+        'cloudflare / da': 'var(--ts-cf-da)',
+        'cloudflare / helix': 'var(--ts-cf-helix)',
+        'cloudflare / workers': 'var(--ts-cf-workers)',
+        aws: 'var(--ts-fastly-aws)',
+        cloudflare: 'var(--ts-cf-workers)',
+        'cloudflare (implied)': 'var(--ts-cf-workers)',
+      };
+      return BACKEND_TYPE_COLORS[value.toLowerCase()] || '';
     },
   },
 

--- a/js/copy-facet.js
+++ b/js/copy-facet.js
@@ -63,6 +63,7 @@ export async function copyFacetAsTsv(facetId) {
     showCopyFeedback(card, true);
     return true;
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error('Failed to copy facet data:', err);
     showCopyFeedback(card, false);
     return false;

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -309,6 +309,7 @@ export function initDashboard(config = {}) {
         }
       } catch (err) {
         localStorage.removeItem('clickhouse_credentials');
+        // eslint-disable-next-line no-console
         console.log('Invalid credentials in localStorage');
       }
     }

--- a/js/templates/breakdown-table.js
+++ b/js/templates/breakdown-table.js
@@ -178,7 +178,10 @@ export function buildBreakdownRow({
 
   const barWidth = (isSynthetic && cnt > maxCount) ? 100 : (cnt / maxCount) * 100;
   const overflowClass = isSynthetic ? ' bar-overflow' : '';
-  const { pct5xx, pct4xx, pctOk } = calculateBarPercentages(cnt, parseInt(row.cnt_ok, 10) || 0, parseInt(row.cnt_4xx, 10) || 0, parseInt(row.cnt_5xx, 10) || 0);
+  const cntOk = parseInt(row.cnt_ok, 10) || 0;
+  const cnt4xx = parseInt(row.cnt_4xx, 10) || 0;
+  const cnt5xx = parseInt(row.cnt_5xx, 10) || 0;
+  const { pct5xx, pct4xx, pctOk } = calculateBarPercentages(cnt, cntOk, cnt4xx, cnt5xx);
 
   const { isIncluded, isExcluded } = getFilterState(columnFilters, row.dim);
   const rowClass = buildRowClass(isSynthetic, isIncluded, isExcluded, row.isFilteredValue === true);
@@ -188,7 +191,13 @@ export function buildBreakdownRow({
   });
 
   const filterAttrs = buildFilterAttrs(col, row.dim, filterCol, filterValueFn, filterOp);
-  const { filterTag, bgColor } = buildFilterTag(colorIndicator, formattedDim, linkUrl, isIncluded, isExcluded);
+  const { filterTag, bgColor } = buildFilterTag(
+    colorIndicator,
+    formattedDim,
+    linkUrl,
+    isIncluded,
+    isExcluded,
+  );
 
   const dimAction = (isIncluded || isExcluded) ? 'remove-filter-value' : 'add-filter';
   const dimDataAttr = (row.dim || '').replace(/"/g, '&quot;');

--- a/js/templates/breakdown-table.js
+++ b/js/templates/breakdown-table.js
@@ -87,60 +87,47 @@ export function buildDimParts({
  * @param {number} params.rowIndex
  * @returns {string} HTML string
  */
-export function buildBreakdownRow({
-  row, col, maxCount, columnFilters, valueFormatter,
-  linkPrefix, linkSuffix, linkFn, dimPrefixes, dimFormatFn,
-  filterCol, filterValueFn, filterOp, rowIndex,
-}) {
-  const cnt = parseInt(row.cnt, 10);
-  const cntOk = parseInt(row.cnt_ok, 10) || 0;
-  const cnt4xx = parseInt(row.cnt_4xx, 10) || 0;
-  const cnt5xx = parseInt(row.cnt_5xx, 10) || 0;
-  const dim = row.dim || '(empty)';
-  const isSynthetic = isSyntheticBucket(dim);
+/**
+ * Calculate bar percentages from count values
+ */
+function calculateBarPercentages(cnt, cntOk, cnt4xx, cnt5xx) {
+  if (cnt <= 0) return { pct5xx: 0, pct4xx: 0, pctOk: 0 };
+  return {
+    pct5xx: (cnt5xx / cnt) * 100,
+    pct4xx: (cnt4xx / cnt) * 100,
+    pctOk: (cntOk / cnt) * 100,
+  };
+}
 
-  const barWidth = (isSynthetic && cnt > maxCount)
-    ? 100 : (cnt / maxCount) * 100;
-  const overflowClass = isSynthetic ? ' bar-overflow' : '';
-  const pct5xx = cnt > 0 ? (cnt5xx / cnt) * 100 : 0;
-  const pct4xx = cnt > 0 ? (cnt4xx / cnt) * 100 : 0;
-  const pctOk = cnt > 0 ? (cntOk / cnt) * 100 : 0;
+/**
+ * Determine filter state for a row
+ */
+function getFilterState(columnFilters, rowDim) {
+  const activeFilter = columnFilters.find((f) => f.value === (rowDim || ''));
+  return {
+    isIncluded: activeFilter && !activeFilter.exclude,
+    isExcluded: activeFilter && activeFilter.exclude,
+  };
+}
 
-  const activeFilter = columnFilters.find(
-    (f) => f.value === (row.dim || ''),
-  );
-  const isIncluded = activeFilter && !activeFilter.exclude;
-  const isExcluded = activeFilter && activeFilter.exclude;
-  const isFilteredValue = row.isFilteredValue === true;
-
+/**
+ * Build row CSS class based on filter state
+ */
+function buildRowClass(isSynthetic, isIncluded, isExcluded, isFilteredValue) {
   let filterClass = '';
   if (isIncluded) filterClass = 'filter-included';
   else if (isExcluded) filterClass = 'filter-excluded';
   if (isFilteredValue) filterClass += ' filtered-value-row';
-  const rowClass = isSynthetic
-    ? `synthetic-row ${filterClass}` : filterClass.trim();
+  return isSynthetic ? `synthetic-row ${filterClass}` : filterClass.trim();
+}
 
-  const { formattedDim, linkUrl, colorIndicator } = buildDimParts({
-    row, dim, col, linkPrefix, linkSuffix, linkFn, dimPrefixes, dimFormatFn,
-  });
-
-  const actualFilterCol = filterCol || col;
-  const actualFilterValue = filterValueFn
-    ? filterValueFn(row.dim || '') : (row.dim || '');
-  const actualFilterOp = filterOp || '=';
-  const filterAttrs = [
-    `data-col="${escapeHtml(col)}"`,
-    `data-value="${escapeHtml(row.dim || '')}"`,
-    `data-filter-col="${escapeHtml(actualFilterCol)}"`,
-    `data-filter-value="${escapeHtml(actualFilterValue)}"`,
-    `data-filter-op="${escapeHtml(actualFilterOp)}"`,
-  ].join(' ');
-
-  // Extract background color from color indicator
+/**
+ * Build filter tag HTML
+ */
+function buildFilterTag(colorIndicator, formattedDim, linkUrl, isIncluded, isExcluded) {
   const colorMatch = colorIndicator.match(/background:\s*([^;"]+)/);
   const bgColor = colorMatch ? colorMatch[1] : '';
 
-  // Build filter tag with consistent structure in all states
   let stateClass = '';
   let iconChar = '';
   let tagStyle = '';
@@ -154,24 +141,60 @@ export function buildBreakdownRow({
     tagStyle = ` style="background: ${bgColor || 'var(--text)'}"`;
   }
 
-  const indicatorSlot = '<span class="filter-indicator-slot">'
-    + `<span class="filter-icon">${iconChar}</span>`
-    + `${colorIndicator}</span>`;
+  const indicatorSlot = `<span class="filter-indicator-slot"><span class="filter-icon">${iconChar}</span>${colorIndicator}</span>`;
   const textHtml = linkUrl
-    ? `<a href="${linkUrl}" target="_blank" rel="noopener">`
-      + `${formattedDim}</a>`
+    ? `<a href="${linkUrl}" target="_blank" rel="noopener">${formattedDim}</a>`
     : formattedDim;
-  const filterTag = '<span class="filter-tag-indicator'
-    + `${stateClass}"${tagStyle}>${indicatorSlot}${textHtml}</span>`;
 
-  // Cycle filter state: none -> include -> exclude -> none
-  const dimAction = (isIncluded || isExcluded)
-    ? 'remove-filter-value' : 'add-filter';
-  const dimExclude = isExcluded ? 'true' : 'false';
+  return {
+    filterTag: `<span class="filter-tag-indicator${stateClass}"${tagStyle}>${indicatorSlot}${textHtml}</span>`,
+    bgColor,
+  };
+}
 
-  const ariaSelected = isIncluded || isExcluded ? 'true' : 'false';
+/**
+ * Build filter attributes string for a row
+ */
+function buildFilterAttrs(col, rowDim, filterCol, filterValueFn, filterOp) {
+  const actualFilterCol = filterCol || col;
+  const actualFilterValue = filterValueFn ? filterValueFn(rowDim || '') : (rowDim || '');
+  return [
+    `data-col="${escapeHtml(col)}"`,
+    `data-value="${escapeHtml(rowDim || '')}"`,
+    `data-filter-col="${escapeHtml(actualFilterCol)}"`,
+    `data-filter-value="${escapeHtml(actualFilterValue)}"`,
+    `data-filter-op="${escapeHtml(filterOp || '=')}"`,
+  ].join(' ');
+}
+
+export function buildBreakdownRow({
+  row, col, maxCount, columnFilters, valueFormatter,
+  linkPrefix, linkSuffix, linkFn, dimPrefixes, dimFormatFn,
+  filterCol, filterValueFn, filterOp, rowIndex,
+}) {
+  const cnt = parseInt(row.cnt, 10);
+  const dim = row.dim || '(empty)';
+  const isSynthetic = isSyntheticBucket(dim);
+
+  const barWidth = (isSynthetic && cnt > maxCount) ? 100 : (cnt / maxCount) * 100;
+  const overflowClass = isSynthetic ? ' bar-overflow' : '';
+  const { pct5xx, pct4xx, pctOk } = calculateBarPercentages(cnt, parseInt(row.cnt_ok, 10) || 0, parseInt(row.cnt_4xx, 10) || 0, parseInt(row.cnt_5xx, 10) || 0);
+
+  const { isIncluded, isExcluded } = getFilterState(columnFilters, row.dim);
+  const rowClass = buildRowClass(isSynthetic, isIncluded, isExcluded, row.isFilteredValue === true);
+
+  const { formattedDim, linkUrl, colorIndicator } = buildDimParts({
+    row, dim, col, linkPrefix, linkSuffix, linkFn, dimPrefixes, dimFormatFn,
+  });
+
+  const filterAttrs = buildFilterAttrs(col, row.dim, filterCol, filterValueFn, filterOp);
+  const { filterTag, bgColor } = buildFilterTag(colorIndicator, formattedDim, linkUrl, isIncluded, isExcluded);
+
+  const dimAction = (isIncluded || isExcluded) ? 'remove-filter-value' : 'add-filter';
   const dimDataAttr = (row.dim || '').replace(/"/g, '&quot;');
   const bgAttr = escapeHtml(bgColor || 'var(--text)');
+  const ariaSelected = (isIncluded || isExcluded) ? 'true' : 'false';
+  const dimExclude = isExcluded ? 'true' : 'false';
 
   return `
     <tr class="${rowClass}" tabindex="0" role="option" aria-selected="${ariaSelected}" data-value-index="${rowIndex}" data-dim="${dimDataAttr}">

--- a/js/templates/logs-table.js
+++ b/js/templates/logs-table.js
@@ -16,23 +16,34 @@ import { LOG_COLUMN_SHORT_LABELS, LOG_COLUMN_TO_FACET } from '../columns.js';
 
 /**
  * Format timestamp - short format on mobile.
- * @param {string} value
- * @returns {string}
  */
 function formatTimestamp(value) {
   const date = new Date(value);
-  const isMobile = window.innerWidth < 600;
-  if (isMobile) {
-    return date.toLocaleTimeString();
-  }
-  return date.toLocaleString();
+  return window.innerWidth < 600 ? date.toLocaleTimeString() : date.toLocaleString();
+}
+
+/**
+ * Format status column
+ */
+function formatStatusCell(value) {
+  const status = parseInt(value, 10);
+  let cellClass = 'status-ok';
+  if (status >= 500) cellClass = 'status-5xx';
+  else if (status >= 400) cellClass = 'status-4xx';
+  return { displayValue: String(status), cellClass };
+}
+
+/**
+ * Format generic value
+ */
+function formatGenericValue(value) {
+  if (value === null || value === undefined || value === '') return '';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
 }
 
 /**
  * Format a log cell for display and color.
- * @param {string} col
- * @param {unknown} value
- * @returns {{ displayValue: string, cellClass: string, colorIndicator: string }}
  */
 export function formatLogCell(col, value) {
   let cellClass = '';
@@ -42,22 +53,16 @@ export function formatLogCell(col, value) {
     displayValue = formatTimestamp(value);
     cellClass = 'timestamp';
   } else if (col === 'response.status' && value) {
-    const status = parseInt(value, 10);
-    displayValue = String(status);
-    if (status >= 500) cellClass = 'status-5xx';
-    else if (status >= 400) cellClass = 'status-4xx';
-    else cellClass = 'status-ok';
+    const result = formatStatusCell(value);
+    displayValue = result.displayValue;
+    cellClass = result.cellClass;
   } else if (col === 'response.body_size' && value) {
     displayValue = formatBytes(parseInt(value, 10));
   } else if (col === 'request.method') {
     displayValue = value || '';
     cellClass = 'method';
-  } else if (value === null || value === undefined || value === '') {
-    displayValue = '';
-  } else if (typeof value === 'object') {
-    displayValue = JSON.stringify(value);
   } else {
-    displayValue = String(value);
+    displayValue = formatGenericValue(value);
   }
 
   const color = value ? getColorForColumn(col, value) : '';

--- a/js/time.js
+++ b/js/time.js
@@ -45,6 +45,28 @@ function formatSqlDateTime(date) {
   return date.toISOString().replace('T', ' ').slice(0, 19);
 }
 
+// Get period duration in milliseconds (moved up to avoid use-before-define)
+function getPeriodMs() {
+  if (timeState.customTimeRange) {
+    return timeState.customTimeRange.end - timeState.customTimeRange.start;
+  }
+  return TIME_RANGES[state.timeRange]?.periodMs;
+}
+
+// Get time bucket step (moved up to avoid use-before-define)
+function getTimeBucketStep() {
+  if (timeState.customTimeRange) {
+    const durationMs = timeState.customTimeRange.end - timeState.customTimeRange.start;
+    const durationMinutes = durationMs / 60000;
+    if (durationMinutes <= 15) return 'INTERVAL 5 SECOND';
+    if (durationMinutes <= 60) return 'INTERVAL 10 SECOND';
+    if (durationMinutes <= 720) return 'INTERVAL 1 MINUTE';
+    if (durationMinutes <= 1440) return 'INTERVAL 5 MINUTE';
+    return 'INTERVAL 10 MINUTE';
+  }
+  return TIME_RANGES[state.timeRange]?.step;
+}
+
 function getSelectedRange() {
   if (timeState.customTimeRange) {
     return {
@@ -169,20 +191,8 @@ export function getTimeBucket() {
   return TIME_RANGES[state.timeRange]?.bucket;
 }
 
-export function getTimeBucketStep() {
-  if (timeState.customTimeRange) {
-    const durationMs = timeState.customTimeRange.end - timeState.customTimeRange.start;
-    const durationMinutes = durationMs / 60000;
-
-    if (durationMinutes <= 15) return 'INTERVAL 5 SECOND';
-    if (durationMinutes <= 60) return 'INTERVAL 10 SECOND';
-    if (durationMinutes <= 720) return 'INTERVAL 1 MINUTE';
-    if (durationMinutes <= 1440) return 'INTERVAL 5 MINUTE';
-    return 'INTERVAL 10 MINUTE';
-  }
-
-  return TIME_RANGES[state.timeRange]?.step;
-}
+// Re-export getTimeBucketStep for external use
+export { getTimeBucketStep };
 
 export function getTimeFilter() {
   const { start, end } = getTimeFilterBounds();
@@ -215,14 +225,8 @@ export function getTimeRangeEnd() {
   return `toDateTime('${formatSqlDateTime(end)}')`;
 }
 
-// Get period duration in milliseconds
-export function getPeriodMs() {
-  if (timeState.customTimeRange) {
-    return timeState.customTimeRange.end - timeState.customTimeRange.start;
-  }
-
-  return TIME_RANGES[state.timeRange]?.periodMs;
-}
+// Re-export getPeriodMs for external use
+export { getPeriodMs };
 
 // Zoom out to next larger predefined period, centered on current midpoint
 export function zoomOut() {

--- a/js/ui/facet-search.js
+++ b/js/ui/facet-search.js
@@ -223,45 +223,30 @@ export function initFacetSearch(callbacks) {
 
   // Handle keyboard navigation
   input.addEventListener('keydown', (e) => {
-    switch (e.key) {
-      case 'ArrowDown':
-      case 'j':
-        // j only navigates if input is empty (not typing)
-        if (e.key === 'ArrowDown' || input.value === '') {
-          e.preventDefault();
-          navigateResults(1);
-        }
-        break;
-      case 'ArrowUp':
-      case 'k':
-        // k only navigates if input is empty (not typing)
-        if (e.key === 'ArrowUp' || input.value === '') {
-          e.preventDefault();
-          navigateResults(-1);
-        }
-        break;
-      case 'Enter':
-      case 'i':
-        // i only filters if input is empty and item selected
-        if (e.key === 'Enter' || (input.value === '' && selectedIndex >= 0)) {
-          e.preventDefault();
-          applyFilter(selectedIndex, e.shiftKey);
-        }
-        break;
-      case 'e':
-      case 'x':
-        // e/x only excludes if input is empty and item selected
-        if (input.value === '' && selectedIndex >= 0) {
-          e.preventDefault();
-          applyFilter(selectedIndex, true);
-        }
-        break;
-      case 'Escape':
-        e.preventDefault();
-        closeFacetSearch();
-        break;
-      default:
-        break;
+    const isEmpty = input.value === '';
+    const hasSelection = selectedIndex >= 0;
+    const canNav = isEmpty && hasSelection;
+
+    const navDown = e.key === 'ArrowDown' || (e.key === 'j' && isEmpty);
+    const navUp = e.key === 'ArrowUp' || (e.key === 'k' && isEmpty);
+    const include = e.key === 'Enter' || (e.key === 'i' && canNav);
+    const exclude = (e.key === 'e' || e.key === 'x') && canNav;
+
+    if (navDown) {
+      e.preventDefault();
+      navigateResults(1);
+    } else if (navUp) {
+      e.preventDefault();
+      navigateResults(-1);
+    } else if (include) {
+      e.preventDefault();
+      applyFilter(selectedIndex, e.shiftKey);
+    } else if (exclude) {
+      e.preventDefault();
+      applyFilter(selectedIndex, true);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closeFacetSearch();
     }
   });
 

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -43,180 +43,162 @@ export function setUrlStateElements(els) {
   elements = els;
 }
 
-export function saveStateToURL(newAnomalyId = undefined) {
-  const params = new URLSearchParams();
-
+/**
+ * Add basic state parameters to URL params
+ */
+function addBasicParams(params) {
   if (state.timeRange !== DEFAULT_TIME_RANGE) params.set('t', state.timeRange);
   if (state.hostFilter) params.set('host', state.hostFilter);
   if (state.topN !== DEFAULT_TOP_N) params.set('n', state.topN);
   if (state.showLogs) params.set('view', 'logs');
   if (state.title) params.set('title', state.title);
   if (state.contentTypeMode !== 'count') params.set('ctm', state.contentTypeMode);
+}
 
-  // Save custom time range or query timestamp
+/**
+ * Add time range parameters to URL params
+ */
+function addTimeParams(params) {
   const ctr = customTimeRange();
   const qts = queryTimestamp();
   if (ctr) {
-    // Custom zoom range: save both start and end
     params.set('ts', ctr.start.toISOString());
     params.set('te', ctr.end.toISOString());
   } else if (qts) {
-    // Standard mode: just the reference timestamp
     params.set('ts', qts.toISOString());
   }
+}
 
-  // Encode filters as JSON array
+/**
+ * Add anomaly focus parameter to URL params
+ */
+function addAnomalyParam(params, newAnomalyId) {
+  if (newAnomalyId !== undefined) {
+    if (newAnomalyId) params.set('anomaly', newAnomalyId);
+  } else {
+    const currentAnomaly = new URLSearchParams(window.location.search).get('anomaly');
+    if (currentAnomaly) params.set('anomaly', currentAnomaly);
+  }
+}
+
+export function saveStateToURL(newAnomalyId = undefined) {
+  const params = new URLSearchParams();
+
+  addBasicParams(params);
+  addTimeParams(params);
+
   if (state.filters.length > 0) {
     params.set('filters', JSON.stringify(state.filters));
   }
 
-  // Handle anomaly focus:
-  // - If newAnomalyId is explicitly passed, use it (or null to clear)
-  // - If undefined, preserve current anomaly from URL
-  if (newAnomalyId !== undefined) {
-    if (newAnomalyId) {
-      params.set('anomaly', newAnomalyId);
-    }
-    // else: explicitly cleared, don't set
-  } else {
-    // Preserve current anomaly if set
-    const currentAnomaly = new URLSearchParams(window.location.search).get('anomaly');
-    if (currentAnomaly) {
-      params.set('anomaly', currentAnomaly);
-    }
-  }
+  addAnomalyParam(params, newAnomalyId);
 
-  // Save pinned and hidden facets to URL
-  if (state.pinnedFacets.length > 0) {
-    params.set('pf', state.pinnedFacets.join(','));
-  }
-  if (state.hiddenFacets.length > 0) {
-    params.set('hf', state.hiddenFacets.join(','));
-  }
-
-  // Note: pinned columns are NOT auto-saved to URL
-  // They can be manually added as ?pinned=col1,col2 for temporary override
+  if (state.pinnedFacets.length > 0) params.set('pf', state.pinnedFacets.join(','));
+  if (state.hiddenFacets.length > 0) params.set('hf', state.hiddenFacets.join(','));
 
   const newURL = params.toString()
     ? `${window.location.pathname}?${params}`
     : window.location.pathname;
 
-  // Only create history entry if URL actually changed
   if (newURL !== lastSavedURL) {
-    // Use pushState for real navigation changes, creating browser history
     if (lastSavedURL === null) {
-      // First save - replace initial state without creating history
       window.history.replaceState({}, '', newURL);
     } else {
-      // Subsequent saves - create history entry for back button
       window.history.pushState({}, '', newURL);
     }
     lastSavedURL = newURL;
   }
 }
 
-export function loadStateFromURL() {
-  const params = new URLSearchParams(window.location.search);
-
-  if (params.has('t')) {
-    const t = params.get('t');
-    if (TIME_RANGES[t]) {
-      state.timeRange = t;
-    }
+/**
+ * Load basic state from URL params
+ */
+function loadBasicState(params) {
+  if (params.has('t') && TIME_RANGES[params.get('t')]) {
+    state.timeRange = params.get('t');
   }
-
-  if (params.has('host')) {
-    state.hostFilter = params.get('host');
-  }
-
+  if (params.has('host')) state.hostFilter = params.get('host');
   if (params.has('n')) {
     const n = parseInt(params.get('n'), 10);
-    if (TOP_N_OPTIONS.includes(n)) {
-      state.topN = n;
-    }
+    if (TOP_N_OPTIONS.includes(n)) state.topN = n;
   }
-
-  if (params.has('view') && params.get('view') === 'logs') {
-    state.showLogs = true;
+  if (params.get('view') === 'logs') state.showLogs = true;
+  if (params.has('title')) state.title = params.get('title');
+  if (params.has('ctm') && ['count', 'bytes'].includes(params.get('ctm'))) {
+    state.contentTypeMode = params.get('ctm');
   }
-
-  if (params.has('ts')) {
-    const ts = new Date(params.get('ts'));
-    if (!Number.isNaN(ts.getTime())) {
-      // Check if this is a custom time range (has both ts and te)
-      if (params.has('te')) {
-        const te = new Date(params.get('te'));
-        if (!Number.isNaN(te.getTime())) {
-          setCustomTimeRange(ts, te);
-        }
-      } else {
-        // Standard mode: just set the reference timestamp
-        setQueryTimestamp(ts);
-      }
-    }
-  }
-
-  if (params.has('filters')) {
-    try {
-      const filters = JSON.parse(params.get('filters'));
-      if (Array.isArray(filters)) {
-        // Preserve filterCol, filterValue, filterOp if present (for grouped/LIKE filtering)
-        state.filters = filters.filter((f) => f.col && typeof f.value === 'string' && typeof f.exclude === 'boolean')
-          .map((f) => {
-            const filter = { col: f.col, value: f.value, exclude: f.exclude };
-            if (f.filterCol) filter.filterCol = f.filterCol;
-            if (f.filterValue !== undefined) filter.filterValue = f.filterValue;
-            if (f.filterOp) filter.filterOp = f.filterOp;
-            return filter;
-          })
-          .filter((f) => {
-            const sqlCol = f.filterCol || f.col;
-            const sqlOp = f.filterOp || '=';
-            return isValidFilterColumn(sqlCol) && isValidFilterOp(sqlOp);
-          });
-      }
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to parse filters from URL:', e);
-    }
-  }
-
-  if (params.has('pinned')) {
-    const pinned = params.get('pinned').split(',').filter((c) => c);
-    if (pinned.length > 0) {
-      // Override state temporarily without persisting to localStorage
-      state.pinnedColumns = pinned;
-    }
-  }
-
-  // Hide UI controls (comma-separated: timeRange,topN,host,refresh,logout,logs)
   if (params.has('hide')) {
     state.hiddenControls = params.get('hide').split(',').filter((c) => c);
   }
+}
 
-  // Custom title from URL
-  if (params.has('title')) {
-    state.title = params.get('title');
+/**
+ * Load time state from URL params
+ */
+function loadTimeState(params) {
+  if (!params.has('ts')) return;
+
+  const ts = new Date(params.get('ts'));
+  if (Number.isNaN(ts.getTime())) return;
+
+  if (params.has('te')) {
+    const te = new Date(params.get('te'));
+    if (!Number.isNaN(te.getTime())) setCustomTimeRange(ts, te);
+  } else {
+    setQueryTimestamp(ts);
   }
+}
 
-  // Content-type facet mode (count or bytes)
-  if (params.has('ctm')) {
-    const ctm = params.get('ctm');
-    if (['count', 'bytes'].includes(ctm)) {
-      state.contentTypeMode = ctm;
+/**
+ * Parse and validate a filter object
+ */
+function parseFilter(f) {
+  if (!f.col || typeof f.value !== 'string' || typeof f.exclude !== 'boolean') {
+    return null;
+  }
+  const filter = { col: f.col, value: f.value, exclude: f.exclude };
+  if (f.filterCol) filter.filterCol = f.filterCol;
+  if (f.filterValue !== undefined) filter.filterValue = f.filterValue;
+  if (f.filterOp) filter.filterOp = f.filterOp;
+
+  const sqlCol = filter.filterCol || filter.col;
+  const sqlOp = filter.filterOp || '=';
+  return isValidFilterColumn(sqlCol) && isValidFilterOp(sqlOp) ? filter : null;
+}
+
+/**
+ * Load filters from URL params
+ */
+function loadFiltersState(params) {
+  if (!params.has('filters')) return;
+
+  try {
+    const filters = JSON.parse(params.get('filters'));
+    if (Array.isArray(filters)) {
+      state.filters = filters.map(parseFilter).filter(Boolean);
     }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to parse filters from URL:', e);
+  }
+}
+
+export function loadStateFromURL() {
+  const params = new URLSearchParams(window.location.search);
+
+  loadBasicState(params);
+  loadTimeState(params);
+  loadFiltersState(params);
+
+  if (params.has('pinned')) {
+    const pinned = params.get('pinned').split(',').filter((c) => c);
+    if (pinned.length > 0) state.pinnedColumns = pinned;
   }
 
-  // Load facet preferences from localStorage (keyed by title)
   loadFacetPrefs();
 
-  // Override with URL params if present
-  if (params.has('pf')) {
-    state.pinnedFacets = params.get('pf').split(',').filter((f) => f);
-  }
-  if (params.has('hf')) {
-    state.hiddenFacets = params.get('hf').split(',').filter((f) => f);
-  }
+  if (params.has('pf')) state.pinnedFacets = params.get('pf').split(',').filter((f) => f);
+  if (params.has('hf')) state.hiddenFacets = params.get('hf').split(',').filter((f) => f);
 }
 
 export function syncUIFromState() {


### PR DESCRIPTION
## Summary
- Refactor anomaly investigation, chart, and time utilities to reduce branching and complexity.
- Tidy breakdown rendering/template helpers and keep log statements lint-safe.

## Testing Done
- 
> klickhaus@1.0.0 lint
> eslint .

## Checklist
- [ ] Tests pass (
> klickhaus@1.0.0 test
> web-test-runner


Chromium: |██████▋                       | 0/18 test files | 0 passed, 0 failed

Running tests...

Running 18 test files...


[2K[1A[2K[Gjs/filter-sql.test.js:

 🚧 Browser logs:
      Filter rejected: invalid column "1=1 OR 1=1 --"
      Filter rejected: invalid operator "OR 1=1 --"
      Filter rejected: invalid column "INVALID_INJECTION"


[2K[1A[2K[Gjs/step-detection.test.js:

 🚧 Browser logs:
      Detected step: {
        startIndex: [33m8[39m,
        endIndex: [33m9[39m,
        type: [32m'spike'[39m,
        magnitude: [33m1.5749504353073012[39m,
        category: [32m'error'[39m,
        duration: [33m2[39m
      }
      Detected drop: {
        startIndex: [33m5[39m,
        endIndex: [33m6[39m,
        type: [32m'dip'[39m,
        magnitude: [33m0.4936708860759494[39m,
        category: [32m'success'[39m,
        duration: [33m2[39m
      }
      Detected (prioritized): {
        startIndex: [33m4[39m,
        endIndex: [33m4[39m,
        type: [32m'spike'[39m,
        magnitude: [33m1.8418013856812934[39m,
        category: [32m'error'[39m,
        duration: [33m1[39m
      }


[2K[1A[2K[Gjs/breakdowns/buckets.test.js:

 🚧 Browser logs:
        topN=3: got 3 buckets
          labels: 0 (empty), 1 B-100 MB, ≥ 100 MB
        topN=5: got 5 buckets
          labels: 0 (empty), 1 B-10 B, 10 B-50 KB, 50 KB-100 MB, ≥ 100 MB
        topN=7: got 7 buckets
          labels: 0 (empty), 1 B-10 B, 10 B-500 B, 500 B-50 KB, 50 KB-2 MB, 2 MB-100 MB, ≥ 100 MB
        topN=10: got 10 buckets
          labels: 0 (empty), 1 B-10 B, 10 B-100 B, 100 B-1 KB, 1 KB-10 KB, 10 KB-100 KB, 100 KB-1 MB, 1 MB-10 MB, 10 MB-100 MB, ≥ 100 MB
        topN=12: got 12 buckets
          labels: 0 (empty), 1 B-10 B, 10 B-50 B, 50 B-500 B, 500 B-2 KB, 2 KB-10 KB, 10 KB-100 KB, 100 KB-500 KB, 500 KB-2 MB, 2 MB-20 MB, 20 MB-100 MB, ≥ 100 MB
        topN=15: got 15 buckets
          labels: 0 (empty), 1 B-10 B, 10 B-50 B, 50 B-200 B, 200 B-500 B, 500 B-2 KB, 2 KB-10 KB, 10 KB-50 KB, 50 KB-100 KB, 100 KB-500 KB, 500 KB-2 MB, 2 MB-10 MB, 10 MB-20 MB, 20 MB-100 MB, ≥ 100 MB
        topN=20: got 20 buckets
          labels: 0 (empty), 1 B-10 B, 10 B-20 B, 20 B-50 B, 50 B-200 B, 200 B-500 B, 500 B-1 KB, 1 KB-2 KB, 2 KB-10 KB, 10 KB-20 KB, 20 KB-50 KB, 50 KB-100 KB, 100 KB-500 KB, 500 KB-1 MB, 1 MB-2 MB, 2 MB-5 MB, 5 MB-20 MB, 20 MB-50 MB, 50 MB-100 MB, ≥ 100 MB
        topN=3: got 3 buckets
          labels: < 1ms, 1ms-60s, ≥ 60s
        topN=5: got 5 buckets
          labels: < 1ms, 1ms-50ms, 50ms-1.5s, 1.5s-60s, ≥ 60s
        topN=7: got 7 buckets
          labels: < 1ms, 1ms-10ms, 10ms-100ms, 100ms-700ms, 700ms-7s, 7s-60s, ≥ 60s
        topN=10: got 10 buckets
          labels: < 1ms, 1ms-5ms, 5ms-20ms, 20ms-70ms, 70ms-300ms, 300ms-1s, 1s-3s, 3s-15s, 15s-60s, ≥ 60s
        topN=12: got 12 buckets
          labels: < 1ms, 1ms-5ms, 5ms-10ms, 10ms-30ms, 30ms-100ms, 100ms-300ms, 300ms-700ms, 700ms-2s, 2s-7s, 7s-15s, 15s-60s, ≥ 60s
        topN=15: got 15 buckets
          labels: < 1ms, 1ms-3ms, 3ms-7ms, 7ms-15ms, 15ms-30ms, 30ms-70ms, 70ms-150ms, 150ms-500ms, 500ms-1s, 1s-2s, 2s-5s, 5s-10s, 10s-20s, 20s-60s, ≥ 60s
        topN=20: got 20 buckets
          labels: < 1ms, 1ms-3ms, 3ms-5ms, 5ms-10ms, 10ms-15ms, 15ms-30ms, 30ms-50ms, 50ms-100ms, 100ms-150ms, 150ms-300ms, 300ms-500ms, 500ms-1s, 1s-1.5s, 1.5s-3s, 3s-5s, 5s-10s, 10s-15s, 15s-30s, 30s-60s, ≥ 60s


[2K[1A[2K[GChromium: |██████████████████████████████| 18/18 test files | 285 passed, 0 failed

Code coverage: 87.5 %
View full coverage report at coverage/lcov-report/index.html

Finished running tests in 3.4s, all tests passed! 🎉)
- [x] Lint passes (
> klickhaus@1.0.0 lint
> eslint .)
- [ ] Documentation updated (if applicable)
