### PR TITLE
feat: add Domain Explorer dashboard page

### DIFF
--- a/css/domains.css
+++ b/css/domains.css
@@ -26,7 +26,7 @@ html {
   border-radius: 12px;
   border: 1px solid var(--border);
   overflow: hidden;
-  margin: 0 24px 24px;
+  margin: 16px 24px 24px;
 }
 
 .table-container {
@@ -63,11 +63,17 @@ html {
   text-align: right;
 }
 
-.domains-table th.sortable {
+.domains-table th.sortable button {
+  all: unset;
   cursor: pointer;
+  font: inherit;
+  color: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
 }
 
-.domains-table th.sortable:hover {
+.domains-table th.sortable:hover,
+.domains-table th.sortable button:hover {
   color: var(--text);
 }
 

--- a/css/domains.css
+++ b/css/domains.css
@@ -156,6 +156,16 @@ html {
   display: none;
 }
 
+/* Domain links */
+.domain-cell a {
+  color: var(--host-delivery);
+  text-decoration: none;
+}
+
+.domain-cell a:hover {
+  text-decoration: underline;
+}
+
 /* Status badges */
 .badge {
   display: inline-block;

--- a/css/domains.css
+++ b/css/domains.css
@@ -128,12 +128,12 @@ html {
 }
 
 .domains-table th.sort-asc::after {
-  content: ' \u25B2';
+  content: ' \25B2 ';
   font-size: 10px;
 }
 
 .domains-table th.sort-desc::after {
-  content: ' \u25BC';
+  content: ' \25BC ';
   font-size: 10px;
 }
 

--- a/css/domains.css
+++ b/css/domains.css
@@ -8,81 +8,25 @@ html {
   overflow: auto;
 }
 
-/* Dashboard layout */
-#dashboard {
-  display: none;
-  padding: 20px;
-  max-width: 1400px;
-  margin: 0 auto;
+/* Ensure dialog sits above sticky thead */
+#moreMenu[open] {
+  z-index: 10;
 }
 
-#dashboard.visible {
-  display: block;
-}
-
-/* Header */
-.domains-header {
-  margin-bottom: 20px;
-}
-
-.header-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 16px;
-}
-
-.header-top h1 {
-  font-size: 22px;
-  font-weight: 600;
-}
-
-.header-actions {
-  display: flex;
-  gap: 8px;
-}
-
-.header-controls {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.search-input {
-  flex: 1;
-  max-width: 400px;
-  padding: 8px 14px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  font-size: 14px;
-  background: var(--input-bg);
-  color: var(--text);
-}
-
-.search-input:focus {
-  outline: none;
-  border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(235, 16, 0, 0.15);
-}
-
+/* Row count in header */
 .row-count {
   font-size: 13px;
   color: var(--text-secondary);
   white-space: nowrap;
 }
 
-.query-timer {
-  font-size: 13px;
-  font-weight: 400;
-  color: var(--text-secondary);
-}
-
-/* Table */
+/* Table wrapper */
 .domains-main {
   background: var(--card-bg);
   border-radius: 12px;
   border: 1px solid var(--border);
   overflow: hidden;
+  margin: 0 24px 24px;
 }
 
 .table-container {
@@ -214,27 +158,8 @@ html {
 }
 
 /* Responsive */
-@media (max-width: 768px) {
-  #dashboard {
-    padding: 12px;
-  }
-
-  .header-top {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 12px;
-  }
-
-  .header-controls {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .search-input {
-    max-width: none;
-  }
-
-  .row-count {
-    text-align: right;
+@media (max-width: 600px) {
+  .domains-main {
+    margin: 0 12px 16px;
   }
 }

--- a/css/domains.css
+++ b/css/domains.css
@@ -1,0 +1,230 @@
+/*
+ * Domain Explorer
+ * Styles for the domain mapping explorer page
+ */
+
+/* Override base.css html overflow for this page */
+html {
+  overflow: auto;
+}
+
+/* Dashboard layout */
+#dashboard {
+  display: none;
+  padding: 20px;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+#dashboard.visible {
+  display: block;
+}
+
+/* Header */
+.domains-header {
+  margin-bottom: 20px;
+}
+
+.header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.header-top h1 {
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.header-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.search-input {
+  flex: 1;
+  max-width: 400px;
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 14px;
+  background: var(--input-bg);
+  color: var(--text);
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(235, 16, 0, 0.15);
+}
+
+.row-count {
+  font-size: 13px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.query-timer {
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--text-secondary);
+}
+
+/* Table */
+.domains-main {
+  background: var(--card-bg);
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+.domains-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.domains-table thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.domains-table th {
+  background: var(--bg);
+  border-bottom: 2px solid var(--border);
+  padding: 10px 14px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.domains-table th.numeric {
+  text-align: right;
+}
+
+.domains-table th.sortable {
+  cursor: pointer;
+}
+
+.domains-table th.sortable:hover {
+  color: var(--text);
+}
+
+.domains-table th.sort-asc::after {
+  content: ' \u25B2';
+  font-size: 10px;
+}
+
+.domains-table th.sort-desc::after {
+  content: ' \u25BC';
+  font-size: 10px;
+}
+
+.domains-table td {
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+
+.domains-table td.numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.domains-table tbody tr:hover {
+  background: var(--bg);
+}
+
+.domains-table tbody tr.hidden {
+  display: none;
+}
+
+/* Status badges */
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.badge-new {
+  background: color-mix(in srgb, var(--success) 15%, transparent);
+  color: var(--success);
+}
+
+.badge-existing {
+  background: color-mix(in srgb, var(--text-secondary) 15%, transparent);
+  color: var(--text-secondary);
+}
+
+/* Domain cell styling */
+.domain-cell {
+  font-weight: 500;
+  color: var(--text);
+}
+
+.owner-cell {
+  color: var(--host-delivery);
+}
+
+.repo-cell {
+  color: var(--host-authoring);
+}
+
+.cdn-cell {
+  color: var(--text-secondary);
+}
+
+/* Empty and loading states inside main */
+.domains-main .loading {
+  padding: 60px 20px;
+}
+
+.domains-main .error-message {
+  margin: 20px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  #dashboard {
+    padding: 12px;
+  }
+
+  .header-top {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .header-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-input {
+    max-width: none;
+  }
+
+  .row-count {
+    text-align: right;
+  }
+}

--- a/domains.html
+++ b/domains.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Domain Explorer - CDN Analytics</title>
+  <script>
+    window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
+  </script>
+  <script defer type="text/javascript" src="https://ot.aem.live/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
+  <link rel="canonical" href="https://klickhaus.aemstatus.net/domains.html">
+
+  <!-- Favicon Icons -->
+  <link rel="apple-touch-icon" href="/icons/icon-180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/icon-32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png">
+
+  <link rel="stylesheet" href="css/variables.css">
+  <link rel="stylesheet" href="css/base.css">
+  <link rel="stylesheet" href="css/login.css">
+  <link rel="stylesheet" href="css/domains.css">
+</head>
+<body>
+  <!-- Login Form -->
+  <div id="login">
+    <div class="login-card">
+      <h1>Domain Explorer</h1>
+      <p>Sign in to explore AEM domain mappings</p>
+      <div id="loginError" class="error-message"></div>
+      <form id="loginForm">
+        <div class="form-group">
+          <label for="username">Username</label>
+          <input type="text" id="username" name="username" required autocomplete="username">
+        </div>
+        <div class="form-group">
+          <label for="password">Password</label>
+          <input type="password" id="password" name="password" required autocomplete="current-password">
+        </div>
+        <div class="form-group form-option">
+          <label class="checkbox-label">
+            <input type="checkbox" id="forgetMe" name="forgetMe">
+            Forget me on this device
+          </label>
+        </div>
+        <button type="submit" class="btn btn-primary">Sign In</button>
+      </form>
+    </div>
+  </div>
+
+  <!-- Dashboard -->
+  <div id="dashboard">
+    <header class="domains-header">
+      <div class="header-top">
+        <h1>Domain Explorer <span id="queryTimer" class="query-timer"></span></h1>
+        <div class="header-actions">
+          <button id="refreshBtn" class="btn btn-secondary" title="Refresh data">Refresh</button>
+          <button id="logoutBtn" class="btn btn-secondary" title="Sign out">Logout</button>
+        </div>
+      </div>
+      <div class="header-controls">
+        <input type="text" id="searchInput" class="search-input" placeholder="Filter by domain, owner, or repo...">
+        <span id="rowCount" class="row-count"></span>
+      </div>
+    </header>
+
+    <main class="domains-main">
+      <div id="loadingState" class="loading">
+        <div class="spinner"></div>
+        Loading domain mappings...
+      </div>
+      <div id="errorState" class="error-message"></div>
+      <div id="tableContainer" class="table-container">
+        <table id="domainsTable" class="domains-table">
+          <thead>
+            <tr>
+              <th data-col="domain" class="sortable">Domain</th>
+              <th data-col="owner" class="sortable">Owner</th>
+              <th data-col="repo" class="sortable">Repo</th>
+              <th data-col="cdn_type" class="sortable">CDN Type</th>
+              <th data-col="req_per_hour" class="sortable numeric">Req/hour</th>
+              <th data-col="total" class="sortable numeric">Total</th>
+              <th data-col="age_days" class="sortable">Status</th>
+            </tr>
+          </thead>
+          <tbody id="domainsBody"></tbody>
+        </table>
+      </div>
+    </main>
+  </div>
+
+  <script type="module" src="js/domains-main.js"></script>
+</body>
+</html>

--- a/domains.html
+++ b/domains.html
@@ -18,6 +18,8 @@
   <link rel="stylesheet" href="css/variables.css">
   <link rel="stylesheet" href="css/base.css">
   <link rel="stylesheet" href="css/login.css">
+  <link rel="stylesheet" href="css/layout.css">
+  <link rel="stylesheet" href="css/modals.css">
   <link rel="stylesheet" href="css/domains.css">
 </head>
 <body>
@@ -49,18 +51,35 @@
 
   <!-- Dashboard -->
   <div id="dashboard">
-    <header class="domains-header">
-      <div class="header-top">
+    <header>
+      <div class="header-left">
+        <a href="index.html" class="menu-btn" title="Quick Links">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <rect y="3" width="20" height="2" rx="1"/>
+            <rect y="9" width="20" height="2" rx="1"/>
+            <rect y="15" width="20" height="2" rx="1"/>
+          </svg>
+        </a>
         <h1>Domain Explorer <span id="queryTimer" class="query-timer"></span></h1>
-        <div class="header-actions">
-          <button id="refreshBtn" class="btn btn-secondary" title="Refresh data">Refresh</button>
-          <button id="logoutBtn" class="btn btn-secondary" title="Sign out">Logout</button>
-        </div>
-      </div>
-      <div class="header-controls">
-        <input type="text" id="searchInput" class="search-input" placeholder="Filter by domain, owner, or repo...">
         <span id="rowCount" class="row-count"></span>
       </div>
+      <div class="header-right">
+        <input type="text" id="searchInput" placeholder="Filter by domain, owner, or repo...">
+        <button id="moreBtn" class="menu-btn" title="More actions">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <circle cx="10" cy="4" r="1.5"/>
+            <circle cx="10" cy="10" r="1.5"/>
+            <circle cx="10" cy="16" r="1.5"/>
+          </svg>
+        </button>
+      </div>
+
+      <!-- More Actions Menu -->
+      <dialog id="moreMenu">
+        <button id="refreshBtn" class="menu-item">Refresh</button>
+        <div class="menu-divider"></div>
+        <button id="logoutBtn" class="menu-item">Logout</button>
+      </dialog>
     </header>
 
     <main class="domains-main">

--- a/domains.html
+++ b/domains.html
@@ -92,13 +92,13 @@
         <table id="domainsTable" class="domains-table">
           <thead>
             <tr>
-              <th data-col="domain" class="sortable">Domain</th>
-              <th data-col="owner" class="sortable">Owner</th>
-              <th data-col="repo" class="sortable">Repo</th>
-              <th data-col="cdn_type" class="sortable">CDN Type</th>
-              <th data-col="req_per_hour" class="sortable numeric">Req/hour</th>
-              <th data-col="total" class="sortable numeric">Total</th>
-              <th data-col="age_days" class="sortable">Status</th>
+              <th data-col="domain" class="sortable" aria-sort="none"><button type="button">Domain</button></th>
+              <th data-col="owner" class="sortable" aria-sort="none"><button type="button">Owner</button></th>
+              <th data-col="repo" class="sortable" aria-sort="none"><button type="button">Repo</button></th>
+              <th data-col="cdn_type" class="sortable" aria-sort="none"><button type="button">CDN Type</button></th>
+              <th data-col="req_per_hour" class="sortable numeric" aria-sort="none"><button type="button">Req/hour</button></th>
+              <th data-col="total" class="sortable numeric" aria-sort="none"><button type="button">Total</button></th>
+              <th data-col="age_days" class="sortable" aria-sort="ascending"><button type="button">Status</button></th>
             </tr>
           </thead>
           <tbody id="domainsBody"></tbody>

--- a/index.html
+++ b/index.html
@@ -50,6 +50,12 @@
           <div class="description">Lambda function logs: level, function name, app, subsystem, log group</div>
         </a>
       </li>
+      <li>
+        <a href="domains.html">
+          <div class="title">Domain Explorer</div>
+          <div class="description">Map AEM Edge Delivery hostnames to customer domains via x-forwarded-host</div>
+        </a>
+      </li>
     </ul>
 
     <div class="section">

--- a/js/domains-main.js
+++ b/js/domains-main.js
@@ -42,8 +42,7 @@ WHERE \`request.host\` LIKE '%.aem.live'
   AND \`request.headers.x_forwarded_host\` NOT LIKE '%oast%'
   AND timestamp > now() - INTERVAL 7 DAY
 GROUP BY domain, owner, repo, cdn_type
-HAVING (req_per_hour >= 1 OR total >= 1000)
-  AND NOT match(domain, '^[0-9.]+$')
+HAVING NOT match(domain, '^[0-9.]+$')
   AND domain NOT IN ('da.live', 'da.page', 'aem.live', 'docs.da.live', 'docs.da.page')
   AND domain NOT LIKE '%.aem.reviews'
   AND match(domain, '^[a-z0-9][a-z0-9.-]+\\.[a-z]{2,}$')
@@ -52,8 +51,8 @@ ORDER BY total DESC
 
 // State
 let rows = [];
-let sortCol = 'total';
-let sortAsc = false;
+let sortCol = 'age_days';
+let sortAsc = true;
 
 // DOM refs
 const els = {
@@ -85,6 +84,9 @@ function renderTable() {
     }
     if (va < vb) return sortAsc ? -1 : 1;
     if (va > vb) return sortAsc ? 1 : -1;
+    // Secondary sort: total descending
+    if (a.total > b.total) return -1;
+    if (a.total < b.total) return 1;
     return 0;
   });
 
@@ -104,7 +106,7 @@ function renderTable() {
       : `<span class="badge badge-existing">${row.age_days}d</span>`;
 
     return `<tr class="${matchesFilter ? '' : 'hidden'}">
-      <td class="domain-cell">${escapeHtml(row.domain)}</td>
+      <td class="domain-cell"><a href="https://${escapeHtml(row.domain)}" target="_blank" rel="noopener">${escapeHtml(row.domain)}</a></td>
       <td class="owner-cell">${escapeHtml(row.owner)}</td>
       <td class="repo-cell">${escapeHtml(row.repo)}</td>
       <td class="cdn-cell">${escapeHtml(row.cdn_type || '\u2014')}</td>

--- a/js/domains-main.js
+++ b/js/domains-main.js
@@ -180,13 +180,37 @@ els.searchInput.addEventListener('input', () => {
   renderTable();
 });
 
+// Kebab menu
+const moreMenu = document.getElementById('moreMenu');
+const moreBtn = document.getElementById('moreBtn');
+
+moreBtn.addEventListener('click', () => {
+  if (moreMenu.open) {
+    moreMenu.close();
+    return;
+  }
+  const rect = moreBtn.getBoundingClientRect();
+  moreMenu.style.top = `${rect.bottom + 4}px`;
+  moreMenu.style.right = `${document.documentElement.clientWidth - rect.right}px`;
+  moreMenu.style.left = 'auto';
+  moreMenu.show();
+});
+
+document.addEventListener('click', (e) => {
+  if (moreMenu.open && !moreMenu.contains(e.target) && !moreBtn.contains(e.target)) {
+    moreMenu.close();
+  }
+});
+
 // Refresh
 document.getElementById('refreshBtn').addEventListener('click', () => {
+  moreMenu.close();
   loadData();
 });
 
 // Logout
 document.getElementById('logoutBtn').addEventListener('click', () => {
+  moreMenu.close();
   handleLogout();
 });
 

--- a/js/domains-main.js
+++ b/js/domains-main.js
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { state } from './state.js';
+import { query } from './api.js';
+import { DATABASE } from './config.js';
+import { formatNumber, formatQueryTime } from './format.js';
+import {
+  setElements, loadStoredCredentials, handleLogin, handleLogout, showLogin, showDashboard,
+} from './auth.js';
+
+const DOMAIN_QUERY = `
+SELECT
+  \`request.headers.x_forwarded_host\` AS domain,
+  splitByString('--', replaceOne(\`request.host\`, '.aem.live', ''))[3] AS owner,
+  splitByString('--', replaceOne(\`request.host\`, '.aem.live', ''))[2] AS repo,
+  \`request.headers.x_byo_cdn_type\` AS cdn_type,
+  round(count() / (dateDiff('hour', min(timestamp), max(timestamp)) + 1), 1) AS req_per_hour,
+  count() AS total,
+  dateDiff('day', min(timestamp), now()) AS age_days
+FROM {database}.cdn_requests_v2
+WHERE \`request.host\` LIKE '%.aem.live'
+  AND \`request.headers.x_forwarded_host\` != ''
+  AND \`request.headers.x_forwarded_host\` != \`request.host\`
+  AND \`request.headers.x_forwarded_host\` NOT LIKE '%.aem.live'
+  AND \`request.headers.x_forwarded_host\` NOT LIKE '%.aem.page'
+  AND \`request.headers.x_forwarded_host\` NOT LIKE 'localhost%'
+  AND \`request.headers.x_forwarded_host\` NOT LIKE '%.workers.dev'
+GROUP BY domain, owner, repo, cdn_type
+ORDER BY total DESC
+`.replace('{database}', DATABASE);
+
+// State
+let rows = [];
+let sortCol = 'total';
+let sortAsc = false;
+
+// DOM refs
+const els = {
+  loginSection: document.getElementById('login'),
+  dashboardSection: document.getElementById('dashboard'),
+  loginError: document.getElementById('loginError'),
+  queryTimer: document.getElementById('queryTimer'),
+  searchInput: document.getElementById('searchInput'),
+  rowCount: document.getElementById('rowCount'),
+  loadingState: document.getElementById('loadingState'),
+  errorState: document.getElementById('errorState'),
+  tableContainer: document.getElementById('tableContainer'),
+  domainsBody: document.getElementById('domainsBody'),
+};
+
+function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+function renderTable() {
+  const sorted = [...rows].sort((a, b) => {
+    let va = a[sortCol];
+    let vb = b[sortCol];
+    if (typeof va === 'string') {
+      va = va.toLowerCase();
+      vb = vb.toLowerCase();
+    }
+    if (va < vb) return sortAsc ? -1 : 1;
+    if (va > vb) return sortAsc ? 1 : -1;
+    return 0;
+  });
+
+  const filterText = els.searchInput.value.toLowerCase().trim();
+
+  let visibleCount = 0;
+  const html = sorted.map((row) => {
+    const matchesFilter = !filterText
+      || row.domain.toLowerCase().includes(filterText)
+      || row.owner.toLowerCase().includes(filterText)
+      || row.repo.toLowerCase().includes(filterText);
+
+    if (matchesFilter) visibleCount += 1;
+
+    const statusBadge = row.age_days <= 7
+      ? `<span class="badge badge-new">New (${row.age_days}d)</span>`
+      : '<span class="badge badge-existing">Existing</span>';
+
+    return `<tr class="${matchesFilter ? '' : 'hidden'}">
+      <td class="domain-cell">${escapeHtml(row.domain)}</td>
+      <td class="owner-cell">${escapeHtml(row.owner)}</td>
+      <td class="repo-cell">${escapeHtml(row.repo)}</td>
+      <td class="cdn-cell">${escapeHtml(row.cdn_type || '\u2014')}</td>
+      <td class="numeric">${formatNumber(row.req_per_hour)}</td>
+      <td class="numeric">${formatNumber(row.total)}</td>
+      <td>${statusBadge}</td>
+    </tr>`;
+  }).join('');
+
+  els.domainsBody.innerHTML = html;
+  els.rowCount.textContent = filterText
+    ? `${visibleCount} of ${rows.length} domains`
+    : `${rows.length} domains`;
+
+  // Update sort indicators
+  document.querySelectorAll('.domains-table th').forEach((th) => {
+    th.classList.remove('sort-asc', 'sort-desc');
+    if (th.dataset.col === sortCol) {
+      th.classList.add(sortAsc ? 'sort-asc' : 'sort-desc');
+    }
+  });
+}
+
+async function loadData() {
+  els.loadingState.style.display = '';
+  els.errorState.classList.remove('visible');
+  els.tableContainer.style.display = 'none';
+
+  try {
+    const start = performance.now();
+    const data = await query(DOMAIN_QUERY, { cacheTtl: 300 });
+    const elapsed = performance.now() - start;
+
+    rows = data.data.map((r) => ({
+      domain: r.domain,
+      owner: r.owner,
+      repo: r.repo,
+      cdn_type: r.cdn_type,
+      req_per_hour: parseFloat(r.req_per_hour),
+      total: parseInt(r.total, 10),
+      age_days: parseInt(r.age_days, 10),
+    }));
+
+    els.queryTimer.textContent = `(${formatQueryTime(elapsed)})`;
+    els.loadingState.style.display = 'none';
+    els.tableContainer.style.display = '';
+    renderTable();
+  } catch (err) {
+    els.loadingState.style.display = 'none';
+    els.errorState.textContent = `Failed to load: ${err.message}`;
+    els.errorState.classList.add('visible');
+  }
+}
+
+// Sort on column header click
+document.querySelectorAll('.domains-table th.sortable').forEach((th) => {
+  th.addEventListener('click', () => {
+    const { col } = th.dataset;
+    if (sortCol === col) {
+      sortAsc = !sortAsc;
+    } else {
+      sortCol = col;
+      sortAsc = col === 'domain' || col === 'owner' || col === 'repo' || col === 'cdn_type';
+    }
+    renderTable();
+  });
+});
+
+// Search filtering
+els.searchInput.addEventListener('input', () => {
+  renderTable();
+});
+
+// Refresh
+document.getElementById('refreshBtn').addEventListener('click', () => {
+  loadData();
+});
+
+// Logout
+document.getElementById('logoutBtn').addEventListener('click', () => {
+  handleLogout();
+});
+
+// Wire up auth module
+setElements({
+  loginSection: els.loginSection,
+  dashboardSection: els.dashboardSection,
+  loginError: els.loginError,
+});
+
+// Login form
+document.getElementById('loginForm').addEventListener('submit', handleLogin);
+
+// On successful login, show dashboard and load data
+window.addEventListener('login-success', () => {
+  showDashboard();
+  loadData();
+});
+
+// Auto-login from stored credentials
+const stored = loadStoredCredentials();
+if (stored) {
+  state.credentials = stored;
+  query('SELECT 1').then(() => {
+    showDashboard();
+    loadData();
+  }).catch(() => {
+    showLogin();
+  });
+} else {
+  showLogin();
+}

--- a/sql/queries/domains.sql
+++ b/sql/queries/domains.sql
@@ -1,0 +1,29 @@
+SELECT
+  lower(trimRight(splitByChar(':',
+    trimBoth(splitByChar(',', `request.headers.x_forwarded_host`)[1])
+  )[1], '.')) AS domain,
+  splitByString('--', replaceOne(`request.host`, '.aem.live', ''))[3] AS owner,
+  splitByString('--', replaceOne(`request.host`, '.aem.live', ''))[2] AS repo,
+  `request.headers.x_byo_cdn_type` AS cdn_type,
+  round(count() / (dateDiff('hour', min(timestamp), max(timestamp)) + 1), 1) AS req_per_hour,
+  count() AS total,
+  dateDiff('day', min(timestamp), now()) AS age_days
+FROM {{database}}.cdn_requests_v2
+WHERE `request.host` LIKE '%.aem.live'
+  AND `request.headers.x_forwarded_host` != ''
+  AND `request.headers.x_forwarded_host` != `request.host`
+  AND `request.headers.x_forwarded_host` NOT LIKE '%.aem.live'
+  AND `request.headers.x_forwarded_host` NOT LIKE '%.aem.page'
+  AND `request.headers.x_forwarded_host` NOT LIKE 'localhost%'
+  AND `request.headers.x_forwarded_host` NOT LIKE '%.workers.dev%'
+  AND `request.headers.x_forwarded_host` NOT LIKE '%<%'
+  AND `request.headers.x_forwarded_host` NOT LIKE '%{%'
+  AND `request.headers.x_forwarded_host` NOT LIKE '%/%'
+  AND `request.headers.x_forwarded_host` NOT LIKE '%oast%'
+  AND timestamp > now() - INTERVAL 7 DAY
+GROUP BY domain, owner, repo, cdn_type
+HAVING NOT match(domain, '^[0-9.]+$')
+  AND domain NOT IN ('da.live', 'da.page', 'aem.live', 'docs.da.live', 'docs.da.page')
+  AND domain NOT LIKE '%.aem.reviews'
+  AND match(domain, '^[a-z0-9][a-z0-9.-]+\.[a-z]{2,}$')
+ORDER BY total DESC


### PR DESCRIPTION
## Summary
- Add new `domains.html` standalone page that maps AEM Edge Delivery `owner--repo--ref.aem.live` hostnames to actual customer domains via the `x_forwarded_host` header
- Sortable/filterable table with columns: Domain, Owner, Repo, CDN Type, Req/hour, Total, and Status (new vs existing badges)
- Reuses existing auth, API, config, and format modules — no changes to shared code
- Added "Domain Explorer" link to `index.html` quick links

## Testing Done
- `npm run lint` passes with no new errors
- Dev server starts and page loads at `http://localhost:5391/domains.html`
- Login form works with read-only credentials
- Table renders domain mappings from ClickHouse query
- Client-side search filters rows by domain, owner, or repo
- Column header sorting works (ascending/descending toggle)
- "New (Xd)" badges appear for domains with age_days <= 7
- Dark mode supported via shared CSS custom properties

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)