### PR TITLE
fix: show weekday in chart labels for time ranges > 24h

### DIFF
--- a/js/chart-state.js
+++ b/js/chart-state.js
@@ -351,14 +351,18 @@ export function formatScrubberTime(time) {
   const diffMs = now - time;
   const diffMinutes = Math.floor(diffMs / 60000);
 
-  // Format like x-axis: HH:MM:SS UTC
-  const timeStr = time.toLocaleTimeString('en-US', {
+  // Format like x-axis: HH:MM:SS UTC, with weekday prefix if > 24h ago
+  const hms = time.toLocaleTimeString('en-US', {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
     hour12: false,
     timeZone: 'UTC',
   });
+  const diffHours = diffMs / (60 * 60 * 1000);
+  const timeStr = diffHours > 24
+    ? `${time.toLocaleDateString('en-US', { weekday: 'short', timeZone: 'UTC' })} ${hms}`
+    : hms;
 
   // Add relative time if < 120 minutes ago
   let relativeStr = '';

--- a/js/chart-state.js
+++ b/js/chart-state.js
@@ -351,18 +351,16 @@ export function formatScrubberTime(time) {
   const diffMs = now - time;
   const diffMinutes = Math.floor(diffMs / 60000);
 
-  // Format like x-axis: HH:MM:SS UTC, with weekday prefix if > 24h ago
-  const hms = time.toLocaleTimeString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-    timeZone: 'UTC',
-  });
+  // Format time, with weekday prefix and no seconds if > 24h ago
   const diffHours = diffMs / (60 * 60 * 1000);
-  const timeStr = diffHours > 24
-    ? `${time.toLocaleDateString('en-US', { weekday: 'short', timeZone: 'UTC' })} ${hms}`
-    : hms;
+  const longRange = diffHours > 24;
+  const timeStr = longRange
+    ? `${time.toLocaleDateString('en-US', { weekday: 'short', timeZone: 'UTC' })} ${time.toLocaleTimeString('en-US', {
+      hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'UTC',
+    })}`
+    : time.toLocaleTimeString('en-US', {
+      hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false, timeZone: 'UTC',
+    });
 
   // Add relative time if < 120 minutes ago
   let relativeStr = '';

--- a/js/chart.js
+++ b/js/chart.js
@@ -144,7 +144,11 @@ function drawXAxisLabels(ctx, data, chartDimensions, intendedStartTime, intended
     const time = parseUTC(data[i].t);
     const elapsed = time.getTime() - intendedStartTime;
     const x = padding.left + (elapsed / intendedTimeRange) * chartWidth;
-    const label = time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' });
+    const timeStr = time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' });
+    const showDate = intendedTimeRange > 24 * 60 * 60 * 1000;
+    const label = showDate
+      ? `${time.toLocaleDateString('en-US', { weekday: 'short', timeZone: 'UTC' })} ${timeStr}`
+      : timeStr;
     const yPos = height - padding.bottom + 20;
 
     if (i === 0) {


### PR DESCRIPTION
## Summary
- Chart x-axis labels now include the abbreviated weekday (e.g. "Mon 14:30") when the time range exceeds 24 hours, so users can distinguish which day each data point belongs to
- Scrubber tooltip also prefixes the weekday for timestamps older than 24 hours
- Labels remain compact ("14:30") for shorter time ranges (≤ 24h)

## Testing Done
- `npm test` — all 459 tests pass
- `npm run lint` — no new errors (10 pre-existing errors in other files)

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)