### PR TITLE
fix: filter slow query reports to SELECT queries only

### DIFF
--- a/.github/workflows/monitor-clickhouse.yml
+++ b/.github/workflows/monitor-clickhouse.yml
@@ -82,6 +82,7 @@ jobs:
               substring(query, 1, 200) as query_snippet
           FROM system.query_log
           WHERE type = 'QueryFinish'
+            AND query_kind = 'Select'
             AND event_time > now() - INTERVAL 65 MINUTE
             AND user NOT IN ('operator-internal', 'monitoring-internal', 'observability-internal')
           ORDER BY memory_usage DESC
@@ -128,6 +129,7 @@ jobs:
               substring(query, 1, 200) as query_snippet
           FROM system.query_log
           WHERE type = 'QueryFinish'
+            AND query_kind = 'Select'
             AND event_time > now() - INTERVAL 65 MINUTE
             AND user NOT IN ('operator-internal', 'monitoring-internal', 'observability-internal')
           ORDER BY query_duration_ms DESC


### PR DESCRIPTION
## Summary

- Add `AND query_kind = 'Select'` to both top-by-memory and top-by-duration queries
- Filters out INSERTs, system queries, and DDL that aren't relevant to dashboard/user query performance

## Testing Done

- Will verify via manual workflow run after merge

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)