### PR TITLE
Add forget-me opt-out for stored credentials

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -53,8 +53,36 @@
   color: var(--text);
 }
 
+.form-option {
+  display: flex;
+  align-items: center;
+}
+
+.checkbox-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.checkbox-label input {
+  width: auto;
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+}
+
 .form-group input:focus {
   outline: none;
   border-color: var(--primary);
   box-shadow: 0 0 0 3px rgba(235, 16, 0, 0.15);
+}
+
+.checkbox-label input:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+  box-shadow: none;
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -33,6 +33,12 @@
           <label for="password">Password</label>
           <input type="password" id="password" name="password" required autocomplete="current-password">
         </div>
+        <div class="form-group form-option">
+          <label class="checkbox-label">
+            <input type="checkbox" id="forgetMe" name="forgetMe">
+            Forget me on this device
+          </label>
+        </div>
         <button type="submit" class="btn btn-primary">Sign In</button>
       </form>
     </div>

--- a/delivery.html
+++ b/delivery.html
@@ -33,6 +33,12 @@
           <label for="password">Password</label>
           <input type="password" id="password" name="password" required autocomplete="current-password">
         </div>
+        <div class="form-group form-option">
+          <label class="checkbox-label">
+            <input type="checkbox" id="forgetMe" name="forgetMe">
+            Forget me on this device
+          </label>
+        </div>
         <button type="submit" class="btn btn-primary">Sign In</button>
       </form>
     </div>

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -14,7 +14,7 @@ import {
 } from './state.js';
 import { setForceRefresh } from './api.js';
 import {
-  setElements, handleLogin, handleLogout, showDashboard,
+  setElements, handleLogin, handleLogout, showDashboard, loadStoredCredentials,
 } from './auth.js';
 import {
   loadStateFromURL, saveStateToURL, syncUIFromState, setUrlStateElements,
@@ -294,24 +294,15 @@ export function initDashboard(config = {}) {
       copyFacetTsv: copyFacetAsTsv,
     });
 
-    const stored = localStorage.getItem('clickhouse_credentials');
-    if (stored) {
-      try {
-        const creds = JSON.parse(stored);
-        if (creds && creds.user && creds.password) {
-          state.credentials = creds;
-          preloadAllTemplates();
-          syncUIFromState();
-          reorderFacets();
-          showDashboard();
-          updateTimeRangeHint();
-          loadDashboard();
-        }
-      } catch (err) {
-        localStorage.removeItem('clickhouse_credentials');
-        // eslint-disable-next-line no-console
-        console.log('Invalid credentials in localStorage');
-      }
+    const storedCredentials = loadStoredCredentials();
+    if (storedCredentials) {
+      state.credentials = storedCredentials;
+      preloadAllTemplates();
+      syncUIFromState();
+      reorderFacets();
+      showDashboard();
+      updateTimeRangeHint();
+      loadDashboard();
     }
 
     elements.loginForm.addEventListener('submit', handleLogin);


### PR DESCRIPTION
## Summary
- Add a "Forget me on this device" opt-out for login persistence.
- Store credentials in sessionStorage when opted out, otherwise keep localStorage.
- Load credentials from sessionStorage first and clear both on logout/auth errors.

## Testing Done
- Not run (not requested).

## Checklist
- [ ] Tests pass (
> klickhaus@1.0.0 test
> web-test-runner)
- [ ] Lint passes (
> klickhaus@1.0.0 lint
> eslint .


/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/breakdowns/buckets.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/breakdowns/definitions.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/breakdowns/links.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/colors/definitions.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/copy-facet.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/filter-sql.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/format.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/sql-loader.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/step-detection-multi.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/step-detection.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/templates/breakdown-table.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/templates/facet-palette-list.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/templates/facet-search-results.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/templates/filter-tags.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/templates/logs-table.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/templates/release-tooltip.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/time.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

/Users/trieloff/Developer/clickhouse-queries/.yolo/codex-1/js/utils.test.js
  12:24  error  Unable to resolve path to module 'chai'  import/no-unresolved

✖ 18 problems (18 errors, 0 warnings))
- [ ] Documentation updated (if applicable)

Fixes #83
