### PR TITLE
Lambda dashboard: message, invocation ID, admin duration facets; sema…

### DIFF
--- a/js/breakdowns/approx-top.test.js
+++ b/js/breakdowns/approx-top.test.js
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { state } from '../state.js';
+import { loadBreakdown, loadAllBreakdownsRefined, resetFacetTimings } from './index.js';
+import { DEFAULT_TOP_N } from '../constants.js';
+import { startRequestContext } from '../request-context.js';
+import { setQueryTimestamp } from '../time.js';
+
+// SQL templates used by loadBreakdown
+const BREAKDOWN_SQL_TEMPLATE = 'SELECT\n  {{col}} as dim,\n  {{aggTotal}} as cnt,\n  {{aggOk}} as cnt_ok,\n  {{agg4xx}} as cnt_4xx,\n  {{agg5xx}} as cnt_5xx{{summaryCol}}\nFROM {{database}}.{{table}}\n{{sampleClause}}\nWHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{extra}} {{additionalWhereClause}}\nGROUP BY dim WITH TOTALS\nORDER BY {{orderBy}}\nLIMIT {{topN}}\n';
+
+const APPROX_TOP_SQL_TEMPLATE = 'WITH top_dims AS (\n  SELECT tupleElement(pair, 1) AS dim\n  FROM (\n    SELECT arrayJoin(approx_top_count({{topN}})({{col}})) AS pair\n    FROM {{database}}.{{table}}\n    {{sampleClause}}\n    WHERE {{timeFilter}} {{hostFilter}} {{extra}} {{additionalWhereClause}}\n  )\n)\nSELECT {{col}} AS dim, {{aggTotal}} AS cnt, {{aggOk}} AS cnt_ok,\n  {{agg4xx}} AS cnt_4xx, {{agg5xx}} AS cnt_5xx{{summaryCol}}\nFROM {{database}}.{{table}}\nWHERE {{timeFilter}} {{hostFilter}} {{extra}} {{additionalWhereClause}}\n  AND {{col}} IN (SELECT dim FROM top_dims)\nGROUP BY dim\nORDER BY cnt DESC\nLIMIT {{topN}}\nUNION ALL\nSELECT \'\' AS dim, {{aggTotal}} AS cnt, {{aggOk}} AS cnt_ok,\n  {{agg4xx}} AS cnt_4xx, {{agg5xx}} AS cnt_5xx{{summaryCol}}\nFROM {{database}}.{{table}}\nWHERE {{timeFilter}} {{hostFilter}} {{extra}} {{additionalWhereClause}}\n';
+
+function createMockFetch(queryResponse = {
+  data: [{
+    dim: 'test', cnt: '100', cnt_ok: '90', cnt_4xx: '8', cnt_5xx: '2',
+  }],
+  totals: {
+    cnt: '100', cnt_ok: '90', cnt_4xx: '8', cnt_5xx: '2',
+  },
+}) {
+  const calls = [];
+  const mockFetch = async (url, options) => {
+    calls.push({ url, options });
+    if (typeof url === 'string' && url.endsWith('.sql')) {
+      let template = BREAKDOWN_SQL_TEMPLATE;
+      if (url.includes('breakdown-approx-top.sql')) template = APPROX_TOP_SQL_TEMPLATE;
+      return { ok: true, text: async () => template };
+    }
+    if (options && options.method === 'POST') {
+      return {
+        ok: true,
+        json: async () => ({ ...queryResponse, networkTime: 42 }),
+      };
+    }
+    return { ok: false, status: 404 };
+  };
+  return { fetch: mockFetch, calls };
+}
+
+function createCard(id, title) {
+  let card = document.getElementById(id);
+  if (card) card.remove();
+  card = document.createElement('div');
+  card.id = id;
+  const h3 = document.createElement('h3');
+  h3.textContent = title;
+  card.appendChild(h3);
+  document.body.appendChild(card);
+  return card;
+}
+
+beforeEach(() => {
+  state.breakdowns = null;
+  state.filters = [];
+  state.hiddenFacets = [];
+  state.hostFilter = '';
+  state.additionalWhereClause = '';
+  state.contentTypeMode = 'count';
+  state.topN = DEFAULT_TOP_N;
+  state.aggregations = null;
+  state.tableName = 'cdn_requests_v2';
+  state.credentials = { user: 'test', password: 'test' };
+  state.timeRange = '1h';
+  state.pinnedFacets = [];
+  setQueryTimestamp(new Date('2025-06-01T12:00:00Z'));
+  startRequestContext('facets');
+  resetFacetTimings();
+});
+
+describe('approx_top_count refinement for high-cardinality breakdowns', () => {
+  const approxId = 'breakdown-approx-top-test';
+  let card;
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = window.fetch;
+    card = createCard(approxId, 'Approx Top');
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    state.breakdowns = null;
+    if (card && card.parentNode) card.remove();
+  });
+
+  it('uses approx_top_count for high-cardinality refinement', async () => {
+    const { fetch: mockFetch, calls } = createMockFetch({
+      data: [
+        {
+          dim: 'msg-a', cnt: '500', cnt_ok: '500', cnt_4xx: '0', cnt_5xx: '0',
+        },
+        {
+          dim: '', cnt: '1000', cnt_ok: '900', cnt_4xx: '80', cnt_5xx: '20',
+        },
+      ],
+      totals: {},
+    });
+    window.fetch = mockFetch;
+
+    const b = { id: approxId, col: '`message`', highCardinality: true };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx, { sampleClause: '', multiplier: 1 });
+
+    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    assert.isAbove(queryCalls.length, 0, 'should send query');
+    const queryBody = queryCalls[0].options.body;
+    assert.include(queryBody, 'approx_top_count', 'should use approx_top_count');
+    assert.include(queryBody, 'UNION ALL', 'should include UNION ALL for totals');
+  });
+
+  it('extracts dim="" row as totals from UNION ALL result', async () => {
+    const { fetch: mockFetch } = createMockFetch({
+      data: [
+        {
+          dim: 'msg-a', cnt: '500', cnt_ok: '450', cnt_4xx: '40', cnt_5xx: '10',
+        },
+        {
+          dim: 'msg-b', cnt: '300', cnt_ok: '280', cnt_4xx: '15', cnt_5xx: '5',
+        },
+        {
+          dim: '', cnt: '1000', cnt_ok: '900', cnt_4xx: '80', cnt_5xx: '20',
+        },
+      ],
+      totals: {},
+    });
+    window.fetch = mockFetch;
+
+    const b = { id: approxId, col: '`message`', highCardinality: true };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx, { sampleClause: '', multiplier: 1 });
+
+    // The totals row (dim='') should be extracted, not displayed as data
+    const rows = card.querySelectorAll('tr');
+    const dimCells = Array.from(rows).map((r) => r.querySelector('td')?.textContent).filter(Boolean);
+    assert.notInclude(dimCells, '', 'totals row should not appear as data');
+  });
+
+  it('does not use approx-top for non-high-cardinality refinement', async () => {
+    const { fetch: mockFetch, calls } = createMockFetch();
+    window.fetch = mockFetch;
+
+    const b = { id: approxId, col: '`source`' };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx, { sampleClause: '', multiplier: 1 });
+
+    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    assert.isAbove(queryCalls.length, 0, 'should send query');
+    const queryBody = queryCalls[0].options.body;
+    assert.notInclude(queryBody, 'approx_top_count', 'should not use approx_top_count');
+    assert.include(queryBody, 'GROUP BY dim WITH TOTALS', 'should use regular GROUP BY');
+  });
+
+  it('does not use approx-top for initial sampled load', async () => {
+    const { fetch: mockFetch, calls } = createMockFetch();
+    window.fetch = mockFetch;
+
+    const b = { id: approxId, col: '`message`', highCardinality: true };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx, { sampleClause: 'SAMPLE 0.01', multiplier: 100 });
+
+    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    assert.isAbove(queryCalls.length, 0, 'should send query');
+    const queryBody = queryCalls[0].options.body;
+    assert.notInclude(queryBody, 'approx_top_count', 'should not use approx_top_count');
+    assert.include(queryBody, 'SAMPLE 0.01', 'should use sampling');
+  });
+
+  it('uses approx-top via loadAllBreakdownsRefined', async () => {
+    state.breakdowns = [{ id: approxId, col: '`message`', highCardinality: true }];
+    const { fetch: mockFetch, calls } = createMockFetch({
+      data: [
+        {
+          dim: 'msg-a', cnt: '500', cnt_ok: '500', cnt_4xx: '0', cnt_5xx: '0',
+        },
+        {
+          dim: '', cnt: '1000', cnt_ok: '900', cnt_4xx: '80', cnt_5xx: '20',
+        },
+      ],
+      totals: {},
+    });
+    window.fetch = mockFetch;
+
+    await loadAllBreakdownsRefined(startRequestContext('facets'));
+
+    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    assert.isAbove(queryCalls.length, 0, 'should send query');
+    const queryBody = queryCalls[0].options.body;
+    assert.include(queryBody, 'approx_top_count', 'should use approx_top_count');
+    assert.include(queryBody, 'UNION ALL', 'should include UNION ALL for totals');
+  });
+});

