### PR TITLE
feat: progressive facet sampling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ Fastly Backend Services ─► fastly_logs_incoming_<service_id> ──► fastl
 - `cdn_requests_v2_sampled_1` (1% sample via `sample_hash % 100`, 200-week TTL)
 
 IP-related columns (`client.ip`, `cdn.originating_ip`, `request.headers.*_ip`) are stored as `(withheld)` in sampled tables to avoid retaining PII with extended TTLs.
+Sampled tables rebuild facet projections with hourly buckets to keep projection size and query cost down (see `sql/cdn_requests_v2_sampling.sql`).
 
 ### Fastly Backend Services (per-service logging)
 

--- a/css/chart.css
+++ b/css/chart.css
@@ -21,6 +21,18 @@
   height: 250px;
 }
 
+.chart-refine {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 12;
+  pointer-events: none;
+}
+
+.chart-refine .refine-sample-btn {
+  pointer-events: auto;
+}
+
 #chart {
   width: 100%;
   height: 100%;
@@ -264,4 +276,3 @@
   display: flex;
   align-items: center;
 }
-

--- a/css/facets.css
+++ b/css/facets.css
@@ -188,13 +188,35 @@
   font-weight: 500;
 }
 
+.refine-sample-btn {
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  line-height: 1;
+  font-weight: 600;
+}
+
 .copy-facet-btn:hover {
   background: var(--bg);
   border-color: var(--border);
   color: var(--text);
 }
 
+.refine-sample-btn:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
 .copy-facet-btn:active {
+  transform: scale(0.95);
+}
+
+.refine-sample-btn:active {
   transform: scale(0.95);
 }
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -79,6 +79,9 @@
         <h2>Requests over time</h2>
         <div class="chart-container">
           <canvas id="chart"></canvas>
+          <div class="chart-refine">
+            <button id="chartRefineBtn" class="refine-sample-btn" data-action="refine-chart-sampling" hidden>Load more data</button>
+          </div>
         </div>
       </section>
 

