### PR TITLE
Abort stale requests and improve facet errors

### DIFF
--- a/css/facets.css
+++ b/css/facets.css
@@ -86,6 +86,37 @@
   opacity: 0.7;
 }
 
+.facet-error {
+  border: 1px solid rgba(240, 68, 56, 0.3);
+  background: rgba(240, 68, 56, 0.06);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.facet-error-title {
+  color: var(--status-server-error);
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.facet-error-message {
+  color: var(--text-secondary);
+}
+
+.facet-error-detail {
+  margin-top: 6px;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.facet-error-meta {
+  margin-top: 6px;
+  color: var(--text-tertiary);
+  font-size: 11px;
+}
+
 .breakdown-card h3 {
   font-size: 14px;
   font-weight: 600;

--- a/js/api.js
+++ b/js/api.js
@@ -27,7 +27,173 @@ export function setForceRefresh(value) {
 // Auth error event - dispatched when authentication fails
 const authErrorEvent = new CustomEvent('auth-error');
 
-export async function query(sql, { cacheTtl: initialCacheTtl = null, skipCache = false } = {}) {
+const CATEGORY_LABELS = {
+  permissions: 'Permissions',
+  memory: 'Out of memory',
+  syntax: 'Query syntax',
+  timeout: 'Query timeout',
+  schema: 'Schema',
+  resource: 'Resource limits',
+  network: 'Network error',
+  cancelled: 'Cancelled',
+  unknown: 'Query failed',
+};
+
+function summarizeErrorText(text) {
+  if (!text) return 'Unknown error';
+  const trimmed = String(text).trim();
+  const firstLine = trimmed.split('\n').map((line) => line.trim()).find(Boolean) || trimmed;
+  const normalized = firstLine.replace(/\s+/g, ' ').trim();
+  if (normalized.length > 200) {
+    return `${normalized.slice(0, 197)}...`;
+  }
+  return normalized;
+}
+
+function extractErrorType(text) {
+  const matches = [...String(text).matchAll(/\(([A-Z0-9_]+)\)/g)];
+  if (matches.length === 0) return null;
+  return matches[matches.length - 1][1];
+}
+
+function classifyCategory(text, status, type) {
+  const lower = String(text).toLowerCase();
+  if (
+    status === 401
+    || status === 403
+    || type === 'ACCESS_DENIED'
+    || type === 'NOT_ENOUGH_PRIVILEGES'
+    || lower.includes('authentication failed')
+    || lower.includes('required_password')
+    || lower.includes('not enough privileges')
+    || lower.includes('access denied')
+  ) {
+    return 'permissions';
+  }
+  if (type === 'MEMORY_LIMIT_EXCEEDED' || lower.includes('memory limit')) {
+    return 'memory';
+  }
+  if (type === 'SYNTAX_ERROR' || lower.includes('syntax error')) {
+    return 'syntax';
+  }
+  if (type === 'TIMEOUT_EXCEEDED' || lower.includes('timeout')) {
+    return 'timeout';
+  }
+  if (
+    type === 'UNKNOWN_TABLE'
+    || type === 'UNKNOWN_IDENTIFIER'
+    || type === 'UNKNOWN_COLUMN'
+    || type === 'UNKNOWN_FUNCTION'
+    || lower.includes('unknown table')
+    || lower.includes('unknown identifier')
+  ) {
+    return 'schema';
+  }
+  if (
+    type === 'TOO_MANY_PARTS'
+    || type === 'TOO_MANY_SIMULTANEOUS_QUERIES'
+    || type === 'TOO_MANY_BYTES'
+    || type === 'QUERY_WAS_CANCELLED'
+  ) {
+    return 'resource';
+  }
+  if (
+    lower.includes('failed to fetch')
+    || lower.includes('networkerror')
+    || lower.includes('network error')
+  ) {
+    return 'network';
+  }
+  return 'unknown';
+}
+
+export class QueryError extends Error {
+  constructor(message, {
+    status = null,
+    code = null,
+    type = null,
+    category = 'unknown',
+    detail = null,
+  } = {}) {
+    super(message);
+    this.name = 'QueryError';
+    this.status = status;
+    this.code = code;
+    this.type = type;
+    this.category = category;
+    this.detail = detail;
+    this.isQueryError = true;
+  }
+}
+
+function parseQueryError(text, status) {
+  const codeMatch = String(text).match(/Code:\s*(\d+)/i);
+  const code = codeMatch ? parseInt(codeMatch[1], 10) : null;
+  const type = extractErrorType(text);
+  const category = classifyCategory(text, status, type);
+  const message = summarizeErrorText(text);
+  return {
+    status,
+    code,
+    type,
+    category,
+    message,
+    detail: message,
+  };
+}
+
+export function isAbortError(err) {
+  return err?.name === 'AbortError';
+}
+
+export function getQueryErrorDetails(err) {
+  if (!err) {
+    return {
+      label: CATEGORY_LABELS.unknown,
+      category: 'unknown',
+      message: 'Unknown error',
+    };
+  }
+
+  if (isAbortError(err)) {
+    return {
+      label: CATEGORY_LABELS.cancelled,
+      category: 'cancelled',
+      message: 'Request cancelled',
+      isAbort: true,
+    };
+  }
+
+  if (err.isQueryError || err.name === 'QueryError') {
+    const label = CATEGORY_LABELS[err.category] || CATEGORY_LABELS.unknown;
+    return {
+      label,
+      category: err.category,
+      message: err.message || 'Query failed',
+      detail: err.detail || err.message || 'Query failed',
+      code: err.code,
+      type: err.type,
+      status: err.status,
+    };
+  }
+
+  const message = summarizeErrorText(err.message || String(err));
+  const category = classifyCategory(message, null, null);
+  return {
+    label: CATEGORY_LABELS[category] || CATEGORY_LABELS.unknown,
+    category,
+    message,
+  };
+}
+
+export async function query(
+  sql,
+  {
+    cacheTtl: initialCacheTtl = null,
+    skipCache = false,
+    signal,
+  } = {},
+) {
   const params = new URLSearchParams();
 
   // Skip caching entirely for simple queries like auth check
@@ -58,6 +224,7 @@ export async function query(sql, { cacheTtl: initialCacheTtl = null, skipCache =
       Authorization: `Basic ${btoa(`${state.credentials.user}:${state.credentials.password}`)}`,
     },
     body: `${normalizedSql} FORMAT JSON`,
+    signal,
   });
   const fetchEnd = performance.now();
 
@@ -67,7 +234,8 @@ export async function query(sql, { cacheTtl: initialCacheTtl = null, skipCache =
     if (response.status === 401 || text.includes('Authentication failed') || text.includes('REQUIRED_PASSWORD')) {
       window.dispatchEvent(authErrorEvent);
     }
-    throw new Error(text);
+    const parsed = parseQueryError(text, response.status);
+    throw new QueryError(parsed.message, parsed);
   }
 
   const data = await response.json();

--- a/js/api.test.js
+++ b/js/api.test.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import {
+  QueryError,
+  classifyCategory,
+  extractErrorType,
+  getQueryErrorDetails,
+  isAbortError,
+  parseQueryError,
+  summarizeErrorText,
+} from './api.js';
+
+describe('api error helpers', () => {
+  it('summarizes long error messages', () => {
+    const longText = `Line one\n${'x'.repeat(300)}`;
+    const summary = summarizeErrorText(longText);
+    assert.isAtMost(summary.length, 200);
+    assert.ok(summary.startsWith('Line one'));
+  });
+
+  it('extracts error types from ClickHouse messages', () => {
+    const text = 'Code: 241. DB::Exception: Memory limit exceeded (MEMORY_LIMIT_EXCEEDED)';
+    assert.strictEqual(extractErrorType(text), 'MEMORY_LIMIT_EXCEEDED');
+  });
+
+  it('parses ClickHouse errors into structured data', () => {
+    const text = 'Code: 241. DB::Exception: Memory limit exceeded (MEMORY_LIMIT_EXCEEDED)';
+    const parsed = parseQueryError(text, 500);
+    assert.strictEqual(parsed.code, 241);
+    assert.strictEqual(parsed.type, 'MEMORY_LIMIT_EXCEEDED');
+    assert.strictEqual(parsed.category, 'memory');
+    assert.include(parsed.message, 'Memory limit');
+  });
+
+  it('classifies common error categories', () => {
+    const cases = [
+      {
+        text: 'DB::Exception: not enough privileges (NOT_ENOUGH_PRIVILEGES)',
+        status: 403,
+        type: 'NOT_ENOUGH_PRIVILEGES',
+        expected: 'permissions',
+      },
+      {
+        text: 'DB::Exception: memory limit exceeded (MEMORY_LIMIT_EXCEEDED)',
+        status: 500,
+        type: 'MEMORY_LIMIT_EXCEEDED',
+        expected: 'memory',
+      },
+      {
+        text: 'DB::Exception: Syntax error (SYNTAX_ERROR)',
+        status: 400,
+        type: 'SYNTAX_ERROR',
+        expected: 'syntax',
+      },
+      {
+        text: 'DB::Exception: Timeout exceeded (TIMEOUT_EXCEEDED)',
+        status: 504,
+        type: 'TIMEOUT_EXCEEDED',
+        expected: 'timeout',
+      },
+      {
+        text: 'DB::Exception: Unknown table (UNKNOWN_TABLE)',
+        status: 404,
+        type: 'UNKNOWN_TABLE',
+        expected: 'schema',
+      },
+      {
+        text: 'DB::Exception: Too many simultaneous queries (TOO_MANY_SIMULTANEOUS_QUERIES)',
+        status: 429,
+        type: 'TOO_MANY_SIMULTANEOUS_QUERIES',
+        expected: 'resource',
+      },
+      {
+        text: 'Failed to fetch',
+        status: null,
+        type: null,
+        expected: 'network',
+      },
+    ];
+
+    cases.forEach((entry) => {
+      const category = classifyCategory(entry.text, entry.status, entry.type);
+      assert.strictEqual(category, entry.expected);
+    });
+  });
+
+  it('formats QueryError details for the UI', () => {
+    const err = new QueryError('Denied', {
+      category: 'permissions',
+      code: 497,
+      type: 'ACCESS_DENIED',
+      status: 403,
+    });
+    const details = getQueryErrorDetails(err);
+    assert.strictEqual(details.label, 'Permissions');
+    assert.strictEqual(details.category, 'permissions');
+    assert.strictEqual(details.code, 497);
+    assert.strictEqual(details.type, 'ACCESS_DENIED');
+    assert.strictEqual(details.status, 403);
+  });
+
+  it('detects AbortError instances', () => {
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    assert.isTrue(isAbortError(abortError));
+
+    const details = getQueryErrorDetails(abortError);
+    assert.strictEqual(details.category, 'cancelled');
+    assert.isTrue(details.isAbort);
+  });
+});

--- a/js/breakdowns/render.js
+++ b/js/breakdowns/render.js
@@ -228,8 +228,32 @@ export function renderBreakdownTable(
   card.classList.remove('facet-hidden');
 }
 
-export function renderBreakdownError(id, _) {
+export function renderBreakdownError(id, details = {}) {
   const card = document.getElementById(id);
-  const title = card.querySelector('h3').textContent;
-  card.innerHTML = `<h3>${title}</h3><div class="empty">Error loading data</div>`;
+  const title = card.querySelector('h3')?.textContent || card.dataset.title || id;
+  const label = details.label || 'Query failed';
+  const message = details.message || 'Error loading data';
+  const detail = details.detail && details.detail !== message ? details.detail : '';
+  const metaParts = [];
+
+  if (details.code) metaParts.push(`Code ${details.code}`);
+  if (details.type) metaParts.push(details.type);
+  if (details.status) metaParts.push(`HTTP ${details.status}`);
+
+  const detailHtml = detail
+    ? `<div class="facet-error-detail">${escapeHtml(detail)}</div>`
+    : '';
+  const metaHtml = metaParts.length > 0
+    ? `<div class="facet-error-meta">${escapeHtml(metaParts.join(' | '))}</div>`
+    : '';
+
+  card.innerHTML = `
+    <h3>${escapeHtml(title)}</h3>
+    <div class="facet-error">
+      <div class="facet-error-title">${escapeHtml(label)}</div>
+      <div class="facet-error-message">${escapeHtml(message)}</div>
+      ${detailHtml}${metaHtml}
+    </div>
+    <button class="facet-hide-btn" data-action="toggle-facet-hide" data-facet="${escapeHtml(id)}" title="Hide facet"></button>
+  `;
 }

--- a/js/logs.js
+++ b/js/logs.js
@@ -513,8 +513,7 @@ export function toggleLogsView(saveStateToURL) {
 }
 
 export async function loadLogs(requestContext = getRequestContext('dashboard')) {
-  const activeContext = requestContext || getRequestContext('dashboard');
-  const { requestId, signal, scope } = activeContext;
+  const { requestId, signal, scope } = requestContext;
   const isCurrent = () => isRequestCurrent(requestId, scope);
 
   state.logsLoading = true;

--- a/js/logs.js
+++ b/js/logs.js
@@ -11,12 +11,13 @@
  */
 import { DATABASE } from './config.js';
 import { state, setOnPinnedColumnsChange } from './state.js';
-import { query } from './api.js';
+import { query, isAbortError } from './api.js';
 import { getTimeFilter, getHostFilter, getTable } from './time.js';
 import { getFacetFilters } from './breakdowns/index.js';
 import { escapeHtml } from './utils.js';
 import { formatBytes } from './format.js';
 import { getColorForColumn } from './colors/index.js';
+import { getRequestContext, isRequestCurrent } from './request-context.js';
 import { LOG_COLUMN_ORDER, LOG_COLUMN_SHORT_LABELS } from './columns.js';
 import { loadSql } from './sql-loader.js';
 import { buildLogRowHtml, buildLogTableHeaderHtml } from './templates/logs-table.js';
@@ -416,6 +417,9 @@ export function renderLogsTable(data) {
 async function loadMoreLogs() {
   if (loadingMore || !hasMoreLogs) return;
   loadingMore = true;
+  const requestContext = getRequestContext('dashboard');
+  const { requestId, signal, scope } = requestContext;
+  const isCurrent = () => isRequestCurrent(requestId, scope);
 
   const timeFilter = getTimeFilter();
   const hostFilter = getHostFilter();
@@ -433,7 +437,8 @@ async function loadMoreLogs() {
   });
 
   try {
-    const result = await query(sql);
+    const result = await query(sql, { signal });
+    if (!isCurrent()) return;
     if (result.data.length > 0) {
       state.logsData = [...state.logsData, ...result.data];
       appendLogsRows(result.data);
@@ -442,10 +447,13 @@ async function loadMoreLogs() {
     // Check if there might be more data
     hasMoreLogs = result.data.length === PAGE_SIZE;
   } catch (err) {
+    if (!isCurrent() || isAbortError(err)) return;
     // eslint-disable-next-line no-console
     console.error('Load more logs error:', err);
   } finally {
-    loadingMore = false;
+    if (isCurrent()) {
+      loadingMore = false;
+    }
   }
 }
 
@@ -504,10 +512,14 @@ export function toggleLogsView(saveStateToURL) {
   saveStateToURL();
 }
 
-export async function loadLogs() {
-  if (state.logsLoading) return;
+export async function loadLogs(requestContext = getRequestContext('dashboard')) {
+  const activeContext = requestContext || getRequestContext('dashboard');
+  const { requestId, signal, scope } = activeContext;
+  const isCurrent = () => isRequestCurrent(requestId, scope);
+
   state.logsLoading = true;
   state.logsReady = false;
+  loadingMore = false;
 
   // Reset pagination state
   logsOffset = 0;
@@ -532,7 +544,8 @@ export async function loadLogs() {
   });
 
   try {
-    const result = await query(sql);
+    const result = await query(sql, { signal });
+    if (!isCurrent()) return;
     state.logsData = result.data;
     renderLogsTable(result.data);
     state.logsReady = true;
@@ -540,11 +553,14 @@ export async function loadLogs() {
     hasMoreLogs = result.data.length === PAGE_SIZE;
     logsOffset = result.data.length;
   } catch (err) {
+    if (!isCurrent() || isAbortError(err)) return;
     // eslint-disable-next-line no-console
     console.error('Logs error:', err);
     renderLogsError(err.message);
   } finally {
-    state.logsLoading = false;
-    container.classList.remove('updating');
+    if (isCurrent()) {
+      state.logsLoading = false;
+      container.classList.remove('updating');
+    }
   }
 }

--- a/js/request-context.js
+++ b/js/request-context.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const contexts = new Map();
+
+function getContext(scope) {
+  const key = scope || 'dashboard';
+  if (!contexts.has(key)) {
+    contexts.set(key, { requestId: 0, controller: null });
+  }
+  return contexts.get(key);
+}
+
+export function startRequestContext(scope) {
+  const ctx = getContext(scope);
+  if (ctx.controller) {
+    ctx.controller.abort();
+  }
+  ctx.controller = new AbortController();
+  ctx.requestId += 1;
+  return {
+    requestId: ctx.requestId,
+    signal: ctx.controller.signal,
+    scope: scope || 'dashboard',
+  };
+}
+
+export function getRequestContext(scope) {
+  const ctx = getContext(scope);
+  return {
+    requestId: ctx.requestId,
+    signal: ctx.controller ? ctx.controller.signal : undefined,
+    scope: scope || 'dashboard',
+  };
+}
+
+export function isRequestCurrent(requestId, scope) {
+  const ctx = getContext(scope);
+  return requestId === ctx.requestId;
+}
+
+export function mergeAbortSignals(signals) {
+  const activeSignals = (signals || []).filter(Boolean);
+  if (activeSignals.length === 0) return undefined;
+  if (activeSignals.length === 1) return activeSignals[0];
+
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any(activeSignals);
+  }
+
+  const controller = new AbortController();
+  const onAbort = () => controller.abort();
+
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      controller.abort();
+      return controller.signal;
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+  }
+
+  return controller.signal;
+}

--- a/js/request-context.test.js
+++ b/js/request-context.test.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import {
+  startRequestContext,
+  getRequestContext,
+  isRequestCurrent,
+  mergeAbortSignals,
+} from './request-context.js';
+
+describe('request-context', () => {
+  it('increments requestId and aborts previous context', () => {
+    const first = startRequestContext('test');
+    assert.isFalse(first.signal.aborted);
+    assert.isTrue(isRequestCurrent(first.requestId, first.scope));
+
+    const second = startRequestContext('test');
+    assert.isTrue(first.signal.aborted);
+    assert.notStrictEqual(second.requestId, first.requestId);
+    assert.isTrue(isRequestCurrent(second.requestId, second.scope));
+    assert.isFalse(isRequestCurrent(first.requestId, first.scope));
+  });
+
+  it('returns current context for scope', () => {
+    const ctx = startRequestContext('test-read');
+    const current = getRequestContext('test-read');
+    assert.strictEqual(current.requestId, ctx.requestId);
+    assert.strictEqual(current.signal, ctx.signal);
+  });
+
+  it('merges abort signals with fallback when AbortSignal.any is unavailable', () => {
+    const originalAny = AbortSignal.any;
+    AbortSignal.any = undefined;
+    try {
+      const controllerA = new AbortController();
+      const controllerB = new AbortController();
+      const merged = mergeAbortSignals([controllerA.signal, controllerB.signal]);
+
+      assert.isFalse(merged.aborted);
+      controllerA.abort();
+      assert.isTrue(merged.aborted);
+    } finally {
+      AbortSignal.any = originalAny;
+    }
+  });
+
+  it('returns undefined for empty signal list', () => {
+    const merged = mergeAbortSignals([]);
+    assert.isUndefined(merged);
+  });
+
+  it('returns the same signal when only one is provided', () => {
+    const controller = new AbortController();
+    const merged = mergeAbortSignals([controller.signal]);
+    assert.strictEqual(merged, controller.signal);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "klickhaus",
       "version": "1.0.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "puppeteer-core": "24.36.1"
-      },
       "devDependencies": {
         "@adobe/eslint-config-helix": "^3.0.16",
         "@playwright/cli": "^0.0.63",
@@ -22,7 +19,8 @@
         "jscpd": "^4.0.5",
         "knip": "^5.82.1",
         "lint-staged": "^16.2.7",
-        "live-server": "^1.2.2"
+        "live-server": "^1.2.2",
+        "puppeteer-core": "24.36.1"
       }
     },
     "node_modules/@adobe/eslint-config-helix": {
@@ -828,6 +826,7 @@
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.2.tgz",
       "integrity": "sha512-GBY0+2lI9fDrjgb5dFL9+enKXqyOPok9PXg/69NVkjW3bikbK9RQrNrI3qccQXmDNN7ln4j/yL89Qgvj/tfqrw==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
@@ -848,6 +847,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -859,6 +859,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
       "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "dev": true,
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -872,6 +873,7 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
       "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -1285,7 +1287,8 @@
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -1509,7 +1512,7 @@
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
       "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
-      "devOptional": true,
+      "dev": true,
       "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1584,6 +1587,7 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -2201,6 +2205,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -2241,6 +2246,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2249,6 +2255,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2505,6 +2512,7 @@
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -2581,6 +2589,7 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
       "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -2618,6 +2627,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2631,6 +2641,7 @@
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.3.tgz",
       "integrity": "sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -2655,6 +2666,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
       "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "dev": true,
       "optional": true,
       "engines": {
         "bare": ">=1.14.0"
@@ -2664,6 +2676,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
@@ -2673,6 +2686,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
       "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "streamx": "^2.21.0"
@@ -2694,6 +2708,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
       "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -2765,6 +2780,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
       "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -2898,6 +2914,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -3188,6 +3205,7 @@
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.0.1.tgz",
       "integrity": "sha512-c+RLxH0Vg2x2syS9wPw378oJgiJNXtYXUvnVAldUlt5uaHekn0CCU7gPksNgHjrH1qFhmjVXQj4esvuthuC7OQ==",
+      "dev": true,
       "dependencies": {
         "mitt": "^3.0.1",
         "zod": "^3.24.1"
@@ -3334,6 +3352,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -3398,6 +3417,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3408,7 +3428,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -3657,6 +3678,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -3723,6 +3745,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3912,6 +3935,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -3971,6 +3995,7 @@
       "version": "0.0.1551306",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
       "integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
+      "dev": true,
       "peer": true
     },
     "node_modules/diff": {
@@ -4043,7 +4068,8 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -4058,6 +4084,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -4235,6 +4262,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4261,6 +4289,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -4498,6 +4527,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -4534,6 +4564,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -4549,6 +4580,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4587,6 +4619,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
       "dependencies": {
         "bare-events": "^2.7.0"
       }
@@ -4728,6 +4761,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -4752,7 +4786,8 @@
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -4898,6 +4933,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -5175,6 +5211,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -5233,6 +5270,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -5264,6 +5302,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
       "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -5604,6 +5643,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -5616,6 +5656,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -5775,6 +5816,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
       "engines": {
         "node": ">= 12"
       }
@@ -6056,6 +6098,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7226,6 +7269,7 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -7481,7 +7525,8 @@
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
@@ -7561,7 +7606,8 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/nan": {
       "version": "2.25.0",
@@ -7691,6 +7737,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -7947,6 +7994,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8154,6 +8202,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -8172,6 +8221,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -8278,7 +8328,8 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8435,6 +8486,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -8452,6 +8504,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -8469,7 +8522,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/proxy-middleware": {
       "version": "0.15.0",
@@ -8608,6 +8662,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -8626,6 +8681,8 @@
       "version": "24.36.1",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.36.1.tgz",
       "integrity": "sha512-L7ykMWc3lQf3HS7ME3PSjp7wMIjJeW6+bKfH/RSTz5l6VUDGubnrC2BKj3UvM28Y5PMDFW0xniJOZHBZPpW1dQ==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.11.2",
         "chromium-bidi": "13.0.1",
@@ -8867,6 +8924,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9622,6 +9680,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -9749,6 +9808,7 @@
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -9762,6 +9822,7 @@
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -9775,6 +9836,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9929,6 +9991,7 @@
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
       "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dev": true,
       "dependencies": {
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
@@ -9958,6 +10021,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10027,6 +10091,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10158,6 +10223,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
       "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
       "dependencies": {
         "b4a": "^1.6.4"
       }
@@ -10276,7 +10342,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -10439,7 +10506,8 @@
     "node_modules/typed-query-selector": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "dev": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -10487,7 +10555,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/union-value": {
       "version": "1.0.1",
@@ -10681,7 +10749,8 @@
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
-      "integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA=="
+      "integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -10874,6 +10943,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -10889,12 +10959,14 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10915,6 +10987,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -10939,6 +11012,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -10956,6 +11030,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -10964,6 +11039,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -10995,6 +11071,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "jscpd": "^4.0.5",
     "knip": "^5.82.1",
     "lint-staged": "^16.2.7",
-    "live-server": "^1.2.2"
+    "live-server": "^1.2.2",
+    "puppeteer-core": "24.36.1"
   },
   "keywords": [
     "clickhouse",
@@ -36,8 +37,5 @@
     "*.{js,mjs}": [
       "eslint --fix"
     ]
-  },
-  "dependencies": {
-    "puppeteer-core": "24.36.1"
   }
 }


### PR DESCRIPTION
## Summary
- Abort stale dashboard/facet requests with scoped `AbortSignal` contexts to prevent outdated results from applying.
- Classify ClickHouse query errors and show a structured facet error UI with category/details.

Fixes #81

## Testing Done
- Not run (not requested).

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)
