### PR TITLE
feat: add Lambda Logs dashboard and configurable table/facets

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,12 @@
           <div class="description">Core delivery traffic only, excludes backend and admin services</div>
         </a>
       </li>
+      <li>
+        <a href="lambda.html">
+          <div class="title">Lambda Logs</div>
+          <div class="description">Lambda function logs: level, function name, app, subsystem, log group</div>
+        </a>
+      </li>
     </ul>
 
     <div class="section">

--- a/js/anomaly-investigation.js
+++ b/js/anomaly-investigation.js
@@ -17,7 +17,7 @@
 
 import { getTimeFilter } from './time.js';
 import { getFacetFilters } from './breakdowns/index.js';
-import { allBreakdowns } from './breakdowns/definitions.js';
+import { getBreakdowns } from './breakdowns/index.js';
 import { parseUTC } from './chart-state.js';
 import {
   CACHE_TOP_N,
@@ -397,7 +397,7 @@ export async function investigateAnomalies(anomalies, chartData) {
   const fullEnd = parseUTC(chartData[chartData.length - 1].t);
 
   // Select facets to investigate
-  const facetsToInvestigate = allBreakdowns.filter((b) => ['breakdown-hosts', 'breakdown-forwarded-hosts', 'breakdown-paths',
+  const facetsToInvestigate = getBreakdowns().filter((b) => ['breakdown-hosts', 'breakdown-forwarded-hosts', 'breakdown-paths',
     'breakdown-errors', 'breakdown-user-agents', 'breakdown-ips',
     'breakdown-asn', 'breakdown-datacenters', 'breakdown-cache',
     'breakdown-content-types', 'breakdown-backend-type'].includes(b.id));
@@ -640,7 +640,7 @@ export async function investigateTimeRange(selectionStart, selectionEnd, fullSta
   clearSelectionHighlights();
 
   // Select facets to investigate (same as anomaly investigation)
-  const facetsToInvestigate = allBreakdowns.filter((b) => ['breakdown-hosts', 'breakdown-forwarded-hosts', 'breakdown-paths',
+  const facetsToInvestigate = getBreakdowns().filter((b) => ['breakdown-hosts', 'breakdown-forwarded-hosts', 'breakdown-paths',
     'breakdown-errors', 'breakdown-user-agents', 'breakdown-ips',
     'breakdown-asn', 'breakdown-datacenters', 'breakdown-cache',
     'breakdown-content-types', 'breakdown-backend-type'].includes(b.id));

--- a/js/autocomplete.test.js
+++ b/js/autocomplete.test.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { state } from './state.js';
+import { loadHostAutocomplete } from './autocomplete.js';
+
+const HOST_CACHE_KEY = 'hostAutocompleteSuggestions';
+const FUNCTION_CACHE_KEY = 'functionAutocompleteSuggestions';
+
+describe('loadHostAutocomplete', () => {
+  let datalist;
+  let savedCache;
+  let createdDatalist = false;
+
+  beforeEach(() => {
+    state.hostFilterColumn = null;
+    datalist = document.getElementById('hostSuggestions');
+    if (!datalist) {
+      datalist = document.createElement('datalist');
+      datalist.id = 'hostSuggestions';
+      document.body.appendChild(datalist);
+      createdDatalist = true;
+    } else {
+      createdDatalist = false;
+    }
+    savedCache = localStorage.getItem(HOST_CACHE_KEY);
+    localStorage.removeItem(HOST_CACHE_KEY);
+    localStorage.removeItem(FUNCTION_CACHE_KEY);
+  });
+
+  afterEach(() => {
+    if (savedCache !== null) {
+      localStorage.setItem(HOST_CACHE_KEY, savedCache);
+    } else {
+      localStorage.removeItem(HOST_CACHE_KEY);
+    }
+    if (createdDatalist && datalist && datalist.parentNode) {
+      datalist.remove();
+    }
+  });
+
+  it('populates datalist from cache when host cache is valid', async () => {
+    const hosts = ['host-a.aem.live', 'host-b.aem.page'];
+    localStorage.setItem(HOST_CACHE_KEY, JSON.stringify({
+      hosts,
+      timestamp: Date.now(),
+    }));
+    state.hostFilterColumn = null;
+
+    await loadHostAutocomplete();
+
+    assert.strictEqual(datalist.children.length, 2);
+    assert.strictEqual(datalist.children[0].value, 'host-a.aem.live');
+    assert.strictEqual(datalist.children[1].value, 'host-b.aem.page');
+  });
+
+  it('populates datalist from function cache when hostFilterColumn is function_name', async () => {
+    const functions = ['myLambda', 'otherFunc'];
+    localStorage.setItem(FUNCTION_CACHE_KEY, JSON.stringify({
+      hosts: functions,
+      timestamp: Date.now(),
+    }));
+    state.hostFilterColumn = 'function_name';
+
+    await loadHostAutocomplete();
+
+    assert.strictEqual(datalist.children.length, 2);
+    assert.strictEqual(datalist.children[0].value, 'myLambda');
+    assert.strictEqual(datalist.children[1].value, 'otherFunc');
+  });
+
+  it('uses cache when within TTL', async () => {
+    const hosts = ['cached.example.com'];
+    localStorage.setItem(HOST_CACHE_KEY, JSON.stringify({
+      hosts,
+      timestamp: Date.now() - 1000,
+    }));
+
+    await loadHostAutocomplete();
+
+    assert.strictEqual(datalist.children.length, 1);
+    assert.strictEqual(datalist.children[0].value, 'cached.example.com');
+  });
+});

--- a/js/breakdowns/definitions-lambda.js
+++ b/js/breakdowns/definitions-lambda.js
@@ -39,4 +39,8 @@ export const lambdaBreakdowns = [
     col: '`log_group`',
     highCardinality: true,
   },
+  {
+    id: 'breakdown-admin-method',
+    col: 'CAST(message_json.admin.method, \'String\')',
+  },
 ];

--- a/js/breakdowns/definitions-lambda.js
+++ b/js/breakdowns/definitions-lambda.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Breakdown (facet) definitions for the lambda_logs table.
+ */
+export const lambdaBreakdowns = [
+  {
+    id: 'breakdown-level',
+    col: '`level`',
+    summaryCountIf: "`level` = 'ERROR'",
+    summaryLabel: 'error rate',
+    summaryColor: 'error',
+  },
+  {
+    id: 'breakdown-function-name',
+    col: '`function_name`',
+    highCardinality: true,
+  },
+  {
+    id: 'breakdown-app-name',
+    col: '`app_name`',
+  },
+  {
+    id: 'breakdown-subsystem',
+    col: '`subsystem`',
+  },
+  {
+    id: 'breakdown-log-group',
+    col: '`log_group`',
+    highCardinality: true,
+  },
+];

--- a/js/breakdowns/definitions-lambda.test.js
+++ b/js/breakdowns/definitions-lambda.test.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { lambdaBreakdowns } from './definitions-lambda.js';
+
+describe('lambdaBreakdowns', () => {
+  it('has six facets', () => {
+    assert.strictEqual(lambdaBreakdowns.length, 6);
+  });
+
+  it('each facet has id and col', () => {
+    const ids = [
+      'breakdown-level',
+      'breakdown-function-name',
+      'breakdown-app-name',
+      'breakdown-subsystem',
+      'breakdown-log-group',
+      'breakdown-admin-method',
+    ];
+    lambdaBreakdowns.forEach((b, i) => {
+      assert.strictEqual(b.id, ids[i]);
+      assert.isString(b.col);
+    });
+  });
+
+  it('level facet has summaryCountIf for error rate', () => {
+    const levelFacet = lambdaBreakdowns.find((b) => b.id === 'breakdown-level');
+    assert.ok(levelFacet);
+    assert.strictEqual(levelFacet.summaryCountIf, "`level` = 'ERROR'");
+    assert.strictEqual(levelFacet.summaryLabel, 'error rate');
+  });
+
+  it('function_name and log_group are high cardinality', () => {
+    const fn = lambdaBreakdowns.find((b) => b.id === 'breakdown-function-name');
+    const lg = lambdaBreakdowns.find((b) => b.id === 'breakdown-log-group');
+    assert.strictEqual(fn.highCardinality, true);
+    assert.strictEqual(lg.highCardinality, true);
+  });
+
+  it('admin-method facet has col for message_json.admin.method', () => {
+    const adminMethod = lambdaBreakdowns.find((b) => b.id === 'breakdown-admin-method');
+    assert.ok(adminMethod);
+    assert.include(adminMethod.col, 'message_json');
+    assert.include(adminMethod.col, 'admin');
+    assert.include(adminMethod.col, 'method');
+  });
+});

--- a/js/breakdowns/index.test.js
+++ b/js/breakdowns/index.test.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { state } from '../state.js';
+import {
+  getBreakdowns,
+  resetFacetTimings,
+  getFacetFilters,
+  getFacetFiltersExcluding,
+  facetTimings,
+} from './index.js';
+import { allBreakdowns } from './definitions.js';
+import { lambdaBreakdowns } from './definitions-lambda.js';
+
+beforeEach(() => {
+  state.breakdowns = null;
+  state.filters = [];
+});
+
+describe('getBreakdowns', () => {
+  it('returns default breakdowns when state.breakdowns is null', () => {
+    state.breakdowns = null;
+    const result = getBreakdowns();
+    assert.strictEqual(result, allBreakdowns);
+    assert.isAbove(result.length, 5);
+  });
+
+  it('returns default breakdowns when state.breakdowns is empty array', () => {
+    state.breakdowns = [];
+    const result = getBreakdowns();
+    assert.strictEqual(result, allBreakdowns);
+  });
+
+  it('returns state.breakdowns when set', () => {
+    state.breakdowns = lambdaBreakdowns;
+    const result = getBreakdowns();
+    assert.strictEqual(result, lambdaBreakdowns);
+    assert.strictEqual(result.length, 6);
+  });
+});
+
+describe('resetFacetTimings', () => {
+  it('clears all keys from facetTimings', () => {
+    facetTimings['breakdown-level'] = 100;
+    facetTimings['breakdown-host'] = 200;
+    resetFacetTimings();
+    assert.strictEqual(Object.keys(facetTimings).length, 0);
+  });
+});
+
+describe('getFacetFilters', () => {
+  it('returns empty SQL when no filters', () => {
+    state.filters = [];
+    const sql = getFacetFilters();
+    assert.strictEqual(sql, '');
+  });
+
+  it('returns SQL for single include filter', () => {
+    state.filters = [{ col: '`request.host`', value: 'example.com', exclude: false }];
+    const sql = getFacetFilters();
+    assert.ok(sql.includes("`request.host` = 'example.com'"));
+  });
+});
+
+describe('getFacetFiltersExcluding', () => {
+  it('omits filter for given column', () => {
+    state.filters = [
+      { col: '`request.host`', value: 'a.com', exclude: false },
+      { col: '`request.method`', value: 'GET', exclude: false },
+    ];
+    const sql = getFacetFiltersExcluding('`request.host`');
+    assert.ok(sql.includes("`request.method` = 'GET'"));
+    assert.notInclude(sql, 'a.com');
+  });
+});

--- a/js/breakdowns/index.test.js
+++ b/js/breakdowns/index.test.js
@@ -137,7 +137,13 @@ describe('increaseTopN', () => {
     const [first, second] = TOP_N_OPTIONS;
     state.topN = first;
     const topNSelectEl = document.createElement('select');
-    topNSelectEl.value = '5';
+    TOP_N_OPTIONS.forEach((n) => {
+      const opt = document.createElement('option');
+      opt.value = String(n);
+      opt.textContent = String(n);
+      topNSelectEl.appendChild(opt);
+    });
+    topNSelectEl.value = String(first);
     let saveCalled = false;
     let loadCalled = false;
     increaseTopN(

--- a/js/breakdowns/index.test.js
+++ b/js/breakdowns/index.test.js
@@ -18,6 +18,7 @@ import {
   getFacetFiltersExcluding,
   markSlowestFacet,
   increaseTopN,
+  loadBreakdown,
   facetTimings,
 } from './index.js';
 import { allBreakdowns } from './definitions.js';
@@ -27,6 +28,7 @@ import { TOP_N_OPTIONS } from '../constants.js';
 beforeEach(() => {
   state.breakdowns = null;
   state.filters = [];
+  state.hiddenFacets = [];
   resetFacetTimings();
 });
 
@@ -163,5 +165,39 @@ describe('increaseTopN', () => {
     );
     assert.isFalse(saveCalled);
     assert.isFalse(loadCalled);
+  });
+});
+
+describe('loadBreakdown', () => {
+  const hiddenFacetId = 'breakdown-hidden-facet-test';
+  let card;
+
+  beforeEach(() => {
+    card = document.getElementById(hiddenFacetId);
+    if (!card) {
+      card = document.createElement('div');
+      card.id = hiddenFacetId;
+      const h3 = document.createElement('h3');
+      h3.textContent = 'Hidden Facet';
+      card.appendChild(h3);
+      document.body.appendChild(card);
+    }
+  });
+
+  afterEach(() => {
+    if (card && card.parentNode) {
+      card.remove();
+    }
+    state.hiddenFacets = [];
+  });
+
+  it('renders hidden facet and returns early when facet is in hiddenFacets', async () => {
+    state.hiddenFacets = [hiddenFacetId];
+    const b = { id: hiddenFacetId, col: '`level`' };
+    await loadBreakdown(b, '1=1', '');
+    assert.isTrue(card.classList.contains('facet-hidden'));
+    assert.include(card.innerHTML, 'Hidden Facet');
+    assert.include(card.innerHTML, 'facet-hide-btn');
+    assert.include(card.innerHTML, 'Show facet');
   });
 });

--- a/js/breakdowns/render.test.js
+++ b/js/breakdowns/render.test.js
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { state } from '../state.js';
+import {
+  getFiltersForColumn,
+  getNextTopN,
+  renderBreakdownError,
+} from './render.js';
+import { TOP_N_OPTIONS } from '../constants.js';
+
+beforeEach(() => {
+  state.filters = [];
+  state.pinnedFacets = [];
+});
+
+describe('getFiltersForColumn', () => {
+  it('returns empty array when no filters', () => {
+    state.filters = [];
+    assert.deepEqual(getFiltersForColumn('`request.host`'), []);
+  });
+
+  it('returns only filters matching the column', () => {
+    state.filters = [
+      { col: '`request.host`', value: 'a.com', exclude: false },
+      { col: '`request.method`', value: 'GET', exclude: false },
+      { col: '`request.host`', value: 'b.com', exclude: true },
+    ];
+    const result = getFiltersForColumn('`request.host`');
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].value, 'a.com');
+    assert.strictEqual(result[1].value, 'b.com');
+  });
+
+  it('returns empty array when column has no filters', () => {
+    state.filters = [{ col: '`request.method`', value: 'GET', exclude: false }];
+    assert.deepEqual(getFiltersForColumn('`request.host`'), []);
+  });
+});
+
+describe('getNextTopN', () => {
+  it('returns next option when not at max', () => {
+    const [first, second, third, fourth] = TOP_N_OPTIONS;
+    state.topN = first;
+    assert.strictEqual(getNextTopN(), second);
+    state.topN = third;
+    assert.strictEqual(getNextTopN(), fourth);
+  });
+
+  it('returns null when at max option', () => {
+    state.topN = TOP_N_OPTIONS.at(-1);
+    assert.strictEqual(getNextTopN(), null);
+  });
+
+  it('returns null when state.topN not in options', () => {
+    state.topN = 99;
+    assert.strictEqual(getNextTopN(), null);
+  });
+});
+
+describe('renderBreakdownError', () => {
+  let card;
+
+  beforeEach(() => {
+    card = document.getElementById('breakdown-test-error');
+    if (!card) {
+      card = document.createElement('div');
+      card.id = 'breakdown-test-error';
+      const h3 = document.createElement('h3');
+      h3.textContent = 'Test Facet';
+      card.appendChild(h3);
+      document.body.appendChild(card);
+    }
+  });
+
+  afterEach(() => {
+    if (card && card.parentNode) {
+      card.remove();
+    }
+  });
+
+  it('renders error with default label and message', () => {
+    renderBreakdownError('breakdown-test-error', {});
+    assert.include(card.innerHTML, 'Query failed');
+    assert.include(card.innerHTML, 'Error loading data');
+    assert.include(card.innerHTML, 'Test Facet');
+  });
+
+  it('renders error with custom label and message', () => {
+    renderBreakdownError('breakdown-test-error', {
+      label: 'Connection failed',
+      message: 'Timeout after 30s',
+    });
+    assert.include(card.innerHTML, 'Connection failed');
+    assert.include(card.innerHTML, 'Timeout after 30s');
+  });
+
+  it('includes detail when provided', () => {
+    renderBreakdownError('breakdown-test-error', {
+      detail: 'Code: 241. Memory limit exceeded',
+    });
+    assert.include(card.innerHTML, 'facet-error-detail');
+    assert.include(card.innerHTML, 'Memory limit exceeded');
+  });
+
+  it('includes meta when code, type, or status provided', () => {
+    renderBreakdownError('breakdown-test-error', {
+      code: 241,
+      type: 'MEMORY_LIMIT_EXCEEDED',
+      status: 500,
+    });
+    assert.include(card.innerHTML, 'facet-error-meta');
+    assert.include(card.innerHTML, 'Code 241');
+    assert.include(card.innerHTML, 'MEMORY_LIMIT_EXCEEDED');
+    assert.include(card.innerHTML, 'HTTP 500');
+  });
+
+  it('uses card dataset.title when h3 not present', () => {
+    card.innerHTML = '';
+    card.dataset.title = 'Custom Title';
+    card.id = 'breakdown-test-error';
+    document.body.appendChild(card);
+
+    renderBreakdownError('breakdown-test-error', {});
+    assert.include(card.innerHTML, 'Custom Title');
+  });
+});

--- a/js/chart.js
+++ b/js/chart.js
@@ -917,7 +917,8 @@ export async function loadTimeSeries(requestContext = getRequestContext('dashboa
   const rangeStart = getTimeRangeStart();
   const rangeEnd = getTimeRangeEnd();
 
-  const sql = await loadSql('time-series', {
+  const timeSeriesTemplate = state.timeSeriesTemplate || 'time-series';
+  const sql = await loadSql(timeSeriesTemplate, {
     bucket,
     database: DATABASE,
     table: getTable(),

--- a/js/colors/definitions.test.js
+++ b/js/colors/definitions.test.js
@@ -13,7 +13,19 @@ import { assert } from 'chai';
 import { colorRules } from './definitions.js';
 
 describe('colorRules.status', () => {
-  const { getColor } = colorRules.status;
+  const { getColor, transform } = colorRules.status;
+
+  it('transform extracts first digit and multiplies by 100', () => {
+    assert.strictEqual(transform('2xx'), 200);
+    assert.strictEqual(transform('4xx'), 400);
+    assert.strictEqual(transform('5'), 500);
+    assert.strictEqual(transform('3'), 300);
+  });
+
+  it('transform returns value as-is when no leading digit', () => {
+    assert.strictEqual(transform('xx'), 'xx');
+    assert.strictEqual(transform(''), '');
+  });
 
   it('returns ok color for 2xx/3xx', () => {
     assert.strictEqual(getColor('200'), 'var(--status-ok)');

--- a/js/colors/index.test.js
+++ b/js/colors/index.test.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import {
+  getColorForColumn,
+  getColorIndicatorHtml,
+  getStatusColor,
+  getHostColor,
+  getMethodColor,
+  getPathColor,
+  getCacheStatusColor,
+  getRequestTypeColor,
+  getLocationColor,
+} from './index.js';
+
+describe('getColorForColumn', () => {
+  it('returns color when col matches pattern', () => {
+    assert.strictEqual(
+      getColorForColumn('`response.status`', '200'),
+      'var(--status-ok)',
+    );
+    assert.strictEqual(
+      getColorForColumn('request.host', 'main--site.aem.live'),
+      'var(--host-delivery)',
+    );
+    assert.strictEqual(
+      getColorForColumn('request.method', 'GET'),
+      'var(--method-get)',
+    );
+  });
+
+  it('uses transform when rule has transform (status range)', () => {
+    assert.strictEqual(
+      getColorForColumn('response.status', '2xx'),
+      'var(--status-ok)',
+    );
+    assert.strictEqual(
+      getColorForColumn('response.status', '4xx'),
+      'var(--status-client-error)',
+    );
+    assert.strictEqual(
+      getColorForColumn('response.status', '5xx'),
+      'var(--status-server-error)',
+    );
+  });
+
+  it('returns empty for falsy value', () => {
+    assert.strictEqual(getColorForColumn('request.host', ''), '');
+    assert.strictEqual(getColorForColumn('request.host', null), '');
+  });
+
+  it('returns empty for synthetic bucket values', () => {
+    assert.strictEqual(getColorForColumn('request.host', '(empty)'), '');
+    assert.strictEqual(getColorForColumn('request.host', '(same)'), '');
+    assert.strictEqual(getColorForColumn('request.host', '(other)'), '');
+  });
+
+  it('returns empty when no pattern matches column', () => {
+    assert.strictEqual(getColorForColumn('unknown.column', 'value'), '');
+  });
+
+  it('matches column by pattern substring', () => {
+    assert.strictEqual(
+      getColorForColumn('request.headers.x_forwarded_host', 'cdn.aem.page'),
+      'var(--host-authoring)',
+    );
+  });
+});
+
+describe('getColorIndicatorHtml', () => {
+  it('returns span with background and color style when color found', () => {
+    const html = getColorIndicatorHtml('response.status', '200');
+    assert.include(html, '<span');
+    assert.include(html, 'status-color');
+    assert.include(html, 'var(--status-ok)');
+    assert.include(html, 'background:');
+    assert.include(html, 'color:');
+  });
+
+  it('uses custom className when provided', () => {
+    const html = getColorIndicatorHtml('request.host', 'example.aem.live', 'facet-color');
+    assert.include(html, 'facet-color');
+    assert.include(html, 'var(--host-delivery)');
+  });
+
+  it('returns empty string when no color', () => {
+    assert.strictEqual(getColorIndicatorHtml('unknown.col', 'x'), '');
+    assert.strictEqual(getColorIndicatorHtml('request.host', ''), '');
+    assert.strictEqual(getColorIndicatorHtml('request.host', '(empty)'), '');
+  });
+});
+
+describe('legacy color getters', () => {
+  it('getStatusColor returns status color', () => {
+    assert.strictEqual(getStatusColor('200'), 'var(--status-ok)');
+    assert.strictEqual(getStatusColor('404'), 'var(--status-client-error)');
+  });
+
+  it('getHostColor returns host color', () => {
+    assert.strictEqual(getHostColor('main.aem.live'), 'var(--host-delivery)');
+    assert.strictEqual(getHostColor('main.aem.page'), 'var(--host-authoring)');
+  });
+
+  it('getMethodColor returns method color', () => {
+    assert.strictEqual(getMethodColor('GET'), 'var(--method-get)');
+    assert.strictEqual(getMethodColor('POST'), 'var(--method-post)');
+  });
+
+  it('getPathColor returns path color by extension', () => {
+    assert.strictEqual(getPathColor('/page.html'), 'var(--path-document)');
+    assert.strictEqual(getPathColor('/script.js'), 'var(--path-script)');
+  });
+
+  it('getCacheStatusColor returns cache status color', () => {
+    assert.strictEqual(getCacheStatusColor('HIT'), 'var(--cache-hit)');
+    assert.strictEqual(getCacheStatusColor('MISS'), 'var(--cache-miss)');
+  });
+
+  it('getRequestTypeColor returns request type color', () => {
+    assert.strictEqual(getRequestTypeColor('pipeline'), 'var(--rt-pipeline)');
+    assert.strictEqual(getRequestTypeColor('static'), 'var(--rt-static)');
+  });
+
+  it('getLocationColor returns location color', () => {
+    assert.strictEqual(getLocationColor('https://example.com'), 'var(--loc-absolute)');
+    assert.strictEqual(getLocationColor('/relative'), 'var(--loc-relative)');
+  });
+});

--- a/js/colors/index.test.js
+++ b/js/colors/index.test.js
@@ -15,10 +15,21 @@ import {
   getColorIndicatorHtml,
   getStatusColor,
   getHostColor,
-  getMethodColor,
-  getPathColor,
+  getContentTypeColor,
   getCacheStatusColor,
   getRequestTypeColor,
+  getBackendTypeColor,
+  getMethodColor,
+  getAsnColor,
+  getErrorColor,
+  getIPColor,
+  getUserAgentColor,
+  getRefererColor,
+  getPathColor,
+  getAcceptColor,
+  getAcceptEncodingColor,
+  getCacheControlColor,
+  getByoCdnColor,
   getLocationColor,
 } from './index.js';
 
@@ -133,5 +144,60 @@ describe('legacy color getters', () => {
   it('getLocationColor returns location color', () => {
     assert.strictEqual(getLocationColor('https://example.com'), 'var(--loc-absolute)');
     assert.strictEqual(getLocationColor('/relative'), 'var(--loc-relative)');
+  });
+
+  it('getContentTypeColor returns content type color', () => {
+    assert.strictEqual(getContentTypeColor('text/html'), 'var(--ct-text)');
+    assert.strictEqual(getContentTypeColor('image/png'), 'var(--ct-image)');
+  });
+
+  it('getBackendTypeColor returns backend type color', () => {
+    assert.strictEqual(getBackendTypeColor('fastly / aws'), 'var(--ts-fastly-aws)');
+    assert.strictEqual(getBackendTypeColor('cloudflare / r2'), 'var(--ts-cf-r2)');
+  });
+
+  it('getAsnColor returns ASN color', () => {
+    assert.strictEqual(getAsnColor('14340 - Adobe Inc.'), 'var(--asn-adobe)');
+    assert.strictEqual(getAsnColor('54113 - Fastly'), 'var(--asn-good-cdn)');
+  });
+
+  it('getErrorColor returns error color', () => {
+    assert.strictEqual(getErrorColor('moved'), 'var(--err-redirect)');
+    assert.strictEqual(getErrorColor('not allowed'), 'var(--err-security)');
+  });
+
+  it('getIPColor returns IP color', () => {
+    assert.strictEqual(getIPColor('192.168.1.1'), 'var(--ip-v4)');
+    assert.strictEqual(getIPColor('2001:db8::1'), 'var(--ip-v6)');
+  });
+
+  it('getUserAgentColor returns user agent color', () => {
+    assert.strictEqual(getUserAgentColor('Mozilla/5.0 (iPhone)'), 'var(--ua-ios)');
+    assert.strictEqual(getUserAgentColor('curl/7.0'), 'var(--ua-bad-bot)');
+  });
+
+  it('getRefererColor returns referer color', () => {
+    assert.strictEqual(getRefererColor('https://www.google.com/'), 'var(--ref-google)');
+    assert.strictEqual(getRefererColor('https://example.com/'), 'var(--ref-other)');
+  });
+
+  it('getAcceptColor returns accept header color', () => {
+    assert.strictEqual(getAcceptColor('text/html'), 'var(--ct-text)');
+    assert.strictEqual(getAcceptColor('*/*'), 'var(--ct-binary)');
+  });
+
+  it('getAcceptEncodingColor returns encoding color', () => {
+    assert.strictEqual(getAcceptEncodingColor('gzip, br'), 'var(--enc-br)');
+    assert.strictEqual(getAcceptEncodingColor('gzip'), 'var(--enc-gzip)');
+  });
+
+  it('getCacheControlColor returns cache-control color', () => {
+    assert.strictEqual(getCacheControlColor('no-store'), 'var(--cc-no-store)');
+    assert.strictEqual(getCacheControlColor('max-age=3600'), 'var(--cc-max-age)');
+  });
+
+  it('getByoCdnColor returns BYO CDN color', () => {
+    assert.strictEqual(getByoCdnColor('fastly'), 'var(--cdn-fastly)');
+    assert.strictEqual(getByoCdnColor('cloudfront'), 'var(--cdn-cloudfront)');
   });
 });

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -32,7 +32,7 @@ import {
   renderChart,
 } from './chart.js';
 import {
-  loadAllBreakdowns, loadBreakdown, allBreakdowns, markSlowestFacet, resetFacetTimings,
+  loadAllBreakdowns, loadBreakdown, getBreakdowns, markSlowestFacet, resetFacetTimings,
 } from './breakdowns/index.js';
 import { getNextTopN } from './breakdowns/render.js';
 import {
@@ -102,7 +102,7 @@ export function initDashboard(config = {}) {
     );
     const isFacetsCurrent = () => isRequestCurrent(facetsContext.requestId, facetsContext.scope);
 
-    const facetPromises = allBreakdowns.map(
+    const facetPromises = getBreakdowns().map(
       (b) => loadBreakdown(b, timeFilter, hostFilter, facetsContext).then(() => {
         if (!isFacetsCurrent()) return;
         if (!hasVisibleUpdatingFacets()) {
@@ -229,7 +229,7 @@ export function initDashboard(config = {}) {
     saveStateToURL();
 
     if (toggledFacetId) {
-      const breakdown = allBreakdowns.find((b) => b.id === toggledFacetId);
+      const breakdown = getBreakdowns().find((b) => b.id === toggledFacetId);
       if (breakdown) {
         const timeFilter = getTimeFilter();
         const hostFilter = getHostFilter();
@@ -258,7 +258,7 @@ export function initDashboard(config = {}) {
 
     const timeFilter = getTimeFilter();
     const hostFilter = getHostFilter();
-    const breakdowns = allBreakdowns.filter((b) => b.modeToggle === stateKey);
+    const breakdowns = getBreakdowns().filter((b) => b.modeToggle === stateKey);
     for (const breakdown of breakdowns) {
       const facetsContext = startRequestContext(`facet:${breakdown.id}`);
       loadBreakdown(breakdown, timeFilter, hostFilter, facetsContext);
@@ -273,8 +273,23 @@ export function initDashboard(config = {}) {
     if (config.title && !state.title) {
       state.title = config.title;
     }
-    if (config.additionalWhereClause) {
+    if (config.additionalWhereClause !== undefined) {
       state.additionalWhereClause = config.additionalWhereClause;
+    }
+    if (config.tableName) {
+      state.tableName = config.tableName;
+    }
+    if (config.timeSeriesTemplate) {
+      state.timeSeriesTemplate = config.timeSeriesTemplate;
+    }
+    if (config.aggregations) {
+      state.aggregations = config.aggregations;
+    }
+    if (config.hostFilterColumn !== undefined) {
+      state.hostFilterColumn = config.hostFilterColumn;
+    }
+    if (config.breakdowns) {
+      state.breakdowns = config.breakdowns;
     }
     if (config.defaultHiddenFacets) {
       const hasCustomPrefs = localStorage.getItem(`facetPrefs_${state.title || ''}`);

--- a/js/filter-sql.js
+++ b/js/filter-sql.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { allBreakdowns } from './breakdowns/definitions.js';
+import { getBreakdowns } from './breakdowns/index.js';
 import { COLUMN_DEFS } from './columns.js';
 
 /**
@@ -33,7 +33,7 @@ let allowedColumnsCache = null;
 export function getAllowedColumns() {
   if (allowedColumnsCache) return allowedColumnsCache;
   const cols = new Set();
-  for (const b of allBreakdowns) {
+  for (const b of getBreakdowns()) {
     if (typeof b.col === 'string') cols.add(b.col);
     if (b.filterCol) cols.add(b.filterCol);
   }

--- a/js/filters.js
+++ b/js/filters.js
@@ -11,7 +11,7 @@
  */
 import { state } from './state.js';
 import { getColorIndicatorHtml } from './colors/index.js';
-import { allBreakdowns } from './breakdowns/definitions.js';
+import { getBreakdowns } from './breakdowns/index.js';
 import { renderFilterTags } from './templates/filter-tags.js';
 
 // Callbacks set by main.js to avoid circular dependencies
@@ -31,7 +31,7 @@ export function updateHeaderFixed() {
 
 // Get facet title from breakdown column
 function getFacetTitle(col) {
-  const breakdown = allBreakdowns.find((b) => b.col === col);
+  const breakdown = getBreakdowns().find((b) => b.col === col);
   if (!breakdown) return null;
   const card = document.getElementById(breakdown.id);
   if (!card) return null;
@@ -166,7 +166,7 @@ export function addFilter(col, value, exclude, filterCol, filterValue, filterOp,
     }
   } else {
     // Fallback: look up breakdown to get filterCol and filterValueFn if defined
-    const breakdown = allBreakdowns.find((b) => b.col === col);
+    const breakdown = getBreakdowns().find((b) => b.col === col);
     if (breakdown?.filterCol) {
       filter.filterCol = breakdown.filterCol;
       filter.filterValue = breakdown.filterValueFn ? breakdown.filterValueFn(value) : value;

--- a/js/lambda-main.js
+++ b/js/lambda-main.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { initDashboard } from './dashboard-init.js';
+import { lambdaBreakdowns } from './breakdowns/definitions-lambda.js';
+
+const LAMBDA_AGGREGATIONS = {
+  aggTotal: 'count()',
+  aggOk: "countIf(level NOT IN ('ERROR', 'WARN', 'WARNING'))",
+  agg4xx: "countIf(level IN ('WARN', 'WARNING'))",
+  agg5xx: "countIf(level = 'ERROR')",
+};
+
+initDashboard({
+  title: 'Lambda Logs',
+  tableName: 'lambda_logs',
+  timeSeriesTemplate: 'time-series-lambda',
+  aggregations: LAMBDA_AGGREGATIONS,
+  hostFilterColumn: 'function_name',
+  breakdowns: lambdaBreakdowns,
+});

--- a/js/sql-loader.js
+++ b/js/sql-loader.js
@@ -66,6 +66,7 @@ const ALL_TEMPLATES = [
   'breakdown-missing',
   'autocomplete-hosts',
   'autocomplete-forwarded',
+  'autocomplete-functions',
   'releases',
   'facet-search-initial',
   'facet-search-pattern',

--- a/js/state.js
+++ b/js/state.js
@@ -37,6 +37,11 @@ export const state = {
   pinnedFacets: [], // Facet IDs pinned to top
   hiddenFacets: [], // Facet IDs hidden at bottom
   additionalWhereClause: '', // Additional WHERE clause for queries (e.g., delivery exclusions)
+  tableName: 'cdn_requests_v2', // Table to query (e.g. lambda_logs for Lambda dashboard)
+  timeSeriesTemplate: 'time-series', // SQL template name for chart (e.g. time-series-lambda)
+  aggregations: null, // Optional { aggTotal, aggOk, agg4xx, agg5xx } for non-CDN tables
+  hostFilterColumn: null, // Optional column for header filter (e.g. function_name for lambda)
+  breakdowns: null, // Optional override breakdown list (e.g. lambda facets)
 };
 
 // Callback for re-rendering logs table when pinned columns change

--- a/js/time.js
+++ b/js/time.js
@@ -149,7 +149,7 @@ export function getCustomTimeRange() {
 }
 
 export function getTable() {
-  return 'cdn_requests_v2';
+  return state.tableName || 'cdn_requests_v2';
 }
 
 export function getInterval() {
@@ -204,6 +204,9 @@ export function getTimeFilter() {
 export function getHostFilter() {
   if (!state.hostFilter) return '';
   const escaped = state.hostFilter.replace(/'/g, "\\'");
+  if (state.hostFilterColumn) {
+    return `AND \`${state.hostFilterColumn}\` LIKE '%${escaped}%'`;
+  }
   return `AND (\`request.host\` LIKE '%${escaped}%' OR \`request.headers.x_forwarded_host\` LIKE '%${escaped}%')`;
 }
 

--- a/lambda.html
+++ b/lambda.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lambda Logs - CDN Analytics</title>
+  <script>
+    window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
+  </script>
+  <script defer type="text/javascript" src="https://ot.aem.live/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
+  <link rel="canonical" href="https://klickhaus.aemstatus.net/lambda.html">
+
+  <!-- Favicon Icons -->
+  <link rel="apple-touch-icon" href="/icons/icon-180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/icon-32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png">
+
+  <link rel="stylesheet" href="dashboard.css">
+</head>
+<body>
+  <!-- Login Form -->
+  <div id="login">
+    <div class="login-card">
+      <h1>Lambda Logs</h1>
+      <p>Sign in to view Lambda log analytics</p>
+      <div id="loginError" class="error-message"></div>
+      <form id="loginForm">
+        <div class="form-group">
+          <label for="username">Username</label>
+          <input type="text" id="username" name="username" required autocomplete="username">
+        </div>
+        <div class="form-group">
+          <label for="password">Password</label>
+          <input type="password" id="password" name="password" required autocomplete="current-password">
+        </div>
+        <div class="form-group form-option">
+          <label class="checkbox-label">
+            <input type="checkbox" id="forgetMe" name="forgetMe">
+            Forget me on this device
+          </label>
+        </div>
+        <button type="submit" class="btn btn-primary">Sign In</button>
+      </form>
+    </div>
+  </div>
+
+  <!-- Dashboard -->
+  <div id="dashboard">
+    <header>
+      <div class="header-left">
+        <button id="menuBtn" class="menu-btn" title="Quick Links">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <rect y="3" width="20" height="2" rx="1"/>
+            <rect y="9" width="20" height="2" rx="1"/>
+            <rect y="15" width="20" height="2" rx="1"/>
+          </svg>
+        </button>
+        <h1><span id="dashboardTitle">Lambda Logs</span> <span id="queryTimer" class="query-timer"></span></h1>
+        <div id="activeFilters"></div>
+      </div>
+      <div class="header-right">
+        <span class="kbd-control"><kbd class="kbd-hint" id="timeRangeHint">2</kbd><select id="timeRange"></select></span>
+        <select id="topN"></select>
+        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by function..." list="hostSuggestions" autocomplete="off"></span>
+        <datalist id="hostSuggestions"></datalist>
+        <button id="moreBtn" class="menu-btn" title="More actions">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <circle cx="10" cy="4" r="1.5"/>
+            <circle cx="10" cy="10" r="1.5"/>
+            <circle cx="10" cy="16" r="1.5"/>
+          </svg>
+        </button>
+      </div>
+    </header>
+
+    <main id="dashboardContent">
+      <!-- Time Series Chart -->
+      <section class="chart-section">
+        <h2>Events over time</h2>
+        <div class="chart-container">
+          <canvas id="chart"></canvas>
+        </div>
+      </section>
+
+      <!-- Filters View (Breakdowns) -->
+      <div id="filtersView" class="visible">
+        <!-- Breakdown Tables -->
+        <section class="breakdowns breakdowns-pinned" id="breakdowns-pinned"></section>
+        <section class="breakdowns" id="breakdowns">
+        <div class="breakdown-card" id="breakdown-level">
+          <h3>Level</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-function-name">
+          <h3>Function Name</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-app-name">
+          <h3>App Name</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-subsystem">
+          <h3>Subsystem</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-log-group">
+          <h3>Log Group</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+      </section>
+      <section class="breakdowns breakdowns-hidden" id="breakdowns-hidden"></section>
+      </div>
+
+      <!-- Logs View -->
+      <div id="logsView">
+        <div class="logs-table-container">
+          <div class="logs-loading"><div class="spinner"></div>Loading logs...</div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <!-- Quick Links Modal -->
+  <dialog id="quickLinksModal">
+    <div class="modal-header">
+      <h2>Quick Links</h2>
+      <button class="modal-close" data-action="close-quick-links">&times;</button>
+    </div>
+    <iframe id="quickLinksFrame" src="index.html"></iframe>
+  </dialog>
+
+  <!-- More Actions Menu -->
+  <dialog id="moreMenu" class="dropdown-menu">
+    <button id="viewToggleBtn" class="menu-item" data-kbd="t">
+      <span class="menu-item-label">View Logs</span>
+      <kbd class="menu-item-kbd">t</kbd>
+    </button>
+    <button id="refreshBtn" class="menu-item" data-kbd="r">
+      <span class="menu-item-label">Refresh</span>
+      <kbd class="menu-item-kbd">r</kbd>
+    </button>
+    <div class="menu-divider"></div>
+    <button id="logoutBtn" class="menu-item">
+      <span class="menu-item-label">Logout</span>
+    </button>
+  </dialog>
+
+  <!-- Keyboard Help Dialog -->
+  <dialog id="keyboardHelp" role="dialog" aria-labelledby="keyboardHelpTitle">
+    <div class="keyboard-help-content">
+      <h2 id="keyboardHelpTitle">Keyboard Shortcuts <button data-action="close-dialog" aria-label="Close">&times;</button></h2>
+      <div class="keyboard-help-grid">
+        <div class="key-group"><kbd>j</kbd> <kbd>k</kbd></div>
+        <div class="key-desc">Navigate between values</div>
+
+        <div class="key-group"><kbd>h</kbd> <kbd>l</kbd></div>
+        <div class="key-desc">Navigate between facets</div>
+
+        <div class="key-group"><kbd>Tab</kbd></div>
+        <div class="key-desc">Next value (wraps to next facet)</div>
+
+        <div class="key-group"><kbd>i</kbd> <kbd>c</kbd> <kbd>Space</kbd></div>
+        <div class="key-desc">Toggle filter on value (Shift+click for exclude; tap value to reveal Filter/Exclude on touch)</div>
+
+        <div class="key-group"><kbd>e</kbd> <kbd>x</kbd></div>
+        <div class="key-desc">Toggle exclude on value</div>
+
+        <div class="key-group"><kbd>c</kbd><kbd>c</kbd></div>
+        <div class="key-desc">Clear all filters</div>
+
+        <div class="key-group"><kbd>.</kbd></div>
+        <div class="key-desc">Expand (other) / show more</div>
+
+        <div class="key-group"><kbd>o</kbd></div>
+        <div class="key-desc">Open link in new tab</div>
+
+        <div class="key-group"><kbd>p</kbd></div>
+        <div class="key-desc">Pin/unpin facet</div>
+
+        <div class="key-group"><kbd>d</kbd></div>
+        <div class="key-desc">Hide/show facet</div>
+
+        <div class="key-group"><kbd>g</kbd></div>
+        <div class="key-desc">Go to facet (quick navigation)</div>
+
+        <div class="key-group"><kbd>r</kbd></div>
+        <div class="key-desc">Refresh data</div>
+
+        <div class="key-group"><kbd>f</kbd></div>
+        <div class="key-desc">Focus function filter</div>
+
+        <div class="key-group"><kbd>t</kbd></div>
+        <div class="key-desc">Toggle logs view</div>
+
+        <div class="key-group"><kbd>1</kbd>-<kbd>5</kbd></div>
+        <div class="key-desc">Zoom to anomaly by rank</div>
+
+        <div class="key-group"><kbd>+</kbd></div>
+        <div class="key-desc">Zoom timeframe to most prominent anomaly</div>
+
+        <div class="key-group"><kbd>-</kbd></div>
+        <div class="key-desc">Zoom timeframe out to larger period</div>
+
+        <div class="key-group"><kbd>?</kbd></div>
+        <div class="key-desc">Show this help</div>
+
+        <div class="key-group"><kbd>Esc</kbd></div>
+        <div class="key-desc">Exit keyboard mode</div>
+      </div>
+    </div>
+  </dialog>
+
+  <!-- Log Detail Modal -->
+  <dialog id="logDetailModal" role="dialog" aria-labelledby="logDetailTitle">
+    <div class="log-detail-header">
+      <h2 id="logDetailTitle">Log Entry Details</h2>
+      <button class="modal-close" data-action="close-log-detail">&times;</button>
+    </div>
+    <div class="log-detail-content">
+      <table class="log-detail-table" id="logDetailTable"></table>
+    </div>
+  </dialog>
+
+  <!-- Facet Command Palette (VS Code-style goto) -->
+  <dialog id="facetPalette" role="dialog" aria-labelledby="facetPaletteTitle">
+    <div class="palette-header">
+      <input type="text" id="facetPaletteInput" placeholder="Go to facet..." aria-label="Search facets">
+    </div>
+    <div id="facetPaletteList" role="listbox" aria-label="Facet list"></div>
+  </dialog>
+
+  <!-- Facet Value Search Popover -->
+  <dialog id="facetSearchPopover" role="dialog" aria-labelledby="facetSearchTitle">
+    <div class="facet-search-header">
+      <h4 id="facetSearchTitle">Search</h4>
+      <input type="text" id="facetSearchInput" placeholder="Search values..." aria-label="Search facet values">
+    </div>
+    <div id="facetSearchResults" role="listbox" aria-label="Search results"></div>
+  </dialog>
+
+  <script type="module" src="js/lambda-main.js"></script>
+</body>
+</html>

--- a/lambda.html
+++ b/lambda.html
@@ -107,6 +107,10 @@
           <h3>Log Group</h3>
           <div class="loading"><div class="spinner"></div>Loading...</div>
         </div>
+        <div class="breakdown-card" id="breakdown-admin-method">
+          <h3>Admin method</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
       </section>
       <section class="breakdowns breakdowns-hidden" id="breakdowns-hidden"></section>
       </div>

--- a/sql/queries/autocomplete-functions.sql
+++ b/sql/queries/autocomplete-functions.sql
@@ -1,0 +1,6 @@
+SELECT `function_name` as host, count() as cnt
+FROM {{database}}.{{table}}
+WHERE timestamp > now() - INTERVAL 1 DAY
+GROUP BY `function_name`
+ORDER BY cnt DESC
+LIMIT 100

--- a/sql/queries/time-series-lambda.sql
+++ b/sql/queries/time-series-lambda.sql
@@ -1,0 +1,9 @@
+SELECT
+  {{bucket}} as t,
+  countIf(level NOT IN ('ERROR', 'WARN', 'WARNING')) as cnt_ok,
+  countIf(level IN ('WARN', 'WARNING')) as cnt_4xx,
+  countIf(level = 'ERROR') as cnt_5xx
+FROM {{database}}.{{table}}
+WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{additionalWhereClause}}
+GROUP BY t
+ORDER BY t WITH FILL FROM {{rangeStart}} TO {{rangeEnd}} STEP {{step}}


### PR DESCRIPTION
- Add lambda.html with time series chart and facets (level, function_name, app_name, subsystem, log_group) for lambda_logs table
- Add lambda-main.js, definitions-lambda.js, time-series-lambda.sql
- Make dashboard configurable: state.tableName, timeSeriesTemplate, aggregations, hostFilterColumn, breakdowns; time.js getTable/getHostFilter and chart/breakdowns use config
- Add getBreakdowns() and use it in dashboard-init, filters, filter-sql, anomaly-investigation so lambda and CDN dashboards use correct facets
- Add Lambda Logs link below CDN Delivery in quick links (index.html)
