### PR TITLE
feat: use line dash patterns for sampling indicator

### DIFF
--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -56,6 +56,28 @@ function getSamplingConfig(highCardinality) {
   return { sampleClause: 'SAMPLE 0.1', multiplier: 10 };
 }
 
+/**
+ * Get current sampling info for UI display (chart line style)
+ * @returns {{ isActive: boolean, rate: string, description: string }}
+ *   Sampling status and display info
+ */
+export function getCurrentSamplingInfo() {
+  const periodMs = getPeriodMs();
+
+  // No sampling for time ranges <= 1 hour
+  if (!periodMs || periodMs <= ONE_HOUR_MS) {
+    return { isActive: false, rate: '', description: '' };
+  }
+
+  // 1% sampling for 7d
+  if (periodMs >= 7 * 24 * ONE_HOUR_MS) {
+    return { isActive: true, rate: '1%', description: '1% sample for faster queries' };
+  }
+
+  // 10% sampling for 12h, 24h
+  return { isActive: true, rate: '10%', description: '10% sample for faster queries' };
+}
+
 export function resetFacetTimings() {
   Object.keys(facetTimings).forEach((key) => {
     delete facetTimings[key];


### PR DESCRIPTION
## Summary

Alternative to #98 per @trieloff's [suggestion](https://github.com/adobe/klickhaus/pull/98#issuecomment-3850367208): use **dotted/dashed/solid line styles** instead of blur effects to visually indicate data sampling levels in the time series chart.

Line styles by sampling rate:
- **Solid lines**: no sampling (15m, 1h) — precise data
- **Dashed lines** `[8, 4]`: 10% sampling (12h, 24h) — approximate data
- **Dotted lines** `[3, 3]`: 1% sampling (7d) — highly sampled data

This approach is less visually jarring than blur while still communicating data precision through a familiar visual convention.

### Changes
- Added `getCurrentSamplingInfo()` in `js/breakdowns/index.js` to expose sampling status for UI use
- Modified `drawStackedArea()` in `js/chart.js` to accept a `lineDash` parameter
- Applied line dash patterns in `renderChart()` based on current sampling rate

## Testing Done

- `npm run lint` passes with no errors
- `npm test` passes (305/305 tests, 86.87% coverage)

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)