--- a/js/api.js
+++ b/js/api.js
@@ -196,6 +196,8 @@ export async function query(
   } = {},
 ) {
   const params = new URLSearchParams();
+  params.set('max_execution_time', '30');
+  params.set('timeout_before_checking_execution_speed', '0');
 
   // Skip caching entirely for simple queries like auth check
   if (!skipCache) {

--- a/js/api.js
+++ b/js/api.js
@@ -15,6 +15,7 @@ import { state } from './state.js';
 
 // Force refresh state - set by dashboard when refresh button is clicked
 const refreshState = { force: false };
+const DEFAULT_MAX_EXECUTION_TIME = 10;
 
 export function isForceRefresh() {
   return refreshState.force;
@@ -194,10 +195,14 @@ export async function query(
     cacheTtl: initialCacheTtl = null,
     skipCache = false,
     signal,
+    maxExecutionTime = DEFAULT_MAX_EXECUTION_TIME,
   } = {},
 ) {
   const params = new URLSearchParams();
-  params.set('max_execution_time', '10');
+  const executionTime = Number.isFinite(maxExecutionTime)
+    ? maxExecutionTime
+    : DEFAULT_MAX_EXECUTION_TIME;
+  params.set('max_execution_time', String(executionTime));
   params.set('timeout_before_checking_execution_speed', '0');
 
   // Skip caching entirely for simple queries like auth check

--- a/js/api.js
+++ b/js/api.js
@@ -93,6 +93,7 @@ export function classifyCategory(text, status, type) {
   ].some(Boolean);
   if (isPermissions) return 'permissions';
 
+  if (status === 408 || status === 504 || status === 524) return 'timeout';
   if (type === 'MEMORY_LIMIT_EXCEEDED' || lower.includes('memory limit')) return 'memory';
   if (type === 'SYNTAX_ERROR' || lower.includes('syntax error')) return 'syntax';
   if (type === 'TIMEOUT_EXCEEDED' || lower.includes('timeout')) return 'timeout';
@@ -196,7 +197,7 @@ export async function query(
   } = {},
 ) {
   const params = new URLSearchParams();
-  params.set('max_execution_time', '30');
+  params.set('max_execution_time', '10');
   params.set('timeout_before_checking_execution_speed', '0');
 
   // Skip caching entirely for simple queries like auth check

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -62,7 +62,6 @@ function getSamplingConfig(sampleRate) {
     sampleRate: rate,
     multiplier,
     table: getSampledTable(rate),
-    sampleClause: '',
   };
 }
 
@@ -214,7 +213,6 @@ async function appendMissingFilteredValues(data, b, col, aggs, queryParams, requ
     agg5xx: aggs.agg5xx,
     database: DATABASE,
     table: queryParams.table,
-    sampleClause: queryParams.sampleClause,
     timeFilter: queryParams.timeFilter,
     hostFilter: queryParams.hostFilter,
     extra: queryParams.extra,
@@ -254,7 +252,7 @@ function buildBreakdownQueryParams(b, col, timeFilter, hostFilter, sampleRateOve
   const mode = b.modeToggle ? state[b.modeToggle] : 'count';
   const isBytes = mode === 'bytes';
   const {
-    sampleRate, sampleClause, multiplier, table,
+    sampleRate, multiplier, table,
   } = getSamplingConfig(sampleRateOverride);
   const mult = multiplier > 1 ? ` * ${multiplier}` : '';
 
@@ -264,7 +262,6 @@ function buildBreakdownQueryParams(b, col, timeFilter, hostFilter, sampleRateOve
     hasActiveFilter,
     isBytes,
     sampleRate,
-    sampleClause,
     mult,
     table,
     extra: b.extraFilter || '',
@@ -311,7 +308,6 @@ async function runBreakdownStage(b, params, timeFilter, hostFilter, requestStatu
     summaryCol: summaryColWithMult,
     database: DATABASE,
     table: params.table,
-    sampleClause: params.sampleClause,
     timeFilter,
     hostFilter,
     facetFilters: params.facetFilters,

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -14,7 +14,12 @@ import { state } from '../state.js';
 import { query, getQueryErrorDetails, isAbortError } from '../api.js';
 import { getRequestContext, isRequestCurrent, mergeAbortSignals } from '../request-context.js';
 import {
-  getTimeFilter, getHostFilter, getPeriodMs, getSampledTable, getSelectedRange,
+  getTimeFilter,
+  getHostFilter,
+  getPeriodMs,
+  getSampledTable,
+  getSelectedRange,
+  normalizeSampleRate,
 } from '../time.js';
 import { allBreakdowns } from './definitions.js';
 import { renderBreakdownTable, renderBreakdownError, getNextTopN } from './render.js';
@@ -51,7 +56,7 @@ function getSamplingPlan(highCardinality) {
 }
 
 function getSamplingConfig(sampleRate) {
-  const rate = sampleRate || 1;
+  const rate = normalizeSampleRate(sampleRate);
   const multiplier = rate < 1 ? Math.round(1 / rate) : 1;
   return {
     sampleRate: rate,

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -99,25 +99,6 @@ function setFacetSampleRate(facetId, sampleRate) {
   updateGlobalSampleRate(getInitialSamplingRate());
 }
 
-/**
- * Get current sampling info for UI display (chart blur/line width).
- * @returns {{ isActive: boolean, rate: string, description: string }}
- * Sampling status and display info.
- */
-export function getCurrentSamplingInfo() {
-  const rate = normalizeSampleRate(state.sampleRate);
-  if (!rate || rate >= 1) {
-    return { isActive: false, rate: '', description: '' };
-  }
-
-  const percentage = `${Math.round(rate * 100)}%`;
-  return {
-    isActive: true,
-    rate: percentage,
-    description: `${percentage} sample for faster queries`,
-  };
-}
-
 export function resetFacetTimings() {
   Object.keys(facetTimings).forEach((key) => {
     delete facetTimings[key];

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -365,7 +365,6 @@ async function runSamplingStages({
   card,
   baseCol,
   samplingPlan,
-  timeFilter,
   hostFilter,
   requestStatus,
   signal,
@@ -415,6 +414,7 @@ async function runSamplingStages({
   for (let idx = 0; idx < samplingPlan.length; idx += 1) {
     const sampleRate = samplingPlan[idx];
     if (!isCurrent()) return hasRendered;
+    const timeFilter = getTimeFilter(sampleRate);
     const params = buildBreakdownQueryParams(
       breakdown,
       baseCol,
@@ -467,13 +467,7 @@ async function runSamplingStages({
   return hasRendered;
 }
 
-export async function loadBreakdown(
-  b,
-  timeFilter,
-  hostFilter,
-  requestContext = null,
-  options = {},
-) {
+export async function loadBreakdown(b, hostFilter, requestContext = null, options = {}) {
   const requestStatus = createRequestStatus(requestContext);
   const card = document.getElementById(b.id);
 
@@ -489,7 +483,6 @@ export async function loadBreakdown(
       card,
       baseCol,
       samplingPlan,
-      timeFilter,
       hostFilter,
       requestStatus,
       signal: requestStatus.signal,
@@ -503,11 +496,10 @@ export async function loadBreakdown(
 }
 
 export async function loadAllBreakdowns(requestContext = getRequestContext('facets')) {
-  const timeFilter = getTimeFilter();
   const hostFilter = getHostFilter();
   updateGlobalSampleRate(getInitialSamplingRate());
   await Promise.all(
-    allBreakdowns.map((b) => loadBreakdown(b, timeFilter, hostFilter, requestContext)),
+    allBreakdowns.map((b) => loadBreakdown(b, hostFilter, requestContext)),
   );
 }
 
@@ -565,10 +557,9 @@ export async function refineFacetSampling(facetId, targetSampleRate = null) {
   );
   if (startIndex === -1) return;
 
-  const timeFilter = getTimeFilter();
   const hostFilter = getHostFilter();
   const context = startRequestContext(`facet-${facetId}`);
-  await loadBreakdown(breakdown, timeFilter, hostFilter, context, {
+  await loadBreakdown(breakdown, hostFilter, context, {
     samplingPlan: samplingPlan.slice(startIndex),
     disableTimeouts: true,
   });

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -82,6 +82,27 @@ function setFacetSampleRate(facetId, sampleRate) {
   updateGlobalSampleRate(getRetentionSampleLimit());
 }
 
+/**
+ * Get current sampling info for UI display (chart blur/line width)
+ * @returns {{ isActive: boolean, rate: string, description: string }} - Sampling status and display info
+ */
+export function getCurrentSamplingInfo() {
+  const periodMs = getPeriodMs();
+
+  // No sampling for time ranges <= 1 hour
+  if (!periodMs || periodMs <= ONE_HOUR_MS) {
+    return { isActive: false, rate: '', description: '' };
+  }
+
+  // 1% sampling for 7d
+  if (periodMs >= 7 * 24 * ONE_HOUR_MS) {
+    return { isActive: true, rate: '1%', description: '1% sample for faster queries' };
+  }
+
+  // 10% sampling for 12h, 24h
+  return { isActive: true, rate: '10%', description: '10% sample for faster queries' };
+}
+
 export function resetFacetTimings() {
   Object.keys(facetTimings).forEach((key) => {
     delete facetTimings[key];

--- a/js/chart-sampling.js
+++ b/js/chart-sampling.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { normalizeSampleRate, getSampledTable } from './time.js';
+
+let chartNextSampleRate = null;
+
+export function isChartTimeoutError(err) {
+  return err?.category === 'timeout' || err?.type === 'TIMEOUT_EXCEEDED';
+}
+
+export function getChartSamplingConfig(sampleRate) {
+  const rate = normalizeSampleRate(sampleRate);
+  const multiplier = rate < 1 ? Math.round(1 / rate) : 1;
+  return {
+    table: getSampledTable(rate),
+    mult: multiplier > 1 ? ` * ${multiplier}` : '',
+  };
+}
+
+function formatSampleRateLabel(rate) {
+  const normalizedRate = normalizeSampleRate(rate);
+  if (!Number.isFinite(normalizedRate)) return '';
+  if (normalizedRate >= 1) return 'full';
+  return `${Math.round(normalizedRate * 100)}%`;
+}
+
+export function setChartRefineTarget(nextSampleRate = null) {
+  chartNextSampleRate = Number.isFinite(nextSampleRate)
+    ? normalizeSampleRate(nextSampleRate)
+    : null;
+  const button = document.getElementById('chartRefineBtn');
+  if (!button) return;
+
+  if (!Number.isFinite(chartNextSampleRate)) {
+    button.hidden = true;
+    button.removeAttribute('data-sample-rate');
+    return;
+  }
+
+  const label = formatSampleRateLabel(chartNextSampleRate);
+  const text = label === 'full' ? 'Load full data' : `Load ${label} data`;
+  button.textContent = text;
+  button.title = `${text} without a timeout`;
+  button.hidden = false;
+  button.dataset.sampleRate = String(chartNextSampleRate);
+}
+
+export function getChartRefineTarget() {
+  return chartNextSampleRate;
+}

--- a/js/chart.js
+++ b/js/chart.js
@@ -901,7 +901,6 @@ export function setupChartNavigation(callback) {
 export async function loadTimeSeries(requestContext = getRequestContext('dashboard'), options = {}) {
   const { requestId, signal, scope } = requestContext;
   const isCurrent = () => isRequestCurrent(requestId, scope);
-  const timeFilter = getTimeFilter();
   const hostFilter = getHostFilter();
   const facetFilters = getFacetFilters();
   const bucket = getTimeBucket();
@@ -921,6 +920,7 @@ export async function loadTimeSeries(requestContext = getRequestContext('dashboa
   for (let idx = 0; idx < samplingPlan.length; idx += 1) {
     const sampleRate = samplingPlan[idx];
     if (!isCurrent()) return;
+    const timeFilter = getTimeFilter(sampleRate);
     const { table, mult } = getChartSamplingConfig(sampleRate);
     const maxExecutionTime = getSampleRateTimeout(sampleRate, { disableTimeouts });
     // Progressive refinement requires sequential queries.

--- a/js/chart.js
+++ b/js/chart.js
@@ -240,8 +240,9 @@ function drawAnomalyHighlight(ctx, step, data, chartDimensions, getX, getY, stac
 
 /**
  * Draw a stacked area with line on top
- * @param {number[]} [lineDash] - Optional dash array for stroke (e.g. [6, 4] dashed, [2, 2] dotted). Omit or [] for solid.
- */
+ * @param {number[]} [lineDash] - Optional dash array for stroke
+ * (e.g. [6, 4] dashed, [2, 2] dotted). Omit or [] for solid.
+*/
 function drawStackedArea(ctx, data, getX, getY, topStack, bottomStack, colors, lineDash = []) {
   if (!topStack.some((v, i) => v > bottomStack[i])) return;
 
@@ -357,7 +358,10 @@ export function renderChart(data) {
 
   // Line style based on sampling: solid (no sampling), dashed (10%), dotted (1%)
   const samplingInfo = getCurrentSamplingInfo();
-  const lineDash = !samplingInfo.isActive ? [] : samplingInfo.rate === '1%' ? [2, 2] : [6, 4];
+  let lineDash = [];
+  if (samplingInfo.isActive) {
+    lineDash = samplingInfo.rate === '1%' ? [2, 2] : [6, 4];
+  }
 
   drawStackedArea(ctx, data, getX, getY, stackedOk, stackedClient, colors.ok, lineDash);
   drawStackedArea(ctx, data, getX, getY, stackedClient, stackedServer, colors.client, lineDash);

--- a/js/chart.js
+++ b/js/chart.js
@@ -16,7 +16,7 @@
  */
 
 import { query, isAbortError } from './api.js';
-import { getFacetFilters } from './breakdowns/index.js';
+import { getFacetFilters, getCurrentSamplingInfo, getSamplingPlan } from './breakdowns/index.js';
 import { DATABASE } from './config.js';
 import { formatNumber } from './format.js';
 import { getRequestContext, isRequestCurrent } from './request-context.js';
@@ -24,10 +24,11 @@ import { state } from './state.js';
 import { detectSteps } from './step-detection.js';
 import {
   getHostFilter,
-  getTable,
+  getSampledTable,
   getTimeBucket,
   getTimeBucketStep,
   getTimeFilter,
+  normalizeSampleRate,
   setCustomTimeRange,
   getTimeRangeBounds,
   getTimeRangeStart,
@@ -65,6 +66,15 @@ import {
   hexToRgba,
   parseUTC,
 } from './chart-state.js';
+
+function getSamplingConfig(sampleRate) {
+  const rate = normalizeSampleRate(sampleRate);
+  const multiplier = rate < 1 ? Math.round(1 / rate) : 1;
+  return {
+    table: getSampledTable(rate),
+    mult: multiplier > 1 ? ` * ${multiplier}` : '',
+  };
+}
 
 // Re-export state functions for external use
 export {
@@ -231,7 +241,7 @@ function drawAnomalyHighlight(ctx, step, data, chartDimensions, getX, getY, stac
 /**
  * Draw a stacked area with line on top
  */
-function drawStackedArea(ctx, data, getX, getY, topStack, bottomStack, colors) {
+function drawStackedArea(ctx, data, getX, getY, topStack, bottomStack, colors, lineWidth = 2) {
   if (!topStack.some((v, i) => v > bottomStack[i])) return;
 
   ctx.beginPath();
@@ -246,7 +256,7 @@ function drawStackedArea(ctx, data, getX, getY, topStack, bottomStack, colors) {
   ctx.moveTo(getX(0), getY(topStack[0]));
   for (let i = 1; i < data.length; i += 1) ctx.lineTo(getX(i), getY(topStack[i]));
   ctx.strokeStyle = colors.line;
-  ctx.lineWidth = 2;
+  ctx.lineWidth = lineWidth;
   ctx.stroke();
 }
 
@@ -342,9 +352,22 @@ export function renderChart(data) {
   const stackedOk = series.server.map((v, i) => v + series.client[i] + series.ok[i]);
   const zeros = new Array(data.length).fill(0);
 
-  drawStackedArea(ctx, data, getX, getY, stackedOk, stackedClient, colors.ok);
-  drawStackedArea(ctx, data, getX, getY, stackedClient, stackedServer, colors.client);
-  drawStackedArea(ctx, data, getX, getY, stackedServer, zeros, colors.server);
+  // Apply blur and thicker lines based on sampling rate
+  const samplingInfo = getCurrentSamplingInfo();
+  let lineWidth = 2; // Default line width
+  if (samplingInfo.isActive) {
+    // 1% sampling = more blur and thicker, 10% sampling = slight blur and slightly thicker
+    const blurAmount = samplingInfo.rate === '1%' ? 3 : 1.5;
+    lineWidth = samplingInfo.rate === '1%' ? 4 : 3;
+    ctx.filter = `blur(${blurAmount}px)`;
+  }
+
+  drawStackedArea(ctx, data, getX, getY, stackedOk, stackedClient, colors.ok, lineWidth);
+  drawStackedArea(ctx, data, getX, getY, stackedClient, stackedServer, colors.client, lineWidth);
+  drawStackedArea(ctx, data, getX, getY, stackedServer, zeros, colors.server, lineWidth);
+
+  // Reset filter for other elements
+  ctx.filter = 'none';
 
   // Detect anomalies (skip for ranges < 5 minutes)
   const lastIdx = data.length - 1;
@@ -916,28 +939,44 @@ export async function loadTimeSeries(requestContext = getRequestContext('dashboa
   const step = getTimeBucketStep();
   const rangeStart = getTimeRangeStart();
   const rangeEnd = getTimeRangeEnd();
+  const samplingPlan = getSamplingPlan();
 
-  const sql = await loadSql('time-series', {
-    bucket,
-    database: DATABASE,
-    table: getTable(),
-    timeFilter,
-    hostFilter,
-    facetFilters,
-    additionalWhereClause: state.additionalWhereClause,
-    rangeStart,
-    rangeEnd,
-    step,
-  });
-
-  try {
-    const result = await query(sql, { signal });
+  for (const sampleRate of samplingPlan) {
     if (!isCurrent()) return;
-    state.chartData = result.data;
-    renderChart(result.data);
-  } catch (err) {
-    if (!isCurrent() || isAbortError(err)) return;
-    // eslint-disable-next-line no-console
-    console.error('Chart error:', err);
+    const { table, mult } = getSamplingConfig(sampleRate);
+    // Progressive refinement requires sequential queries.
+    // eslint-disable-next-line no-await-in-loop
+    const sql = await loadSql('time-series', {
+      bucket,
+      database: DATABASE,
+      table,
+      timeFilter,
+      hostFilter,
+      facetFilters,
+      additionalWhereClause: state.additionalWhereClause,
+      rangeStart,
+      rangeEnd,
+      step,
+      mult,
+    });
+
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await query(sql, { signal });
+      if (!isCurrent()) return;
+      state.chartData = result.data;
+      renderChart(result.data);
+    } catch (err) {
+      if (!isCurrent() || isAbortError(err)) return;
+      // eslint-disable-next-line no-console
+      console.error('Chart error:', err);
+      return;
+    }
   }
 }
+
+window.addEventListener('sample-rate-change', () => {
+  if (state.chartData) {
+    renderChart(state.chartData);
+  }
+});

--- a/js/chart.js
+++ b/js/chart.js
@@ -16,7 +16,12 @@
  */
 
 import { query, isAbortError } from './api.js';
-import { getFacetFilters, getCurrentSamplingInfo, getSamplingPlan } from './breakdowns/index.js';
+import {
+  getFacetFilters,
+  getCurrentSamplingInfo,
+  getSamplingPlan,
+  setTimelineSampleRate,
+} from './breakdowns/index.js';
 import { DATABASE } from './config.js';
 import { formatNumber } from './format.js';
 import { getRequestContext, isRequestCurrent } from './request-context.js';
@@ -938,9 +943,13 @@ export async function loadTimeSeries(requestContext = getRequestContext('dashboa
   const rangeStart = getTimeRangeStart();
   const rangeEnd = getTimeRangeEnd();
   const samplingPlan = getSamplingPlan();
+  if (samplingPlan.length > 0) {
+    setTimelineSampleRate(samplingPlan[0]);
+  }
 
   for (const sampleRate of samplingPlan) {
     if (!isCurrent()) return;
+    setTimelineSampleRate(sampleRate);
     const { table, mult } = getSamplingConfig(sampleRate);
     // Progressive refinement requires sequential queries.
     // eslint-disable-next-line no-await-in-loop

--- a/js/chart.js
+++ b/js/chart.js
@@ -264,23 +264,6 @@ function drawStackedArea(ctx, data, getX, getY, topStack, bottomStack, colors, l
   ctx.setLineDash([]);
 }
 
-function getChartSamplingConfig() {
-  const { start } = getSelectedRange();
-  const ageMs = Math.max(0, Date.now() - start.getTime());
-  const TWO_WEEKS_MS = 14 * 24 * 60 * 60 * 1000;
-  const TWENTY_WEEKS_MS = 20 * 7 * 24 * 60 * 60 * 1000;
-  let rate = SAMPLE_RATES.full;
-  if (ageMs >= TWENTY_WEEKS_MS) rate = SAMPLE_RATES.onePercent;
-  else if (ageMs >= TWO_WEEKS_MS) rate = SAMPLE_RATES.tenPercent;
-  rate = normalizeSampleRate(rate);
-  const multiplier = rate < 1 ? Math.round(1 / rate) : 1;
-  return {
-    table: getSampledTable(rate),
-    mult: multiplier > 1 ? ` * ${multiplier}` : '',
-    sampleRate: rate,
-  };
-}
-
 export function renderChart(data) {
   setLastChartData(data);
   resetAnomalyBounds();
@@ -374,11 +357,10 @@ export function renderChart(data) {
   const zeros = new Array(data.length).fill(0);
 
   // Line style based on sampling: solid (no sampling), dashed (10%), dotted (1%)
-  const chartSampling = getChartSamplingConfig();
+  const samplingInfo = getCurrentSamplingInfo();
   let lineDash = [];
-  if (chartSampling.sampleRate < SAMPLE_RATES.full) {
-    lineDash = chartSampling.sampleRate <= SAMPLE_RATES.onePercent
-      ? [2, 2] : [6, 4];
+  if (samplingInfo.isActive) {
+    lineDash = samplingInfo.rate === '1%' ? [2, 2] : [6, 4];
   }
 
   drawStackedArea(ctx, data, getX, getY, stackedOk, stackedClient, colors.ok, lineDash);

--- a/js/chart.js
+++ b/js/chart.js
@@ -240,8 +240,9 @@ function drawAnomalyHighlight(ctx, step, data, chartDimensions, getX, getY, stac
 
 /**
  * Draw a stacked area with line on top
+ * @param {number[]} [lineDash] - Optional dash array for stroke (e.g. [6, 4] dashed, [2, 2] dotted). Omit or [] for solid.
  */
-function drawStackedArea(ctx, data, getX, getY, topStack, bottomStack, colors, lineWidth = 2) {
+function drawStackedArea(ctx, data, getX, getY, topStack, bottomStack, colors, lineDash = []) {
   if (!topStack.some((v, i) => v > bottomStack[i])) return;
 
   ctx.beginPath();
@@ -256,8 +257,10 @@ function drawStackedArea(ctx, data, getX, getY, topStack, bottomStack, colors, l
   ctx.moveTo(getX(0), getY(topStack[0]));
   for (let i = 1; i < data.length; i += 1) ctx.lineTo(getX(i), getY(topStack[i]));
   ctx.strokeStyle = colors.line;
-  ctx.lineWidth = lineWidth;
+  ctx.lineWidth = 2;
+  ctx.setLineDash(lineDash);
   ctx.stroke();
+  ctx.setLineDash([]);
 }
 
 export function renderChart(data) {
@@ -352,22 +355,13 @@ export function renderChart(data) {
   const stackedOk = series.server.map((v, i) => v + series.client[i] + series.ok[i]);
   const zeros = new Array(data.length).fill(0);
 
-  // Apply blur and thicker lines based on sampling rate
+  // Line style based on sampling: solid (no sampling), dashed (10%), dotted (1%)
   const samplingInfo = getCurrentSamplingInfo();
-  let lineWidth = 2; // Default line width
-  if (samplingInfo.isActive) {
-    // 1% sampling = more blur and thicker, 10% sampling = slight blur and slightly thicker
-    const blurAmount = samplingInfo.rate === '1%' ? 3 : 1.5;
-    lineWidth = samplingInfo.rate === '1%' ? 4 : 3;
-    ctx.filter = `blur(${blurAmount}px)`;
-  }
+  const lineDash = !samplingInfo.isActive ? [] : samplingInfo.rate === '1%' ? [2, 2] : [6, 4];
 
-  drawStackedArea(ctx, data, getX, getY, stackedOk, stackedClient, colors.ok, lineWidth);
-  drawStackedArea(ctx, data, getX, getY, stackedClient, stackedServer, colors.client, lineWidth);
-  drawStackedArea(ctx, data, getX, getY, stackedServer, zeros, colors.server, lineWidth);
-
-  // Reset filter for other elements
-  ctx.filter = 'none';
+  drawStackedArea(ctx, data, getX, getY, stackedOk, stackedClient, colors.ok, lineDash);
+  drawStackedArea(ctx, data, getX, getY, stackedClient, stackedServer, colors.client, lineDash);
+  drawStackedArea(ctx, data, getX, getY, stackedServer, zeros, colors.server, lineDash);
 
   // Detect anomalies (skip for ranges < 5 minutes)
   const lastIdx = data.length - 1;

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -22,7 +22,7 @@ import {
 } from './url-state.js';
 import {
   queryTimestamp, setQueryTimestamp, clearCustomTimeRange, isCustomTimeRange,
-  getTimeFilter, getHostFilter,
+  getTimeFilter, getHostFilter, normalizeSampleRate,
 } from './time.js';
 import {
   startQueryTimer, stopQueryTimer, hasVisibleUpdatingFacets, initFacetObservers,
@@ -126,7 +126,7 @@ export function initDashboard(config = {}) {
     const anomalies = getDetectedAnomalies();
     const chartData = getLastChartData();
 
-    if (anomalies.length > 0 && chartData) {
+    if (anomalies.length > 0 && chartData && normalizeSampleRate(state.sampleRate) >= 1) {
       const hasCache = hasCachedInvestigation();
 
       if (hasCache) {

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -30,9 +30,15 @@ import {
 import {
   loadTimeSeries, setupChartNavigation, getDetectedAnomalies, getLastChartData,
   renderChart,
+  refineChartSampling,
 } from './chart.js';
 import {
-  loadAllBreakdowns, loadBreakdown, allBreakdowns, markSlowestFacet, resetFacetTimings,
+  loadAllBreakdowns,
+  loadBreakdown,
+  allBreakdowns,
+  markSlowestFacet,
+  resetFacetTimings,
+  refineFacetSampling,
 } from './breakdowns/index.js';
 import { getNextTopN } from './breakdowns/render.js';
 import {
@@ -307,6 +313,8 @@ export function initDashboard(config = {}) {
       toggleFacetPin: togglePinnedFacet,
       toggleFacetHide: toggleHiddenFacet,
       toggleFacetMode,
+      refineFacetSampling,
+      refineChartSampling,
       closeQuickLinksModal,
       closeDialog: (el) => el.closest('dialog')?.close(),
       openFacetSearch,

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -22,7 +22,7 @@ import {
 } from './url-state.js';
 import {
   queryTimestamp, setQueryTimestamp, clearCustomTimeRange, isCustomTimeRange,
-  getTimeFilter, getHostFilter, normalizeSampleRate,
+  getHostFilter, normalizeSampleRate,
 } from './time.js';
 import {
   startQueryTimer, stopQueryTimer, hasVisibleUpdatingFacets, initFacetObservers,
@@ -99,7 +99,7 @@ export function initDashboard(config = {}) {
   setLogsElements(elements.logsView, elements.viewToggleBtn, elements.filtersView);
 
   // Load dashboard queries (chart and facets)
-  async function loadDashboardQueries(timeFilter, hostFilter, dashboardContext, facetsContext) {
+  async function loadDashboardQueries(hostFilter, dashboardContext, facetsContext) {
     const timeSeriesPromise = loadTimeSeries(dashboardContext);
     const focusedFacetId = getFocusedFacetId();
     const isDashboardCurrent = () => isRequestCurrent(
@@ -109,7 +109,7 @@ export function initDashboard(config = {}) {
     const isFacetsCurrent = () => isRequestCurrent(facetsContext.requestId, facetsContext.scope);
 
     const facetPromises = allBreakdowns.map(
-      (b) => loadBreakdown(b, timeFilter, hostFilter, facetsContext).then(() => {
+      (b) => loadBreakdown(b, hostFilter, facetsContext).then(() => {
         if (!isFacetsCurrent()) return;
         if (!hasVisibleUpdatingFacets()) {
           stopQueryTimer();
@@ -187,14 +187,13 @@ export function initDashboard(config = {}) {
     startQueryTimer();
     resetFacetTimings();
 
-    const timeFilter = getTimeFilter();
     const hostFilter = getHostFilter();
 
     if (state.showLogs) {
       await loadLogs(dashboardContext);
-      loadDashboardQueries(timeFilter, hostFilter, dashboardContext, facetsContext);
+      loadDashboardQueries(hostFilter, dashboardContext, facetsContext);
     } else {
-      await loadDashboardQueries(timeFilter, hostFilter, dashboardContext, facetsContext);
+      await loadDashboardQueries(hostFilter, dashboardContext, facetsContext);
       loadLogs(dashboardContext);
     }
 
@@ -237,10 +236,9 @@ export function initDashboard(config = {}) {
     if (toggledFacetId) {
       const breakdown = allBreakdowns.find((b) => b.id === toggledFacetId);
       if (breakdown) {
-        const timeFilter = getTimeFilter();
         const hostFilter = getHostFilter();
         const facetsContext = startRequestContext(`facet:${breakdown.id}`);
-        loadBreakdown(breakdown, timeFilter, hostFilter, facetsContext);
+        loadBreakdown(breakdown, hostFilter, facetsContext);
       }
     }
   }
@@ -262,12 +260,11 @@ export function initDashboard(config = {}) {
     state[stateKey] = state[stateKey] === 'count' ? 'bytes' : 'count';
     saveStateToURL();
 
-    const timeFilter = getTimeFilter();
     const hostFilter = getHostFilter();
     const breakdowns = allBreakdowns.filter((b) => b.modeToggle === stateKey);
     for (const breakdown of breakdowns) {
       const facetsContext = startRequestContext(`facet:${breakdown.id}`);
-      loadBreakdown(breakdown, timeFilter, hostFilter, facetsContext);
+      loadBreakdown(breakdown, hostFilter, facetsContext);
     }
   }
 

--- a/js/investigation-data.js
+++ b/js/investigation-data.js
@@ -18,7 +18,12 @@
 import { query } from './api.js';
 import { DATABASE } from './config.js';
 import { state } from './state.js';
-import { getTable, getHostFilter, getTimeFilter } from './time.js';
+import {
+  getTable,
+  getHostFilter,
+  getTimeFilter,
+  getSampleRateTimeout,
+} from './time.js';
 import { getFacetFilters } from './breakdowns/index.js';
 import { compileFilters, isFilterSuperset } from './filter-sql.js';
 import { loadSql } from './sql-loader.js';
@@ -426,7 +431,10 @@ export async function investigateFacet(breakdown, anomaly, fullStart, fullEnd) {
   });
 
   try {
-    const result = await query(sql, { cacheTtl: 60 });
+    const result = await query(sql, {
+      cacheTtl: 60,
+      maxExecutionTime: getSampleRateTimeout(state.sampleRate),
+    });
 
     // Calculate anomaly and baseline durations in ms
     const anomalyDurationMs = anomaly.endTime - anomaly.startTime;
@@ -548,7 +556,10 @@ export async function investigateFacetForSelection(breakdown, selection, fullSta
   });
 
   try {
-    const result = await query(sql, { cacheTtl: 60 });
+    const result = await query(sql, {
+      cacheTtl: 60,
+      maxExecutionTime: getSampleRateTimeout(state.sampleRate),
+    });
 
     // Calculate durations for rate normalization
     const selectionDurationMs = selection.endTime - selection.startTime;

--- a/js/logs.js
+++ b/js/logs.js
@@ -430,7 +430,7 @@ async function loadMoreLogs() {
   const { requestId, signal, scope } = requestContext;
   const isCurrent = () => isRequestCurrent(requestId, scope);
 
-  const timeFilter = getTimeFilter();
+  const timeFilter = getTimeFilter(logsSampleRate);
   const hostFilter = getHostFilter();
   const facetFilters = getFacetFilters();
   const table = logsTable || getSampledTable(logsSampleRate);
@@ -542,7 +542,7 @@ export async function loadLogs(requestContext = getRequestContext('dashboard')) 
   const container = logsView.querySelector('.logs-table-container');
   container.classList.add('updating');
 
-  const timeFilter = getTimeFilter();
+  const timeFilter = getTimeFilter(logsSampleRate);
   const hostFilter = getHostFilter();
   const facetFilters = getFacetFilters();
 

--- a/js/state.js
+++ b/js/state.js
@@ -24,6 +24,7 @@ export const state = {
   timeRange: DEFAULT_TIME_RANGE,
   hostFilter: '',
   topN: DEFAULT_TOP_N,
+  sampleRate: 1,
   filters: [], // [{col: '`request.url`', value: '/foo', exclude: false}]
   logsData: null,
   logsLoading: false,

--- a/js/time.js
+++ b/js/time.js
@@ -176,6 +176,14 @@ export function getSampledTable(sampleRate) {
   return BASE_TABLE;
 }
 
+export function getSampleRateTimeout(sampleRate, { disableTimeouts = false } = {}) {
+  if (disableTimeouts) return 0;
+  const normalizedRate = normalizeSampleRate(sampleRate);
+  if (normalizedRate <= SAMPLE_RATES.onePercent) return 10;
+  if (normalizedRate <= SAMPLE_RATES.tenPercent) return 30;
+  return 60;
+}
+
 export function getInterval() {
   // Custom time range doesn't use interval (uses explicit timestamps)
   if (timeState.customTimeRange) {

--- a/js/time.js
+++ b/js/time.js
@@ -26,7 +26,7 @@ const DAY_MS = 24 * HOUR_MS;
 const BASE_TABLE = 'cdn_requests_v2';
 const SAMPLED_TABLE_10 = 'cdn_requests_v2_sampled_10';
 const SAMPLED_TABLE_1 = 'cdn_requests_v2_sampled_1';
-const SAMPLE_RATES = {
+export const SAMPLE_RATES = {
   full: 1,
   tenPercent: 0.1,
   onePercent: 0.01,

--- a/js/time.js
+++ b/js/time.js
@@ -23,6 +23,10 @@ const MINUTE_MS = 60 * SECOND_MS;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
 
+const BASE_TABLE = 'cdn_requests_v2';
+const SAMPLED_TABLE_10 = 'cdn_requests_v2_sampled_10';
+const SAMPLED_TABLE_1 = 'cdn_requests_v2_sampled_1';
+
 function floorToInterval(date, intervalMs) {
   return new Date(Math.floor(date.getTime() / intervalMs) * intervalMs);
 }
@@ -67,7 +71,7 @@ function getTimeBucketStep() {
   return TIME_RANGES[state.timeRange]?.step;
 }
 
-function getSelectedRange() {
+export function getSelectedRange() {
   if (timeState.customTimeRange) {
     return {
       start: new Date(timeState.customTimeRange.start),
@@ -149,7 +153,14 @@ export function getCustomTimeRange() {
 }
 
 export function getTable() {
-  return 'cdn_requests_v2';
+  return BASE_TABLE;
+}
+
+export function getSampledTable(sampleRate) {
+  if (!sampleRate || sampleRate >= 1) return BASE_TABLE;
+  if (sampleRate <= 0.01) return SAMPLED_TABLE_1;
+  if (sampleRate <= 0.1) return SAMPLED_TABLE_10;
+  return BASE_TABLE;
 }
 
 export function getInterval() {

--- a/js/time.js
+++ b/js/time.js
@@ -26,6 +26,11 @@ const DAY_MS = 24 * HOUR_MS;
 const BASE_TABLE = 'cdn_requests_v2';
 const SAMPLED_TABLE_10 = 'cdn_requests_v2_sampled_10';
 const SAMPLED_TABLE_1 = 'cdn_requests_v2_sampled_1';
+const SAMPLE_RATES = {
+  full: 1,
+  tenPercent: 0.1,
+  onePercent: 0.01,
+};
 
 function floorToInterval(date, intervalMs) {
   return new Date(Math.floor(date.getTime() / intervalMs) * intervalMs);
@@ -156,10 +161,18 @@ export function getTable() {
   return BASE_TABLE;
 }
 
+export function normalizeSampleRate(sampleRate) {
+  if (!Number.isFinite(sampleRate) || sampleRate <= 0) return SAMPLE_RATES.full;
+  if (sampleRate >= SAMPLE_RATES.full) return SAMPLE_RATES.full;
+  if (sampleRate <= SAMPLE_RATES.onePercent) return SAMPLE_RATES.onePercent;
+  if (sampleRate <= SAMPLE_RATES.tenPercent) return SAMPLE_RATES.tenPercent;
+  return SAMPLE_RATES.full;
+}
+
 export function getSampledTable(sampleRate) {
-  if (!sampleRate || sampleRate >= 1) return BASE_TABLE;
-  if (sampleRate <= 0.01) return SAMPLED_TABLE_1;
-  if (sampleRate <= 0.1) return SAMPLED_TABLE_10;
+  const normalizedRate = normalizeSampleRate(sampleRate);
+  if (normalizedRate === SAMPLE_RATES.onePercent) return SAMPLED_TABLE_1;
+  if (normalizedRate === SAMPLE_RATES.tenPercent) return SAMPLED_TABLE_10;
   return BASE_TABLE;
 }
 

--- a/js/time.test.js
+++ b/js/time.test.js
@@ -12,9 +12,17 @@
 import { assert } from 'chai';
 import { state } from './state.js';
 import {
-  setQueryTimestamp, setCustomTimeRange, clearCustomTimeRange,
-  getTimeFilter, getTimeBucket, getPeriodMs, getSampledTable,
-  getTimeRangeBounds, getTimeRangeStart, getTimeRangeEnd,
+  setQueryTimestamp,
+  setCustomTimeRange,
+  clearCustomTimeRange,
+  getTimeFilter,
+  getTimeBucket,
+  getPeriodMs,
+  getSampledTable,
+  normalizeSampleRate,
+  getTimeRangeBounds,
+  getTimeRangeStart,
+  getTimeRangeEnd,
 } from './time.js';
 
 beforeEach(() => {
@@ -75,5 +83,20 @@ describe('time helpers', () => {
     assert.strictEqual(getSampledTable(1), 'cdn_requests_v2');
     assert.strictEqual(getSampledTable(0.1), 'cdn_requests_v2_sampled_10');
     assert.strictEqual(getSampledTable(0.01), 'cdn_requests_v2_sampled_1');
+    assert.strictEqual(getSampledTable(0.05), 'cdn_requests_v2_sampled_10');
+    assert.strictEqual(getSampledTable(0), 'cdn_requests_v2');
+    assert.strictEqual(getSampledTable(-1), 'cdn_requests_v2');
+    assert.strictEqual(getSampledTable(null), 'cdn_requests_v2');
+    assert.strictEqual(getSampledTable(undefined), 'cdn_requests_v2');
+  });
+
+  it('normalizes unsupported sample rates', () => {
+    assert.strictEqual(normalizeSampleRate(0.05), 0.1);
+    assert.strictEqual(normalizeSampleRate(0.5), 1);
+    assert.strictEqual(normalizeSampleRate(0.001), 0.01);
+    assert.strictEqual(normalizeSampleRate(0), 1);
+    assert.strictEqual(normalizeSampleRate(-1), 1);
+    assert.strictEqual(normalizeSampleRate(null), 1);
+    assert.strictEqual(normalizeSampleRate(undefined), 1);
   });
 });

--- a/js/time.test.js
+++ b/js/time.test.js
@@ -13,7 +13,7 @@ import { assert } from 'chai';
 import { state } from './state.js';
 import {
   setQueryTimestamp, setCustomTimeRange, clearCustomTimeRange,
-  getTimeFilter, getTimeBucket, getPeriodMs,
+  getTimeFilter, getTimeBucket, getPeriodMs, getSampledTable,
   getTimeRangeBounds, getTimeRangeStart, getTimeRangeEnd,
 } from './time.js';
 
@@ -69,5 +69,11 @@ describe('time helpers', () => {
     state.timeRange = '12h';
     clearCustomTimeRange();
     assert.strictEqual(getPeriodMs(), 12 * 60 * 60 * 1000);
+  });
+
+  it('selects sampled tables based on sample rate', () => {
+    assert.strictEqual(getSampledTable(1), 'cdn_requests_v2');
+    assert.strictEqual(getSampledTable(0.1), 'cdn_requests_v2_sampled_10');
+    assert.strictEqual(getSampledTable(0.01), 'cdn_requests_v2_sampled_1');
   });
 });

--- a/js/time.test.js
+++ b/js/time.test.js
@@ -49,6 +49,16 @@ describe('time helpers', () => {
     assert.ok(filter.includes('2026-01-20 12:02:00'));
   });
 
+  it('rounds long custom time ranges to hour boundaries', () => {
+    const start = new Date('2026-01-20T00:15:00Z');
+    const end = new Date('2026-01-20T15:45:00Z');
+    setCustomTimeRange(start, end);
+
+    const filter = getTimeFilter();
+    assert.ok(filter.includes('2026-01-20 00:00:00'));
+    assert.ok(filter.includes('2026-01-20 16:00:00'));
+  });
+
   it('uses expected bucket for short custom range', () => {
     const start = new Date('2026-01-20T12:00:00Z');
     const end = new Date('2026-01-20T12:10:00Z');
@@ -107,5 +117,10 @@ describe('time helpers', () => {
     assert.strictEqual(getSampleRateTimeout(1), 60);
     assert.strictEqual(getSampleRateTimeout(2), 60);
     assert.strictEqual(getSampleRateTimeout(0.01, { disableTimeouts: true }), 0);
+  });
+
+  it('uses hour rounding for sampled filters', () => {
+    const filter = getTimeFilter(0.1);
+    assert.ok(filter.startsWith('toStartOfHour(timestamp)'));
   });
 });

--- a/js/time.test.js
+++ b/js/time.test.js
@@ -19,6 +19,7 @@ import {
   getTimeBucket,
   getPeriodMs,
   getSampledTable,
+  getSampleRateTimeout,
   normalizeSampleRate,
   getTimeRangeBounds,
   getTimeRangeStart,
@@ -98,5 +99,13 @@ describe('time helpers', () => {
     assert.strictEqual(normalizeSampleRate(-1), 1);
     assert.strictEqual(normalizeSampleRate(null), 1);
     assert.strictEqual(normalizeSampleRate(undefined), 1);
+  });
+
+  it('maps sample rates to execution timeouts', () => {
+    assert.strictEqual(getSampleRateTimeout(0.01), 10);
+    assert.strictEqual(getSampleRateTimeout(0.1), 30);
+    assert.strictEqual(getSampleRateTimeout(1), 60);
+    assert.strictEqual(getSampleRateTimeout(2), 60);
+    assert.strictEqual(getSampleRateTimeout(0.01, { disableTimeouts: true }), 0);
   });
 });

--- a/js/ui/actions.js
+++ b/js/ui/actions.js
@@ -21,6 +21,8 @@
  * @property {(facetId: string) => void} toggleFacetPin
  * @property {(facetId: string) => void} toggleFacetHide
  * @property {(modeKey: string) => void} toggleFacetMode
+ * @property {(facetId: string, sampleRate?: string) => void} refineFacetSampling
+ * @property {(sampleRate?: string) => void} refineChartSampling
  * @property {() => void} closeQuickLinksModal
  * @property {(el: HTMLElement) => void} closeDialog
  * @property {Function} openFacetSearch - (col, facetId, filterCol, title)
@@ -100,6 +102,11 @@ export function initActionHandlers(handlers) {
       'toggle-facet-pin': () => handlers.toggleFacetPin?.(target.dataset.facet || ''),
       'toggle-facet-hide': () => handlers.toggleFacetHide?.(target.dataset.facet || ''),
       'toggle-facet-mode': () => handlers.toggleFacetMode?.(target.dataset.mode || ''),
+      'refine-facet-sampling': () => handlers.refineFacetSampling?.(
+        target.dataset.facet || '',
+        target.dataset.sampleRate,
+      ),
+      'refine-chart-sampling': () => handlers.refineChartSampling?.(target.dataset.sampleRate),
       'close-quick-links': () => handlers.closeQuickLinksModal?.(),
       'close-dialog': () => handlers.closeDialog?.(target),
       'copy-facet-tsv': () => handlers.copyFacetTsv?.(target.dataset.facet || ''),

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -210,6 +210,9 @@ export function syncUIFromState() {
   }
   elements.topNSelect.value = state.topN;
   document.body.dataset.topn = state.topN;
+  if (state.sampleRate) {
+    document.body.dataset.sampleRate = String(state.sampleRate);
+  }
   elements.hostFilterInput.value = state.hostFilter;
   renderActiveFilters();
 

--- a/scripts/add-user.mjs
+++ b/scripts/add-user.mjs
@@ -19,7 +19,15 @@
 const CLICKHOUSE_HOST = 's2p5b8wmt5.eastus2.azure.clickhouse.cloud';
 const CLICKHOUSE_PORT = 8443;
 const DATABASE = 'helix_logs_production';
-const TABLES = ['cdn_requests_combined', 'cdn_requests_v2', 'releases', 'oncall_shifts', 'lambda_logs'];
+const TABLES = [
+  'cdn_requests_combined',
+  'cdn_requests_v2',
+  'cdn_requests_v2_sampled_10',
+  'cdn_requests_v2_sampled_1',
+  'releases',
+  'oncall_shifts',
+  'lambda_logs',
+];
 const DICTIONARIES = ['asn_dict'];
 
 function generatePassword(length = 16) {

--- a/scripts/roll-user.mjs
+++ b/scripts/roll-user.mjs
@@ -26,6 +26,7 @@ const TABLES = [
   'cdn_requests_v2_sampled_1',
   'releases',
   'oncall_shifts',
+  'lambda_logs',
 ];
 const DICTIONARIES = ['asn_dict'];
 

--- a/sql/cdn_requests_v2_sampling.sql
+++ b/sql/cdn_requests_v2_sampling.sql
@@ -53,457 +53,317 @@ AS SELECT * REPLACE (
 FROM helix_logs_production.cdn_requests_v2
 WHERE (sample_hash % 100) = 0;
 
+
+
 -- Rebuild projections for sampled tables using coarse (hourly) buckets.
 -- Drop projections first to stay within the projection limit.
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_url;
+  DROP PROJECTION IF EXISTS proj_hour_facet_content_length;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_user_agent;
+  DROP PROJECTION IF EXISTS proj_hour_facet_time_elapsed;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_referer;
+  DROP PROJECTION IF EXISTS proj_hour_accept;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_x_forwarded_host;
+  DROP PROJECTION IF EXISTS proj_hour_accept_encoding;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_x_error;
+  DROP PROJECTION IF EXISTS proj_hour_asn;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_host;
+  DROP PROJECTION IF EXISTS proj_hour_backend_type;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_method;
+  DROP PROJECTION IF EXISTS proj_hour_byo_cdn;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_datacenter;
+  DROP PROJECTION IF EXISTS proj_hour_cache_control;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_request_type;
+  DROP PROJECTION IF EXISTS proj_hour_cache_status;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_backend_type;
+  DROP PROJECTION IF EXISTS proj_hour_client_ip;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_content_type;
+  DROP PROJECTION IF EXISTS proj_hour_content_type;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_cache_status;
+  DROP PROJECTION IF EXISTS proj_hour_datacenter;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_client_ip;
+  DROP PROJECTION IF EXISTS proj_hour_host;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_status_range;
+  DROP PROJECTION IF EXISTS proj_hour_location;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_status;
+  DROP PROJECTION IF EXISTS proj_hour_method;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_asn;
+  DROP PROJECTION IF EXISTS proj_hour_push_invalidation;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  DROP PROJECTION IF EXISTS proj_facet_asn_num;
+  DROP PROJECTION IF EXISTS proj_hour_referer;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_hour_request_type;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_hour_status;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_hour_status_range;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_hour_url;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_hour_user_agent;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_hour_x_error;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_hour_x_error_grouped;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_hour_x_forwarded_host;
 
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_url;
+  DROP PROJECTION IF EXISTS proj_hour_facet_content_length;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_user_agent;
+  DROP PROJECTION IF EXISTS proj_hour_facet_time_elapsed;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_referer;
+  DROP PROJECTION IF EXISTS proj_hour_accept;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_x_forwarded_host;
+  DROP PROJECTION IF EXISTS proj_hour_accept_encoding;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_x_error;
+  DROP PROJECTION IF EXISTS proj_hour_asn;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_host;
+  DROP PROJECTION IF EXISTS proj_hour_backend_type;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_method;
+  DROP PROJECTION IF EXISTS proj_hour_byo_cdn;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_datacenter;
+  DROP PROJECTION IF EXISTS proj_hour_cache_control;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_request_type;
+  DROP PROJECTION IF EXISTS proj_hour_cache_status;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_backend_type;
+  DROP PROJECTION IF EXISTS proj_hour_client_ip;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_content_type;
+  DROP PROJECTION IF EXISTS proj_hour_content_type;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_cache_status;
+  DROP PROJECTION IF EXISTS proj_hour_datacenter;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_client_ip;
+  DROP PROJECTION IF EXISTS proj_hour_host;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_status_range;
+  DROP PROJECTION IF EXISTS proj_hour_location;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_status;
+  DROP PROJECTION IF EXISTS proj_hour_method;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_asn;
+  DROP PROJECTION IF EXISTS proj_hour_push_invalidation;
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  DROP PROJECTION IF EXISTS proj_facet_asn_num;
+  DROP PROJECTION IF EXISTS proj_hour_referer;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_hour_request_type;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_hour_status;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_hour_status_range;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_hour_url;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_hour_user_agent;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_hour_x_error;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_hour_x_error_grouped;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_hour_x_forwarded_host;
 
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_url (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `request.url`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `request.url`
+  ADD PROJECTION proj_hour_facet_content_length (
+    SELECT toStartOfHour(timestamp) AS hour, multiIf(`response.headers.content_length` = 0, '0 (empty)', `response.headers.content_length` < 100, '1-100 B', `response.headers.content_length` < 500, '100-500 B', `response.headers.content_length` < 1024, '500 B - 1 KB', `response.headers.content_length` < 5120, '1-5 KB', `response.headers.content_length` < 10240, '5-10 KB', `response.headers.content_length` < 51200, '10-50 KB', `response.headers.content_length` < 102400, '50-100 KB', `response.headers.content_length` < 512000, '100-500 KB', `response.headers.content_length` < 1048576, '500 KB - 1 MB', `response.headers.content_length` < 10485760, '1-10 MB', '> 10 MB') AS content_length_bucket, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, content_length_bucket
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_user_agent (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `request.headers.user_agent`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `request.headers.user_agent`
+  ADD PROJECTION proj_hour_facet_time_elapsed (
+    SELECT toStartOfHour(timestamp) AS hour, multiIf(`cdn.time_elapsed_msec` < 5, '< 5ms', `cdn.time_elapsed_msec` < 10, '5-10ms', `cdn.time_elapsed_msec` < 20, '10-20ms', `cdn.time_elapsed_msec` < 35, '20-35ms', `cdn.time_elapsed_msec` < 50, '35-50ms', `cdn.time_elapsed_msec` < 100, '50-100ms', `cdn.time_elapsed_msec` < 250, '100-250ms', `cdn.time_elapsed_msec` < 500, '250-500ms', `cdn.time_elapsed_msec` < 1000, '500ms - 1s', '>= 1s') AS time_elapsed_bucket, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, time_elapsed_bucket
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_referer (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `request.headers.referer`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `request.headers.referer`
+  ADD PROJECTION proj_hour_accept (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.accept`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.headers.accept`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_x_forwarded_host (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `request.headers.x_forwarded_host`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `request.headers.x_forwarded_host`
+  ADD PROJECTION proj_hour_accept_encoding (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.accept_encoding`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.headers.accept_encoding`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_x_error (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `response.headers.x_error`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `response.headers.x_error`
+  ADD PROJECTION proj_hour_asn (
+    SELECT toStartOfHour(timestamp) AS hour, `client.asn`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `client.asn`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_host (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `request.host`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `request.host`
+  ADD PROJECTION proj_hour_backend_type (
+    SELECT toStartOfHour(timestamp) AS hour, `helix.backend_type`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `helix.backend_type`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_method (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `request.method`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `request.method`
+  ADD PROJECTION proj_hour_byo_cdn (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.x_byo_cdn_type`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.headers.x_byo_cdn_type`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_datacenter (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `cdn.datacenter`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `cdn.datacenter`
+  ADD PROJECTION proj_hour_cache_control (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.cache_control`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.headers.cache_control`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_request_type (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `helix.request_type`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `helix.request_type`
+  ADD PROJECTION proj_hour_cache_status (
+    SELECT toStartOfHour(timestamp) AS hour, upper(`cdn.cache_status`) AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf(upper(`cdn.cache_status`) LIKE 'HIT%') AS summary_cnt GROUP BY hour, dim
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_backend_type (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `helix.backend_type`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `helix.backend_type`
+  ADD PROJECTION proj_hour_client_ip (
+    SELECT toStartOfHour(timestamp) AS hour, if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf(if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) LIKE '%:%') AS summary_cnt GROUP BY hour, dim
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_content_type (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `response.headers.content_type`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `response.headers.content_type`
+  ADD PROJECTION proj_hour_content_type (
+    SELECT toStartOfHour(timestamp) AS hour, `response.headers.content_type`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, sum(`response.headers.content_length`) AS bytes, sumIf(`response.headers.content_length`, `response.status` < 400) AS bytes_ok, sumIf(`response.headers.content_length`, (`response.status` >= 400) AND (`response.status` < 500)) AS bytes_4xx, sumIf(`response.headers.content_length`, `response.status` >= 500) AS bytes_5xx GROUP BY hour, `response.headers.content_type`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_cache_status (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      upper(`cdn.cache_status`) as cache_status,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, cache_status
+  ADD PROJECTION proj_hour_datacenter (
+    SELECT toStartOfHour(timestamp) AS hour, `cdn.datacenter`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `cdn.datacenter`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_client_ip (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) as client_ip,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, client_ip
+  ADD PROJECTION proj_hour_host (
+    SELECT toStartOfHour(timestamp) AS hour, `request.host` AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf(`request.host` LIKE '%.aem.live') AS summary_cnt GROUP BY hour, dim
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_status_range (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      concat(toString(intDiv(`response.status`, 100)), 'xx') as status_range,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, status_range
+  ADD PROJECTION proj_hour_location (
+    SELECT toStartOfHour(timestamp) AS hour, `response.headers.location`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `response.headers.location`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_status (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      toString(`response.status`) as status,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, status
+  ADD PROJECTION proj_hour_method (
+    SELECT toStartOfHour(timestamp) AS hour, `request.method` AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf(`request.method` IN ('POST', 'PUT', 'PATCH', 'DELETE')) AS summary_cnt GROUP BY hour, dim
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_asn (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      concat(toString(`client.asn`), ' - ', `client.name`) as asn,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, asn
+  ADD PROJECTION proj_hour_push_invalidation (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.x_push_invalidation`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.headers.x_push_invalidation`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
-  ADD PROJECTION proj_facet_asn_num (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `client.asn` as asn_num,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, asn_num
+  ADD PROJECTION proj_hour_referer (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.referer`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.headers.referer`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_hour_request_type (
+    SELECT toStartOfHour(timestamp) AS hour, `helix.request_type`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `helix.request_type`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_hour_status (
+    SELECT toStartOfHour(timestamp) AS hour, toString(`response.status`) AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, dim
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_hour_status_range (
+    SELECT toStartOfHour(timestamp) AS hour, concat(toString(intDiv(`response.status`, 100)), 'xx') AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf(`response.status` >= 500) AS summary_cnt GROUP BY hour, dim
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_hour_url (
+    SELECT toStartOfHour(timestamp) AS hour, `request.url`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.url`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_hour_user_agent (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.user_agent` AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf((NOT (`request.headers.user_agent` LIKE 'Mozilla/%')) OR (`request.headers.user_agent` LIKE '%+http%')) AS summary_cnt GROUP BY hour, dim
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_hour_x_error (
+    SELECT toStartOfHour(timestamp) AS hour, `response.headers.x_error`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `response.headers.x_error`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_hour_x_error_grouped (
+    SELECT toStartOfHour(timestamp) AS hour, replaceRegexpAll(`response.headers.x_error`, '/[a-zA-Z0-9/_.-]+', '/...') AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, dim
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_hour_x_forwarded_host (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.x_forwarded_host` AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf(`request.headers.x_forwarded_host` != '') AS summary_cnt GROUP BY hour, dim
   );
 
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_url (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `request.url`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `request.url`
+  ADD PROJECTION proj_hour_facet_content_length (
+    SELECT toStartOfHour(timestamp) AS hour, multiIf(`response.headers.content_length` = 0, '0 (empty)', `response.headers.content_length` < 100, '1-100 B', `response.headers.content_length` < 500, '100-500 B', `response.headers.content_length` < 1024, '500 B - 1 KB', `response.headers.content_length` < 5120, '1-5 KB', `response.headers.content_length` < 10240, '5-10 KB', `response.headers.content_length` < 51200, '10-50 KB', `response.headers.content_length` < 102400, '50-100 KB', `response.headers.content_length` < 512000, '100-500 KB', `response.headers.content_length` < 1048576, '500 KB - 1 MB', `response.headers.content_length` < 10485760, '1-10 MB', '> 10 MB') AS content_length_bucket, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, content_length_bucket
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_user_agent (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `request.headers.user_agent`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `request.headers.user_agent`
+  ADD PROJECTION proj_hour_facet_time_elapsed (
+    SELECT toStartOfHour(timestamp) AS hour, multiIf(`cdn.time_elapsed_msec` < 5, '< 5ms', `cdn.time_elapsed_msec` < 10, '5-10ms', `cdn.time_elapsed_msec` < 20, '10-20ms', `cdn.time_elapsed_msec` < 35, '20-35ms', `cdn.time_elapsed_msec` < 50, '35-50ms', `cdn.time_elapsed_msec` < 100, '50-100ms', `cdn.time_elapsed_msec` < 250, '100-250ms', `cdn.time_elapsed_msec` < 500, '250-500ms', `cdn.time_elapsed_msec` < 1000, '500ms - 1s', '>= 1s') AS time_elapsed_bucket, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, time_elapsed_bucket
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_referer (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `request.headers.referer`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `request.headers.referer`
+  ADD PROJECTION proj_hour_accept (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.accept`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.headers.accept`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_x_forwarded_host (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `request.headers.x_forwarded_host`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `request.headers.x_forwarded_host`
+  ADD PROJECTION proj_hour_accept_encoding (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.accept_encoding`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.headers.accept_encoding`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_x_error (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `response.headers.x_error`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `response.headers.x_error`
+  ADD PROJECTION proj_hour_asn (
+    SELECT toStartOfHour(timestamp) AS hour, `client.asn`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `client.asn`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_host (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `request.host`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `request.host`
+  ADD PROJECTION proj_hour_backend_type (
+    SELECT toStartOfHour(timestamp) AS hour, `helix.backend_type`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `helix.backend_type`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_method (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `request.method`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `request.method`
+  ADD PROJECTION proj_hour_byo_cdn (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.x_byo_cdn_type`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.headers.x_byo_cdn_type`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_datacenter (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `cdn.datacenter`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `cdn.datacenter`
+  ADD PROJECTION proj_hour_cache_control (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.cache_control`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.headers.cache_control`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_request_type (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `helix.request_type`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `helix.request_type`
+  ADD PROJECTION proj_hour_cache_status (
+    SELECT toStartOfHour(timestamp) AS hour, upper(`cdn.cache_status`) AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf(upper(`cdn.cache_status`) LIKE 'HIT%') AS summary_cnt GROUP BY hour, dim
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_backend_type (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `helix.backend_type`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `helix.backend_type`
+  ADD PROJECTION proj_hour_client_ip (
+    SELECT toStartOfHour(timestamp) AS hour, if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf(if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) LIKE '%:%') AS summary_cnt GROUP BY hour, dim
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_content_type (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `response.headers.content_type`,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, `response.headers.content_type`
+  ADD PROJECTION proj_hour_content_type (
+    SELECT toStartOfHour(timestamp) AS hour, `response.headers.content_type`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, sum(`response.headers.content_length`) AS bytes, sumIf(`response.headers.content_length`, `response.status` < 400) AS bytes_ok, sumIf(`response.headers.content_length`, (`response.status` >= 400) AND (`response.status` < 500)) AS bytes_4xx, sumIf(`response.headers.content_length`, `response.status` >= 500) AS bytes_5xx GROUP BY hour, `response.headers.content_type`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_cache_status (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      upper(`cdn.cache_status`) as cache_status,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, cache_status
+  ADD PROJECTION proj_hour_datacenter (
+    SELECT toStartOfHour(timestamp) AS hour, `cdn.datacenter`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `cdn.datacenter`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_client_ip (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) as client_ip,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, client_ip
+  ADD PROJECTION proj_hour_host (
+    SELECT toStartOfHour(timestamp) AS hour, `request.host` AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf(`request.host` LIKE '%.aem.live') AS summary_cnt GROUP BY hour, dim
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_status_range (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      concat(toString(intDiv(`response.status`, 100)), 'xx') as status_range,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, status_range
+  ADD PROJECTION proj_hour_location (
+    SELECT toStartOfHour(timestamp) AS hour, `response.headers.location`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `response.headers.location`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_status (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      toString(`response.status`) as status,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, status
+  ADD PROJECTION proj_hour_method (
+    SELECT toStartOfHour(timestamp) AS hour, `request.method` AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf(`request.method` IN ('POST', 'PUT', 'PATCH', 'DELETE')) AS summary_cnt GROUP BY hour, dim
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_asn (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      concat(toString(`client.asn`), ' - ', `client.name`) as asn,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, asn
+  ADD PROJECTION proj_hour_push_invalidation (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.x_push_invalidation`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.headers.x_push_invalidation`
   );
 ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
-  ADD PROJECTION proj_facet_asn_num (
-    SELECT
-      toStartOfHour(timestamp) as hour,
-      `client.asn` as asn_num,
-      count() as cnt,
-      countIf(`response.status` < 400) as cnt_ok,
-      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-      countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY hour, asn_num
+  ADD PROJECTION proj_hour_referer (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.referer`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.headers.referer`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_hour_request_type (
+    SELECT toStartOfHour(timestamp) AS hour, `helix.request_type`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `helix.request_type`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_hour_status (
+    SELECT toStartOfHour(timestamp) AS hour, toString(`response.status`) AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, dim
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_hour_status_range (
+    SELECT toStartOfHour(timestamp) AS hour, concat(toString(intDiv(`response.status`, 100)), 'xx') AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf(`response.status` >= 500) AS summary_cnt GROUP BY hour, dim
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_hour_url (
+    SELECT toStartOfHour(timestamp) AS hour, `request.url`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `request.url`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_hour_user_agent (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.user_agent` AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf((NOT (`request.headers.user_agent` LIKE 'Mozilla/%')) OR (`request.headers.user_agent` LIKE '%+http%')) AS summary_cnt GROUP BY hour, dim
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_hour_x_error (
+    SELECT toStartOfHour(timestamp) AS hour, `response.headers.x_error`, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, `response.headers.x_error`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_hour_x_error_grouped (
+    SELECT toStartOfHour(timestamp) AS hour, replaceRegexpAll(`response.headers.x_error`, '/[a-zA-Z0-9/_.-]+', '/...') AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx GROUP BY hour, dim
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_hour_x_forwarded_host (
+    SELECT toStartOfHour(timestamp) AS hour, `request.headers.x_forwarded_host` AS dim, count() AS cnt, countIf(`response.status` < 400) AS cnt_ok, countIf((`response.status` >= 400) AND (`response.status` < 500)) AS cnt_4xx, countIf(`response.status` >= 500) AS cnt_5xx, countIf(`request.headers.x_forwarded_host` != '') AS summary_cnt GROUP BY hour, dim
   );
 
 -- Materialize projections for existing data (runs in background)
--- ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10 MATERIALIZE PROJECTION proj_facet_url;
--- ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1 MATERIALIZE PROJECTION proj_facet_url;
+-- ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10 MATERIALIZE PROJECTION proj_hour_url;
+-- ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1 MATERIALIZE PROJECTION proj_hour_url;
 
 -- Backfill (run once, per day to keep inserts smaller)
 -- WARNING: destructive. Only run TRUNCATE during initial setup.

--- a/sql/cdn_requests_v2_sampling.sql
+++ b/sql/cdn_requests_v2_sampling.sql
@@ -53,6 +53,458 @@ AS SELECT * REPLACE (
 FROM helix_logs_production.cdn_requests_v2
 WHERE (sample_hash % 100) = 0;
 
+-- Rebuild projections for sampled tables using coarse (hourly) buckets.
+-- Drop projections first to stay within the projection limit.
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_url;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_user_agent;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_referer;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_x_forwarded_host;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_x_error;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_host;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_method;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_datacenter;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_request_type;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_backend_type;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_content_type;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_cache_status;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_client_ip;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_status_range;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_status;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_asn;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  DROP PROJECTION IF EXISTS proj_facet_asn_num;
+
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_url;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_user_agent;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_referer;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_x_forwarded_host;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_x_error;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_host;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_method;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_datacenter;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_request_type;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_backend_type;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_content_type;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_cache_status;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_client_ip;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_status_range;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_status;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_asn;
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  DROP PROJECTION IF EXISTS proj_facet_asn_num;
+
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_url (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `request.url`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `request.url`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_user_agent (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `request.headers.user_agent`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `request.headers.user_agent`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_referer (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `request.headers.referer`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `request.headers.referer`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_x_forwarded_host (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `request.headers.x_forwarded_host`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `request.headers.x_forwarded_host`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_x_error (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `response.headers.x_error`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `response.headers.x_error`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_host (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `request.host`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `request.host`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_method (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `request.method`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `request.method`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_datacenter (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `cdn.datacenter`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `cdn.datacenter`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_request_type (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `helix.request_type`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `helix.request_type`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_backend_type (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `helix.backend_type`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `helix.backend_type`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_content_type (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `response.headers.content_type`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `response.headers.content_type`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_cache_status (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      upper(`cdn.cache_status`) as cache_status,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, cache_status
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_client_ip (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) as client_ip,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, client_ip
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_status_range (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      concat(toString(intDiv(`response.status`, 100)), 'xx') as status_range,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, status_range
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_status (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      toString(`response.status`) as status,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, status
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_asn (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      concat(toString(`client.asn`), ' - ', `client.name`) as asn,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, asn
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  ADD PROJECTION proj_facet_asn_num (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `client.asn` as asn_num,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, asn_num
+  );
+
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_url (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `request.url`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `request.url`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_user_agent (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `request.headers.user_agent`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `request.headers.user_agent`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_referer (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `request.headers.referer`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `request.headers.referer`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_x_forwarded_host (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `request.headers.x_forwarded_host`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `request.headers.x_forwarded_host`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_x_error (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `response.headers.x_error`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `response.headers.x_error`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_host (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `request.host`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `request.host`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_method (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `request.method`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `request.method`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_datacenter (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `cdn.datacenter`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `cdn.datacenter`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_request_type (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `helix.request_type`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `helix.request_type`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_backend_type (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `helix.backend_type`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `helix.backend_type`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_content_type (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `response.headers.content_type`,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, `response.headers.content_type`
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_cache_status (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      upper(`cdn.cache_status`) as cache_status,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, cache_status
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_client_ip (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) as client_ip,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, client_ip
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_status_range (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      concat(toString(intDiv(`response.status`, 100)), 'xx') as status_range,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, status_range
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_status (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      toString(`response.status`) as status,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, status
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_asn (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      concat(toString(`client.asn`), ' - ', `client.name`) as asn,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, asn
+  );
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  ADD PROJECTION proj_facet_asn_num (
+    SELECT
+      toStartOfHour(timestamp) as hour,
+      `client.asn` as asn_num,
+      count() as cnt,
+      countIf(`response.status` < 400) as cnt_ok,
+      countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+      countIf(`response.status` >= 500) as cnt_5xx
+    GROUP BY hour, asn_num
+  );
+
+-- Materialize projections for existing data (runs in background)
+-- ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10 MATERIALIZE PROJECTION proj_facet_url;
+-- ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1 MATERIALIZE PROJECTION proj_facet_url;
+
 -- Backfill (run once, per day to keep inserts smaller)
 -- WARNING: destructive. Only run TRUNCATE during initial setup.
 -- TRUNCATE TABLE helix_logs_production.cdn_requests_v2_sampled_10;

--- a/sql/cdn_requests_v2_sampling.sql
+++ b/sql/cdn_requests_v2_sampling.sql
@@ -1,0 +1,82 @@
+-- Sampled tables for progressive facet sampling
+-- Created: 2026-02-04
+-- Notes:
+-- - 10% table TTL: 20 weeks. 1% table TTL: 200 weeks.
+-- - IP addresses are withheld in sampled tables.
+-- - Drop projections before updating them (projection limit is tight).
+
+-- Create sampled tables with the same schema, projections, and ordering
+CREATE TABLE IF NOT EXISTS helix_logs_production.cdn_requests_v2_sampled_10
+AS helix_logs_production.cdn_requests_v2;
+
+CREATE TABLE IF NOT EXISTS helix_logs_production.cdn_requests_v2_sampled_1
+AS helix_logs_production.cdn_requests_v2;
+
+-- Extend TTLs for sampled retention
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_10
+  MODIFY TTL timestamp + toIntervalWeek(20);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2_sampled_1
+  MODIFY TTL timestamp + toIntervalWeek(200);
+
+-- Ensure the logpush writer can populate the sampled tables via cascading MVs
+GRANT SELECT ON helix_logs_production.cdn_requests_v2 TO logpush_writer;
+GRANT INSERT ON helix_logs_production.cdn_requests_v2_sampled_10 TO logpush_writer;
+GRANT INSERT ON helix_logs_production.cdn_requests_v2_sampled_1 TO logpush_writer;
+
+-- Drop existing MVs before re-creating
+DROP TABLE IF EXISTS helix_logs_production.cdn_requests_v2_sampled_10_mv;
+DROP TABLE IF EXISTS helix_logs_production.cdn_requests_v2_sampled_1_mv;
+
+-- Maintain sampled tables via MVs sourced from the primary table
+CREATE MATERIALIZED VIEW helix_logs_production.cdn_requests_v2_sampled_10_mv
+TO helix_logs_production.cdn_requests_v2_sampled_10
+AS SELECT * REPLACE (
+  '(withheld)' AS `client.ip`,
+  '(withheld)' AS `cdn.originating_ip`,
+  '(withheld)' AS `request.headers.x_forwarded_for`,
+  '(withheld)' AS `request.headers.cf_connecting_ip`,
+  '(withheld)' AS `request.headers.true_client_ip`
+)
+FROM helix_logs_production.cdn_requests_v2
+WHERE (sample_hash % 10) = 0;
+
+CREATE MATERIALIZED VIEW helix_logs_production.cdn_requests_v2_sampled_1_mv
+TO helix_logs_production.cdn_requests_v2_sampled_1
+AS SELECT * REPLACE (
+  '(withheld)' AS `client.ip`,
+  '(withheld)' AS `cdn.originating_ip`,
+  '(withheld)' AS `request.headers.x_forwarded_for`,
+  '(withheld)' AS `request.headers.cf_connecting_ip`,
+  '(withheld)' AS `request.headers.true_client_ip`
+)
+FROM helix_logs_production.cdn_requests_v2
+WHERE (sample_hash % 100) = 0;
+
+-- Backfill (run once, per day to keep inserts smaller)
+TRUNCATE TABLE helix_logs_production.cdn_requests_v2_sampled_10;
+TRUNCATE TABLE helix_logs_production.cdn_requests_v2_sampled_1;
+
+-- Example per-day backfill (substitute partition date)
+-- INSERT INTO helix_logs_production.cdn_requests_v2_sampled_10
+-- SELECT * REPLACE (
+--   '(withheld)' AS `client.ip`,
+--   '(withheld)' AS `cdn.originating_ip`,
+--   '(withheld)' AS `request.headers.x_forwarded_for`,
+--   '(withheld)' AS `request.headers.cf_connecting_ip`,
+--   '(withheld)' AS `request.headers.true_client_ip`
+-- )
+-- FROM helix_logs_production.cdn_requests_v2
+-- WHERE (sample_hash % 10) = 0
+--   AND toDate(timestamp) = toDate('2026-02-04');
+-- INSERT INTO helix_logs_production.cdn_requests_v2_sampled_1
+-- SELECT * REPLACE (
+--   '(withheld)' AS `client.ip`,
+--   '(withheld)' AS `cdn.originating_ip`,
+--   '(withheld)' AS `request.headers.x_forwarded_for`,
+--   '(withheld)' AS `request.headers.cf_connecting_ip`,
+--   '(withheld)' AS `request.headers.true_client_ip`
+-- )
+-- FROM helix_logs_production.cdn_requests_v2
+-- WHERE (sample_hash % 100) = 0
+--   AND toDate(timestamp) = toDate('2026-02-04');

--- a/sql/cdn_requests_v2_sampling.sql
+++ b/sql/cdn_requests_v2_sampling.sql
@@ -54,8 +54,9 @@ FROM helix_logs_production.cdn_requests_v2
 WHERE (sample_hash % 100) = 0;
 
 -- Backfill (run once, per day to keep inserts smaller)
-TRUNCATE TABLE helix_logs_production.cdn_requests_v2_sampled_10;
-TRUNCATE TABLE helix_logs_production.cdn_requests_v2_sampled_1;
+-- WARNING: destructive. Only run TRUNCATE during initial setup.
+-- TRUNCATE TABLE helix_logs_production.cdn_requests_v2_sampled_10;
+-- TRUNCATE TABLE helix_logs_production.cdn_requests_v2_sampled_1;
 
 -- Example per-day backfill (substitute partition date)
 -- INSERT INTO helix_logs_production.cdn_requests_v2_sampled_10

--- a/sql/queries/breakdown-missing.sql
+++ b/sql/queries/breakdown-missing.sql
@@ -5,7 +5,6 @@ SELECT
   {{agg4xx}} as cnt_4xx,
   {{agg5xx}} as cnt_5xx
 FROM {{database}}.{{table}}
-{{sampleClause}}
 WHERE {{timeFilter}} {{hostFilter}} {{extra}} {{additionalWhereClause}}
   AND {{searchCol}} IN ({{valuesList}})
 GROUP BY dim

--- a/sql/queries/breakdown.sql
+++ b/sql/queries/breakdown.sql
@@ -5,7 +5,6 @@ SELECT
   {{agg4xx}} as cnt_4xx,
   {{agg5xx}} as cnt_5xx{{summaryCol}}
 FROM {{database}}.{{table}}
-{{sampleClause}}
 WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{extra}} {{additionalWhereClause}}
 GROUP BY dim WITH TOTALS
 ORDER BY {{orderBy}}

--- a/sql/queries/time-series.sql
+++ b/sql/queries/time-series.sql
@@ -1,8 +1,8 @@
 SELECT
   {{bucket}} as t,
-  countIf(`response.status` < 400) as cnt_ok,
-  countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-  countIf(`response.status` >= 500) as cnt_5xx
+  countIf(`response.status` < 400){{mult}} as cnt_ok,
+  countIf(`response.status` >= 400 AND `response.status` < 500){{mult}} as cnt_4xx,
+  countIf(`response.status` >= 500){{mult}} as cnt_5xx
 FROM {{database}}.{{table}}
 WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{additionalWhereClause}}
 GROUP BY t


### PR DESCRIPTION
## Summary

Replace `SAMPLE` clause-based sampling with **progressive table-based sampling** for high-cardinality facets, and extend sampling to the time-series chart.

### Progressive facet refinement
- High-cardinality facets (hosts, paths, referers, user agents, IPs) query 3 stages sequentially: `cdn_requests_v2_sampled_1` (1%, x100) → `cdn_requests_v2_sampled_10` (10%, x10) → `cdn_requests_v2` (full). Results render progressively after each stage.
- Low-cardinality facets query the appropriate table once based on retention age.
- Retention-based caps: >20 weeks → 1% only, >2 weeks → 10% max, ≤2 weeks → full data.

### Sampled tables (DB infrastructure)
- `cdn_requests_v2_sampled_10`: 10% sample via `sample_hash % 10`, 20-week TTL.
- `cdn_requests_v2_sampled_1`: 1% sample via `sample_hash % 100`, 200-week TTL.
- IP columns (`client.ip`, `cdn.originating_ip`, `request.headers.*_ip`) withheld as `'(withheld)'` in sampled tables to avoid retaining PII with extended TTLs.
- Populated via cascading materialized views from `cdn_requests_v2`.
- Read-only users granted SELECT on sampled tables.

### Chart sampling
- Time-series chart now queries the appropriate sampled table with count multiplier based on retention age (same logic as facets).
- Dashed line style (10%) / dotted (1%) indicates when chart data is sampled.

### Cleanup
- Removed dead `SAMPLE` clause code path from SQL templates and query params.
- Centralized sample rate constants (`SAMPLE_RATES`) in `time.js`, used throughout.
- Removed unused `getCurrentSamplingInfo` and `sample-rate-change` listener that caused redundant chart re-renders and release re-fetches.

### State tracking
- `state.sampleRate` tracks the minimum sample rate across all active facets.
- `document.body.dataset.sampleRate` exposed for CSS/UI indicator use.

Fixes #34
Refs #89

## Testing Done
- 307 unit tests pass, 87% code coverage.
- Lint passes.
- `getSampledTable` and `normalizeSampleRate` unit tests cover edge cases (null, 0, negative, boundary values).
- HAR analysis of a live 7-day dashboard load confirmed correct 3-stage progressive pattern for all 6 high-cardinality facets with correct tables and multipliers.
- Verified sampled table schemas in ClickHouse match primary table (columns, indexes, projections, partitioning, ordering, TTLs).

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)