### PR TITLE
feat: add visual sampling indicator to time series chart

### DIFF
--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -55,6 +55,27 @@ function getSamplingConfig(highCardinality) {
   return { sampleClause: 'SAMPLE 0.1', multiplier: 10 };
 }
 
+/**
+ * Get current sampling info for UI display (chart blur/line width)
+ * @returns {{ isActive: boolean, rate: string, description: string }} - Sampling status and display info
+ */
+export function getCurrentSamplingInfo() {
+  const periodMs = getPeriodMs();
+
+  // No sampling for time ranges <= 1 hour
+  if (!periodMs || periodMs <= ONE_HOUR_MS) {
+    return { isActive: false, rate: '', description: '' };
+  }
+
+  // 1% sampling for 7d
+  if (periodMs >= 7 * 24 * ONE_HOUR_MS) {
+    return { isActive: true, rate: '1%', description: '1% sample for faster queries' };
+  }
+
+  // 10% sampling for 12h, 24h
+  return { isActive: true, rate: '10%', description: '10% sample for faster queries' };
+}
+
 export function resetFacetTimings() {
   Object.keys(facetTimings).forEach((key) => {
     delete facetTimings[key];


### PR DESCRIPTION
Apply blur and increased line width to chart lines when data sampling is active. This provides visual feedback about data precision:
- No sampling (15m, 1h): 2px lines, no blur (precise)
<img width="161" height="276" alt="Screenshot 2026-02-04 at 3 28 45 PM" src="https://github.com/user-attachments/assets/64239471-8931-444e-923a-b15989df9927" />

- 10% sampling (12h, 24h): 3px lines, 1.5px blur (approximate)
<img width="162" height="277" alt="Screenshot 2026-02-04 at 3 28 26 PM" src="https://github.com/user-attachments/assets/3f921f17-f3ea-4616-95bf-3d9b0f407ef8" />

- 1% sampling (7d): 4px lines, 3px blur (highly sampled)
<img width="178" height="284" alt="Screenshot 2026-02-04 at 3 28 02 PM" src="https://github.com/user-attachments/assets/5918fc23-ca43-4e7c-bb86-a6265de86598" />


Added getCurrentSamplingInfo() function to expose sampling status for UI use.

## Summary
<!-- What does this PR do? -->

## Testing Done
<!-- How did you verify this works? -->

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)