--- a/js/breakdowns/definitions-lambda.js
+++ b/js/breakdowns/definitions-lambda.js
@@ -12,7 +12,7 @@
 
 import { timeElapsedBuckets, getTimeElapsedLabels } from './buckets.js';
 
-/** Raw column for admin.duration in ms (message_json.admin.duration assumed to be seconds). */
+/** Raw column for admin.duration in ms (message_json.admin.duration is in milliseconds). */
 const ADMIN_DURATION_MS = 'toFloat64OrZero(CAST(message_json.admin.duration, \'String\'))';
 
 /**

--- a/js/breakdowns/definitions-lambda.js
+++ b/js/breakdowns/definitions-lambda.js
@@ -10,6 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
+import { timeElapsedBuckets, getTimeElapsedLabels } from './buckets.js';
+
+/** Raw column for admin.duration in ms (message_json.admin.duration assumed to be seconds). */
+const ADMIN_DURATION_MS = 'toFloat64OrZero(CAST(message_json.admin.duration, \'String\'))';
+
 /**
  * Breakdown (facet) definitions for the lambda_logs table.
  */
@@ -42,5 +47,25 @@ export const lambdaBreakdowns = [
   {
     id: 'breakdown-admin-method',
     col: 'CAST(message_json.admin.method, \'String\')',
+  },
+  {
+    id: 'breakdown-message',
+    col: '`message`',
+    highCardinality: true,
+  },
+  {
+    id: 'breakdown-request-id',
+    col: '`request_id`',
+    highCardinality: true,
+  },
+  {
+    id: 'breakdown-admin-duration',
+    col: timeElapsedBuckets,
+    rawCol: ADMIN_DURATION_MS,
+    orderBy: `min(${ADMIN_DURATION_MS})`,
+    summaryCountIf: `${ADMIN_DURATION_MS} >= 1000`,
+    summaryLabel: 'slow (≥1s)',
+    summaryColor: 'warning',
+    getExpectedLabels: getTimeElapsedLabels,
   },
 ];

--- a/js/breakdowns/definitions-lambda.js
+++ b/js/breakdowns/definitions-lambda.js
@@ -22,7 +22,7 @@ export const lambdaBreakdowns = [
   {
     id: 'breakdown-level',
     col: '`level`',
-    summaryCountIf: "`level` = 'ERROR'",
+    summaryCountIf: "lower(`level`) = 'error'",
     summaryLabel: 'error rate',
     summaryColor: 'error',
   },

--- a/js/breakdowns/definitions-lambda.test.js
+++ b/js/breakdowns/definitions-lambda.test.js
@@ -76,7 +76,6 @@ describe('lambdaBreakdowns', () => {
     assert.ok(adminDuration);
     assert.strictEqual(typeof adminDuration.col, 'function');
     assert.include(adminDuration.rawCol, 'message_json.admin.duration');
-    // assert.include(adminDuration.rawCol, '* 1000');
     assert.strictEqual(typeof adminDuration.getExpectedLabels, 'function');
   });
 });

--- a/js/breakdowns/definitions-lambda.test.js
+++ b/js/breakdowns/definitions-lambda.test.js
@@ -38,7 +38,7 @@ describe('lambdaBreakdowns', () => {
   it('level facet has summaryCountIf for error rate', () => {
     const levelFacet = lambdaBreakdowns.find((b) => b.id === 'breakdown-level');
     assert.ok(levelFacet);
-    assert.strictEqual(levelFacet.summaryCountIf, "`level` = 'ERROR'");
+    assert.strictEqual(levelFacet.summaryCountIf, "lower(`level`) = 'error'");
     assert.strictEqual(levelFacet.summaryLabel, 'error rate');
   });
 

--- a/js/breakdowns/definitions-lambda.test.js
+++ b/js/breakdowns/definitions-lambda.test.js
@@ -13,11 +13,11 @@ import { assert } from 'chai';
 import { lambdaBreakdowns } from './definitions-lambda.js';
 
 describe('lambdaBreakdowns', () => {
-  it('has six facets', () => {
-    assert.strictEqual(lambdaBreakdowns.length, 6);
+  it('has nine facets', () => {
+    assert.strictEqual(lambdaBreakdowns.length, 9);
   });
 
-  it('each facet has id and col', () => {
+  it('each facet has id and col (string or function)', () => {
     const ids = [
       'breakdown-level',
       'breakdown-function-name',
@@ -25,10 +25,13 @@ describe('lambdaBreakdowns', () => {
       'breakdown-subsystem',
       'breakdown-log-group',
       'breakdown-admin-method',
+      'breakdown-message',
+      'breakdown-request-id',
+      'breakdown-admin-duration',
     ];
     lambdaBreakdowns.forEach((b, i) => {
       assert.strictEqual(b.id, ids[i]);
-      assert.isString(b.col);
+      assert.ok(typeof b.col === 'string' || typeof b.col === 'function');
     });
   });
 
@@ -52,5 +55,28 @@ describe('lambdaBreakdowns', () => {
     assert.include(adminMethod.col, 'message_json');
     assert.include(adminMethod.col, 'admin');
     assert.include(adminMethod.col, 'method');
+  });
+
+  it('message facet has col for message and is high cardinality', () => {
+    const messageFacet = lambdaBreakdowns.find((b) => b.id === 'breakdown-message');
+    assert.ok(messageFacet);
+    assert.strictEqual(messageFacet.col, '`message`');
+    assert.strictEqual(messageFacet.highCardinality, true);
+  });
+
+  it('request_id facet has col for request_id and is high cardinality', () => {
+    const requestIdFacet = lambdaBreakdowns.find((b) => b.id === 'breakdown-request-id');
+    assert.ok(requestIdFacet);
+    assert.strictEqual(requestIdFacet.col, '`request_id`');
+    assert.strictEqual(requestIdFacet.highCardinality, true);
+  });
+
+  it('admin-duration facet is bucketed with rawCol and getExpectedLabels', () => {
+    const adminDuration = lambdaBreakdowns.find((b) => b.id === 'breakdown-admin-duration');
+    assert.ok(adminDuration);
+    assert.strictEqual(typeof adminDuration.col, 'function');
+    assert.include(adminDuration.rawCol, 'message_json.admin.duration');
+    // assert.include(adminDuration.rawCol, '* 1000');
+    assert.strictEqual(typeof adminDuration.getExpectedLabels, 'function');
   });
 });

--- a/js/breakdowns/index.test.js
+++ b/js/breakdowns/index.test.js
@@ -50,7 +50,7 @@ describe('getBreakdowns', () => {
     state.breakdowns = lambdaBreakdowns;
     const result = getBreakdowns();
     assert.strictEqual(result, lambdaBreakdowns);
-    assert.strictEqual(result.length, 6);
+    assert.strictEqual(result.length, 9);
   });
 });
 

--- a/js/colors/definitions.js
+++ b/js/colors/definitions.js
@@ -25,7 +25,7 @@ function hashToLambdaColor(value) {
   for (let i = 0; i < value.length; i += 1) {
     h = (h * 31 + value.charCodeAt(i)) % 2147483647;
   }
-  const idx = Math.abs(h) % LAMBDA_COLORS.length;
+  const idx = h % LAMBDA_COLORS.length;
   return LAMBDA_COLORS[idx];
 }
 
@@ -329,13 +329,12 @@ export const colorRules = {
 
   // Lambda dashboard facets
   lambdaLevel: {
-    patterns: ['`level`', 'level'],
+    patterns: ['`level`'],
     getColor: (value) => {
       if (!value) return '';
       const v = value.toUpperCase();
       if (v === 'ERROR') return 'var(--status-server-error)';
       if (v === 'WARN' || v === 'WARNING') return 'var(--status-client-error)';
-      if (v === 'INFO' || v === 'DEBUG' || v === 'TRACE') return 'var(--status-ok)';
       return 'var(--status-ok)';
     },
   },
@@ -352,7 +351,7 @@ export const colorRules = {
       if (m === 'HEAD') return 'var(--method-head)';
       if (m === 'OPTIONS') return 'var(--method-options)';
       if (m === 'DELETE') return 'var(--method-delete)';
-      return 'var(--path-clean)';
+      return '';
     },
   },
 

--- a/js/colors/definitions.js
+++ b/js/colors/definitions.js
@@ -11,6 +11,24 @@
  */
 // Each rule maps column patterns to color determination logic
 
+/** Deterministic color for Lambda high-cardinality facets (app_name, subsystem, log_group). */
+function hashToLambdaColor(value) {
+  const LAMBDA_COLORS = [
+    'var(--path-clean)',
+    'var(--path-document)',
+    'var(--path-script)',
+    'var(--ct-image)',
+    'var(--host-delivery)',
+    'var(--host-authoring)',
+  ];
+  let h = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    h = (h * 31 + value.charCodeAt(i)) % 2147483647;
+  }
+  const idx = Math.abs(h) % LAMBDA_COLORS.length;
+  return LAMBDA_COLORS[idx];
+}
+
 export const colorRules = {
   status: {
     patterns: ['response.status'],
@@ -306,6 +324,59 @@ export const colorRules = {
       }
       // Relative URLs (start with / or don't have protocol)
       return 'var(--loc-relative)';
+    },
+  },
+
+  // Lambda dashboard facets
+  lambdaLevel: {
+    patterns: ['`level`', 'level'],
+    getColor: (value) => {
+      if (!value) return '';
+      const v = value.toUpperCase();
+      if (v === 'ERROR') return 'var(--status-server-error)';
+      if (v === 'WARN' || v === 'WARNING') return 'var(--status-client-error)';
+      if (v === 'INFO' || v === 'DEBUG' || v === 'TRACE') return 'var(--status-ok)';
+      return 'var(--status-ok)';
+    },
+  },
+
+  lambdaAdminMethod: {
+    patterns: ['admin.method', 'message_json.admin'],
+    getColor: (value) => {
+      if (!value) return '';
+      const m = value.toUpperCase();
+      if (m === 'GET') return 'var(--method-get)';
+      if (m === 'POST') return 'var(--method-post)';
+      if (m === 'PUT') return 'var(--method-put)';
+      if (m === 'PATCH') return 'var(--method-patch)';
+      if (m === 'HEAD') return 'var(--method-head)';
+      if (m === 'OPTIONS') return 'var(--method-options)';
+      if (m === 'DELETE') return 'var(--method-delete)';
+      return 'var(--path-clean)';
+    },
+  },
+
+  lambdaAppName: {
+    patterns: ['app_name'],
+    getColor: (value) => {
+      if (!value) return '';
+      return hashToLambdaColor(value);
+    },
+  },
+
+  lambdaSubsystem: {
+    patterns: ['subsystem'],
+    getColor: (value) => {
+      if (!value) return '';
+      return hashToLambdaColor(value);
+    },
+  },
+
+  lambdaLogGroup: {
+    patterns: ['log_group'],
+    getColor: (value) => {
+      if (!value) return '';
+      return hashToLambdaColor(value);
     },
   },
 };

--- a/js/colors/definitions.test.js
+++ b/js/colors/definitions.test.js
@@ -509,3 +509,50 @@ describe('colorRules.byoCdn', () => {
     assert.strictEqual(getColor('bunny'), 'var(--cdn-other)');
   });
 });
+
+describe('colorRules.lambdaLevel', () => {
+  const { getColor } = colorRules.lambdaLevel;
+
+  it('returns server error for ERROR', () => {
+    assert.strictEqual(getColor('ERROR'), 'var(--status-server-error)');
+  });
+
+  it('returns client error for WARN/WARNING', () => {
+    assert.strictEqual(getColor('WARN'), 'var(--status-client-error)');
+    assert.strictEqual(getColor('WARNING'), 'var(--status-client-error)');
+  });
+
+  it('returns ok for INFO/DEBUG/TRACE', () => {
+    assert.strictEqual(getColor('INFO'), 'var(--status-ok)');
+    assert.strictEqual(getColor('DEBUG'), 'var(--status-ok)');
+    assert.strictEqual(getColor('TRACE'), 'var(--status-ok)');
+  });
+});
+
+describe('colorRules.lambdaAdminMethod', () => {
+  const { getColor } = colorRules.lambdaAdminMethod;
+
+  it('maps HTTP methods to method colors', () => {
+    assert.strictEqual(getColor('GET'), 'var(--method-get)');
+    assert.strictEqual(getColor('POST'), 'var(--method-post)');
+    assert.strictEqual(getColor('DELETE'), 'var(--method-delete)');
+  });
+
+  it('returns path-clean for unknown method', () => {
+    assert.strictEqual(getColor('CUSTOM'), 'var(--path-clean)');
+  });
+});
+
+describe('colorRules.lambdaAppName', () => {
+  const { getColor } = colorRules.lambdaAppName;
+
+  it('returns a deterministic color for any value', () => {
+    const c = getColor('my-app');
+    assert.match(c, /^var\(--/);
+    assert.strictEqual(getColor('my-app'), c);
+  });
+
+  it('returns empty for falsy', () => {
+    assert.strictEqual(getColor(''), '');
+  });
+});

--- a/js/colors/definitions.test.js
+++ b/js/colors/definitions.test.js
@@ -538,8 +538,8 @@ describe('colorRules.lambdaAdminMethod', () => {
     assert.strictEqual(getColor('DELETE'), 'var(--method-delete)');
   });
 
-  it('returns path-clean for unknown method', () => {
-    assert.strictEqual(getColor('CUSTOM'), 'var(--path-clean)');
+  it('returns empty string for unknown method', () => {
+    assert.strictEqual(getColor('CUSTOM'), '');
   });
 });
 
@@ -550,6 +550,46 @@ describe('colorRules.lambdaAppName', () => {
     const c = getColor('my-app');
     assert.match(c, /^var\(--/);
     assert.strictEqual(getColor('my-app'), c);
+  });
+
+  it('returns empty for falsy', () => {
+    assert.strictEqual(getColor(''), '');
+  });
+
+  it('is deterministic across repeated calls', () => {
+    const inputs = ['helix-admin', 'helix-pipeline', 'content-bus', 'rum-collector'];
+    for (const input of inputs) {
+      assert.strictEqual(getColor(input), getColor(input));
+    }
+  });
+
+  it('different inputs can produce different colors', () => {
+    const colors = new Set(['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta'].map(getColor));
+    assert.isAbove(colors.size, 1, 'expected at least two distinct colors from six inputs');
+  });
+});
+
+describe('colorRules.lambdaSubsystem', () => {
+  const { getColor } = colorRules.lambdaSubsystem;
+
+  it('returns a deterministic CSS variable for a value', () => {
+    const c = getColor('my-subsystem');
+    assert.match(c, /^var\(--/);
+    assert.strictEqual(getColor('my-subsystem'), c);
+  });
+
+  it('returns empty for falsy', () => {
+    assert.strictEqual(getColor(''), '');
+  });
+});
+
+describe('colorRules.lambdaLogGroup', () => {
+  const { getColor } = colorRules.lambdaLogGroup;
+
+  it('returns a deterministic CSS variable for a value', () => {
+    const c = getColor('/aws/lambda/my-function');
+    assert.match(c, /^var\(--/);
+    assert.strictEqual(getColor('/aws/lambda/my-function'), c);
   });
 
   it('returns empty for falsy', () => {

--- a/js/lambda-main.js
+++ b/js/lambda-main.js
@@ -14,9 +14,9 @@ import { lambdaBreakdowns } from './breakdowns/definitions-lambda.js';
 
 const LAMBDA_AGGREGATIONS = {
   aggTotal: 'count()',
-  aggOk: "countIf(level NOT IN ('ERROR', 'WARN', 'WARNING'))",
-  agg4xx: "countIf(level IN ('WARN', 'WARNING'))",
-  agg5xx: "countIf(level = 'ERROR')",
+  aggOk: "countIf(lower(level) NOT IN ('error', 'warn', 'warning'))",
+  agg4xx: "countIf(lower(level) IN ('warn', 'warning'))",
+  agg5xx: "countIf(lower(level) = 'error')",
 };
 
 initDashboard({

--- a/js/sql-loader.js
+++ b/js/sql-loader.js
@@ -63,6 +63,7 @@ const ALL_TEMPLATES = [
   'logs',
   'logs-more',
   'breakdown',
+  'breakdown-approx-top',
   'breakdown-facet',
   'breakdown-missing',
   'autocomplete-hosts',

--- a/lambda.html
+++ b/lambda.html
@@ -111,6 +111,18 @@
           <h3>Admin method</h3>
           <div class="loading"><div class="spinner"></div>Loading...</div>
         </div>
+        <div class="breakdown-card" id="breakdown-message">
+          <h3>Message</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-request-id">
+          <h3>Invocation ID</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-admin-duration">
+          <h3>Admin duration</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
       </section>
       <section class="breakdowns breakdowns-hidden" id="breakdowns-hidden"></section>
       </div>

--- a/sql/queries/breakdown-approx-top.sql
+++ b/sql/queries/breakdown-approx-top.sql
@@ -1,0 +1,22 @@
+WITH top_dims AS (
+  SELECT tupleElement(pair, 1) AS dim
+  FROM (
+    SELECT arrayJoin(approx_top_count({{topN}})({{col}})) AS pair
+    FROM {{database}}.{{table}}
+    {{sampleClause}}
+    WHERE {{timeFilter}} {{hostFilter}} {{extra}} {{additionalWhereClause}}
+  )
+)
+SELECT {{col}} AS dim, {{aggTotal}} AS cnt, {{aggOk}} AS cnt_ok,
+  {{agg4xx}} AS cnt_4xx, {{agg5xx}} AS cnt_5xx{{summaryCol}}
+FROM {{database}}.{{table}}
+WHERE {{timeFilter}} {{hostFilter}} {{extra}} {{additionalWhereClause}}
+  AND {{col}} IN (SELECT dim FROM top_dims)
+GROUP BY dim
+ORDER BY cnt DESC
+LIMIT {{topN}}
+UNION ALL
+SELECT '' AS dim, {{aggTotal}} AS cnt, {{aggOk}} AS cnt_ok,
+  {{agg4xx}} AS cnt_4xx, {{agg5xx}} AS cnt_5xx{{summaryCol}}
+FROM {{database}}.{{table}}
+WHERE {{timeFilter}} {{hostFilter}} {{extra}} {{additionalWhereClause}}

--- a/sql/queries/time-series-lambda.sql
+++ b/sql/queries/time-series-lambda.sql
@@ -1,9 +1,10 @@
 SELECT
   {{bucket}} as t,
-  countIf(level NOT IN ('ERROR', 'WARN', 'WARNING')) as cnt_ok,
-  countIf(level IN ('WARN', 'WARNING')) as cnt_4xx,
-  countIf(level = 'ERROR') as cnt_5xx
+  countIf(lower(level) NOT IN ('error', 'warn', 'warning')){{mult}} as cnt_ok,
+  countIf(lower(level) IN ('warn', 'warning')){{mult}} as cnt_4xx,
+  countIf(lower(level) = 'error'){{mult}} as cnt_5xx
 FROM {{database}}.{{table}}
+{{sampleClause}}
 WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{additionalWhereClause}}
 GROUP BY t
 ORDER BY t WITH FILL FROM {{rangeStart}} TO {{rangeEnd}} STEP {{step}}


### PR DESCRIPTION
…ntic colors

Enhacements from #111.

- color coding for facet values - **DONE**
- function name and version in separate facets
- log message facet - **DONE**
- maybe facets for extracted url, path, ip, email, fields
- invocation id facet - **DONE assuming this was referring to request_id**

Also added a bucketed admin.duration per @dominique-pfister in Slack.  I want to get some input on this -- should `<1ms` simply be replaced with `0` or maybe just hidden altogether?  I believe this is a result of [toFloat64OrZero](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toFloat64OrZero) generated by Cursor handling rows with no `message_json` value.

This PR is in progress.  I have not addressed two of the items listed above yet, just wanted to get started with reviews.

@trieloff Please elaborate on `function name and version in separate facets`.  Currently there is one facet with values shown here:
<img width="398" height="348" alt="Screenshot 2026-02-10 at 4 38 41 PM" src="https://github.com/user-attachments/assets/2543dde6-96a6-47ea-80a1-3fdfc34b4cfc" />

For the proposed two-facet breakdown, would function name be `helix3/admin` and version be `v12`?  I am not clear on the relationship here and there does not seem to be much variety.