### PR TITLE
perf: replace projections with facet table, sampling, and concurrency limiter

### DIFF
--- a/.claude/skills/playwright-cli/SKILL.md
+++ b/.claude/skills/playwright-cli/SKILL.md
@@ -1,23 +1,35 @@
 ---
 name: playwright-cli
 description: Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the user needs to navigate websites, interact with web pages, fill forms, take screenshots, test web applications, or extract information from web pages.
-allowed-tools: Bash(playwright-cli:*)
+allowed-tools: Bash(npx playwright-cli:*)
 ---
 
 # Browser Automation with playwright-cli
 
+`playwright-cli` is invoked via `npx playwright-cli <command>`. Do NOT try to install it — it is already available via npx.
+
+## Logging into the dashboard
+
+The dashboard stores credentials in `localStorage` under the key `clickhouse_credentials`. To log in programmatically (look up the password in `README.local.md`):
+
+```bash
+npx playwright-cli open http://localhost:5391/dashboard.html
+npx playwright-cli eval 'localStorage.setItem("clickhouse_credentials", JSON.stringify({user: "<username>", password: "<password>"}))'
+npx playwright-cli reload
+```
+
 ## Quick start
 
 ```bash
-playwright-cli open https://playwright.dev
-playwright-cli click e15
-playwright-cli type "page.click"
-playwright-cli press Enter
+npx playwright-cli open https://playwright.dev
+npx playwright-cli click e15
+npx playwright-cli type "page.click"
+npx playwright-cli press Enter
 ```
 
 ## Core workflow
 
-1. Navigate: `playwright-cli open https://example.com`
+1. Navigate: `npx playwright-cli open https://example.com`
 2. Interact using refs from the snapshot
 3. Re-snapshot after significant changes
 
@@ -26,148 +38,148 @@ playwright-cli press Enter
 ### Core
 
 ```bash
-playwright-cli open https://example.com/
-playwright-cli close
-playwright-cli type "search query"
-playwright-cli click e3
-playwright-cli dblclick e7
-playwright-cli fill e5 "user@example.com"
-playwright-cli drag e2 e8
-playwright-cli hover e4
-playwright-cli select e9 "option-value"
-playwright-cli upload ./document.pdf
-playwright-cli check e12
-playwright-cli uncheck e12
-playwright-cli snapshot
-playwright-cli eval "document.title"
-playwright-cli eval "el => el.textContent" e5
-playwright-cli dialog-accept
-playwright-cli dialog-accept "confirmation text"
-playwright-cli dialog-dismiss
-playwright-cli resize 1920 1080
+npx playwright-cli open https://example.com/
+npx playwright-cli close
+npx playwright-cli type "search query"
+npx playwright-cli click e3
+npx playwright-cli dblclick e7
+npx playwright-cli fill e5 "user@example.com"
+npx playwright-cli drag e2 e8
+npx playwright-cli hover e4
+npx playwright-cli select e9 "option-value"
+npx playwright-cli upload ./document.pdf
+npx playwright-cli check e12
+npx playwright-cli uncheck e12
+npx playwright-cli snapshot
+npx playwright-cli eval "document.title"
+npx playwright-cli eval "el => el.textContent" e5
+npx playwright-cli dialog-accept
+npx playwright-cli dialog-accept "confirmation text"
+npx playwright-cli dialog-dismiss
+npx playwright-cli resize 1920 1080
 ```
 
 ### Navigation
 
 ```bash
-playwright-cli go-back
-playwright-cli go-forward
-playwright-cli reload
+npx playwright-cli go-back
+npx playwright-cli go-forward
+npx playwright-cli reload
 ```
 
 ### Keyboard
 
 ```bash
-playwright-cli press Enter
-playwright-cli press ArrowDown
-playwright-cli keydown Shift
-playwright-cli keyup Shift
+npx playwright-cli press Enter
+npx playwright-cli press ArrowDown
+npx playwright-cli keydown Shift
+npx playwright-cli keyup Shift
 ```
 
 ### Mouse
 
 ```bash
-playwright-cli mousemove 150 300
-playwright-cli mousedown
-playwright-cli mousedown right
-playwright-cli mouseup
-playwright-cli mouseup right
-playwright-cli mousewheel 0 100
+npx playwright-cli mousemove 150 300
+npx playwright-cli mousedown
+npx playwright-cli mousedown right
+npx playwright-cli mouseup
+npx playwright-cli mouseup right
+npx playwright-cli mousewheel 0 100
 ```
 
 ### Save as
 
 ```bash
-playwright-cli screenshot
-playwright-cli screenshot e5
-playwright-cli pdf
+npx playwright-cli screenshot
+npx playwright-cli screenshot e5
+npx playwright-cli pdf
 ```
 
 ### Tabs
 
 ```bash
-playwright-cli tab-list
-playwright-cli tab-new
-playwright-cli tab-new https://example.com/page
-playwright-cli tab-close
-playwright-cli tab-close 2
-playwright-cli tab-select 0
+npx playwright-cli tab-list
+npx playwright-cli tab-new
+npx playwright-cli tab-new https://example.com/page
+npx playwright-cli tab-close
+npx playwright-cli tab-close 2
+npx playwright-cli tab-select 0
 ```
 
 ### DevTools
 
 ```bash
-playwright-cli console
-playwright-cli console warning
-playwright-cli network
-playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
-playwright-cli tracing-start
-playwright-cli tracing-stop
-playwright-cli video-start
-playwright-cli video-stop video.webm
+npx playwright-cli console
+npx playwright-cli console warning
+npx playwright-cli network
+npx playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+npx playwright-cli tracing-start
+npx playwright-cli tracing-stop
+npx playwright-cli video-start
+npx playwright-cli video-stop video.webm
 ```
 
 ### Configuration
 ```bash
 # Configure the session
-playwright-cli config --config my-config.json
-playwright-cli config --headed --isolated --browser=firefox
+npx playwright-cli config --config my-config.json
+npx playwright-cli config --headed --isolated --browser=firefox
 # Configure named session
-playwright-cli --session=mysession config my-config.json
+npx playwright-cli --session=mysession config my-config.json
 # Start with configured session
-playwright-cli open --config=my-config.json
+npx playwright-cli open --config=my-config.json
 ```
 
 ### Sessions
 
 ```bash
-playwright-cli --session=mysession open example.com
-playwright-cli --session=mysession click e6
-playwright-cli session-list
-playwright-cli session-stop mysession
-playwright-cli session-stop-all
-playwright-cli session-delete
-playwright-cli session-delete mysession
+npx playwright-cli --session=mysession open example.com
+npx playwright-cli --session=mysession click e6
+npx playwright-cli session-list
+npx playwright-cli session-stop mysession
+npx playwright-cli session-stop-all
+npx playwright-cli session-delete
+npx playwright-cli session-delete mysession
 ```
 
 ## Example: Form submission
 
 ```bash
-playwright-cli open https://example.com/form
-playwright-cli snapshot
+npx playwright-cli open https://example.com/form
+npx playwright-cli snapshot
 
-playwright-cli fill e1 "user@example.com"
-playwright-cli fill e2 "password123"
-playwright-cli click e3
-playwright-cli snapshot
+npx playwright-cli fill e1 "user@example.com"
+npx playwright-cli fill e2 "password123"
+npx playwright-cli click e3
+npx playwright-cli snapshot
 ```
 
 ## Example: Multi-tab workflow
 
 ```bash
-playwright-cli open https://example.com
-playwright-cli tab-new https://example.com/other
-playwright-cli tab-list
-playwright-cli tab-select 0
-playwright-cli snapshot
+npx playwright-cli open https://example.com
+npx playwright-cli tab-new https://example.com/other
+npx playwright-cli tab-list
+npx playwright-cli tab-select 0
+npx playwright-cli snapshot
 ```
 
 ## Example: Debugging with DevTools
 
 ```bash
-playwright-cli open https://example.com
-playwright-cli click e4
-playwright-cli fill e7 "test"
-playwright-cli console
-playwright-cli network
+npx playwright-cli open https://example.com
+npx playwright-cli click e4
+npx playwright-cli fill e7 "test"
+npx playwright-cli console
+npx playwright-cli network
 ```
 
 ```bash
-playwright-cli open https://example.com
-playwright-cli tracing-start
-playwright-cli click e4
-playwright-cli fill e7 "test"
-playwright-cli tracing-stop
+npx playwright-cli open https://example.com
+npx playwright-cli tracing-start
+npx playwright-cli click e4
+npx playwright-cli fill e7 "test"
+npx playwright-cli tracing-stop
 ```
 
 ## Specific tasks

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 package-lock.json
 coverage/
+.playwright-cli/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ node scripts/roll-user.mjs <admin-user> <admin-password> <username>
 node scripts/drop-user.mjs <admin-user> <admin-password> <username>
 ```
 
-New users get SELECT access to `cdn_requests_combined`, `cdn_requests_v2`, `releases`, `oncall_shifts`, and `lambda_logs`, plus dictGet access to `asn_dict`, along with the following performance/safety settings:
+New users get SELECT access to `cdn_requests_combined`, `cdn_requests_v2`, `cdn_facet_minutes`, `releases`, `oncall_shifts`, and `lambda_logs`, plus dictGet access to `asn_dict`, along with the following performance/safety settings:
 
 - `enable_parallel_replicas = 1` — queries are distributed across all replicas
 - `max_parallel_replicas = 6` — use up to 6 replicas for parallel reads
@@ -224,63 +224,70 @@ If you add new tail workers that make outbound requests to external services, ad
 
 These skip indexes accelerate queries by excluding granules that definitely don't match. Most requests (~93%) have `x_forwarded_host` and `x_forwarded_for` populated from upstream CDNs.
 
-#### Projections (Pre-aggregated Facets)
+#### Facet Table Architecture
 
-The table has two types of projections for dashboard facets:
+Dashboard breakdown queries use a dedicated `cdn_facet_minutes` SummingMergeTree table instead of projections on `cdn_requests_v2`. A materialized view (`cdn_facet_minutes_mv`) uses ARRAY JOIN to fan each incoming row into 14 facet entries, pre-aggregating low-cardinality facets at minute granularity.
 
-**Minute-level projections** (`proj_minute_*`) pre-aggregate by `toStartOfMinute(timestamp)` and facet column. These are the primary projections used by all dashboard breakdown and investigation queries.
-
-| Projection | Facet Column | Dashboard Use |
-|------------|--------------|---------------|
-| `proj_minute_url` | `request.url` | Top paths |
-| `proj_minute_user_agent` | `request.headers.user_agent` | User agents |
-| `proj_minute_referer` | `request.headers.referer` | Referrers |
-| `proj_minute_x_forwarded_host` | `request.headers.x_forwarded_host` | Origin hostnames |
-| `proj_minute_x_error` | `response.headers.x_error` | Error messages |
-| `proj_minute_x_error_grouped` | `REGEXP_REPLACE(x_error, '/[a-zA-Z0-9/_.-]+', '/...')` | Grouped errors |
-| `proj_minute_host` | `request.host` | Edge hostnames |
-| `proj_minute_method` | `request.method` | HTTP methods |
-| `proj_minute_datacenter` | `cdn.datacenter` | Edge locations |
-| `proj_minute_request_type` | `helix.request_type` | AEM request types |
-| `proj_minute_backend_type` | `helix.backend_type` | Backend types |
-| `proj_minute_content_type` | `response.headers.content_type` | Content types |
-| `proj_minute_cache_status` | `upper(cdn.cache_status)` | Cache status |
-| `proj_minute_client_ip` | `if(x_forwarded_for != '', x_forwarded_for, client.ip)` | Client IPs |
-| `proj_minute_status_range` | `concat(intDiv(response.status, 100), 'xx')` | Status ranges (2xx, 4xx) |
-| `proj_minute_status` | `toString(response.status)` | HTTP status codes |
-| `proj_minute_asn` | `client.asn` | ASN breakdown (integer-based) |
-| `proj_minute_source` | `source` | CDN source (cloudflare/fastly) |
-| `proj_minute_accept` | `request.headers.accept` | Accept header |
-| `proj_minute_accept_encoding` | `request.headers.accept_encoding` | Accept-Encoding header |
-| `proj_minute_cache_control` | `request.headers.cache_control` | Cache-Control header |
-| `proj_minute_byo_cdn` | `request.headers.x_byo_cdn_type` | BYO CDN type |
-| `proj_minute_location` | `response.headers.location` | Redirect location |
-| `proj_minute_time_elapsed` | `cdn.time_elapsed_msec` | Response time (raw value for bucketed queries) |
-| `proj_minute_content_length` | `response.headers.content_length` | Content length (raw value for bucketed queries) |
-
-**Bucketed facets** (time-elapsed, content-length) use a two-level query: the inner query groups by the raw column value (hitting `proj_minute_*`), the outer query applies `multiIf()` bucketing. This allows dynamic bucket boundaries while still benefiting from projections. See `sql/queries/breakdown-bucketed.sql`.
-
-Projections are automatically used by ClickHouse when the query matches the projection's GROUP BY. Dashboard facet queries that previously took 8-15s now complete in <1s.
-
-There is a **25 projection limit** on ClickHouse Cloud. Check current count before adding new ones.
-
-To add a new projection:
+**Schema:**
 ```sql
-ALTER TABLE helix_logs_production.cdn_requests_v2
-ADD PROJECTION proj_minute_example (
-    SELECT
-        toStartOfMinute(timestamp) as minute,
-        `column.name`,
-        count() as cnt,
-        countIf(`response.status` < 400) as cnt_ok,
-        countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-        countIf(`response.status` >= 500) as cnt_5xx
-    GROUP BY minute, `column.name`
-);
--- Materialize for existing data (runs in background, one at a time)
-ALTER TABLE helix_logs_production.cdn_requests_v2
-MATERIALIZE PROJECTION proj_minute_example;
+CREATE TABLE cdn_facet_minutes (
+    minute DateTime,
+    facet LowCardinality(String),
+    dim String,
+    cnt UInt64,
+    cnt_ok UInt64,
+    cnt_4xx UInt64,
+    cnt_5xx UInt64
+) ENGINE = SummingMergeTree
+PARTITION BY toDate(minute)
+ORDER BY (facet, minute, dim)
+TTL minute + toIntervalDay(14)
 ```
+
+**Facets in `cdn_facet_minutes`** (14 low-cardinality):
+
+| Facet Name | Source Column | Dashboard Use |
+|------------|---------------|---------------|
+| `status_range` | `concat(intDiv(response.status, 100), 'xx')` | Status ranges (2xx, 4xx) |
+| `source` | `source` | CDN source (cloudflare/fastly) |
+| `content_type` | `response.headers.content_type` | Content types |
+| `status` | `toString(response.status)` | HTTP status codes |
+| `x_error_grouped` | `REGEXP_REPLACE(x_error, '/[a-zA-Z0-9/_.-]+', '/...')` | Grouped errors |
+| `cache_status` | `upper(cdn.cache_status)` | Cache status |
+| `request_type` | `helix.request_type` | AEM request types |
+| `backend_type` | `helix.backend_type` | Backend types |
+| `method` | `request.method` | HTTP methods |
+| `datacenter` | `cdn.datacenter` | Edge locations |
+| `accept` | `request.headers.accept` | Accept header |
+| `accept_encoding` | `request.headers.accept_encoding` | Accept-Encoding header |
+| `cache_control` | `request.headers.cache_control` | Cache-Control header |
+| `byo_cdn` | `request.headers.x_byo_cdn_type` | BYO CDN type |
+
+**High-cardinality facets** (`highCardinality: true` in `js/breakdowns/definitions.js`) skip the facet table and query `cdn_requests_v2` directly with sampling: hosts, forwarded hosts, URLs, referers, user agents, client IPs, and redirect locations.
+
+**Query routing**: `canUseFacetTable()` in `js/breakdowns/index.js` routes a breakdown to the facet table when all of these are true:
+- The breakdown has a `facetName`
+- Not a bucketed facet (`rawCol`)
+- Not marked `highCardinality`
+- No host filter, column filters, or additional WHERE clauses are active
+- Not in bytes aggregation mode
+- Not the ASN breakdown (uses `dictGet` which produces different dim values)
+
+When any condition fails, the query falls back to `cdn_requests_v2` with sampling.
+
+**Bucketed facets** (time-elapsed, content-length) always query `cdn_requests_v2` with a two-level query: the inner query groups by the raw column value, the outer query applies `multiIf()` bucketing. See `sql/queries/breakdown-bucketed.sql`.
+
+**Historical note**: All projections on `cdn_requests_v2` have been dropped (zero remain). The original definitions are backed up in `sql/backup-projections.sql`. ClickHouse Cloud has a **25 projection limit** per table — the facet table approach avoids this constraint entirely.
+
+#### Query Routing and Sampling
+
+**Proportional sampling**: `getSamplingConfig()` in `js/time.js` uses `SAMPLE (1h / period)` for time ranges longer than 1 hour. This keeps scanned row count roughly constant regardless of time range (e.g., a 24h query samples ~4% of data). Ranges ≤ 1 hour use no sampling.
+
+**Concurrency limiter**: Breakdown queries fan out 20+ parallel queries (one per facet). A concurrency limiter (`js/concurrency-limiter.js`) caps this at **4 concurrent queries** to reduce ClickHouse query contention.
+
+**Performance characteristics**:
+- Low-cardinality facets (facet table): 3–50ms
+- High-cardinality facets (sampled raw table): 0.1–0.4s
 
 #### Column Groups
 
@@ -308,6 +315,7 @@ MATERIALIZE PROJECTION proj_minute_example;
 | Table | TTL | Purpose |
 |-------|-----|---------|
 | `cdn_requests_v2` | 2 weeks | Unified CDN logs (primary analytics table, partitioned) |
+| `cdn_facet_minutes` | 2 weeks | Pre-aggregated facet counts (SummingMergeTree, 14 facets at minute level) |
 | `cloudflare_http_requests` | 1 day | Raw Cloudflare Logpush data |
 | `cloudflare_tail_incoming` | 1 day | Raw Cloudflare Tail Worker logs (legacy) |
 | `fastly_logs_incoming2` | 1 day | Raw Fastly logs - helix5 main service |
@@ -348,7 +356,6 @@ GROUP BY `client.asn`  -- Filter on integer, not string
 **Benefits:**
 - Cloudflare requests now show ASN names (resolved via dictionary)
 - Filtering uses integer comparison (`client.asn = 13335`) instead of string matching
-- Projection `proj_facet_asn_num` pre-aggregates by integer ASN for faster queries
 
 ### Raw Table Schemas
 
@@ -383,6 +390,17 @@ WHERE timestamp > now() - INTERVAL 1 HOUR
   AND `response.status` >= 400
 GROUP BY `response.status`
 ORDER BY count() DESC;
+
+-- Facet table query (low-cardinality breakdowns)
+SELECT dim, sum(cnt) as cnt, sum(cnt_ok) as cnt_ok,
+       sum(cnt_4xx) as cnt_4xx, sum(cnt_5xx) as cnt_5xx
+FROM helix_logs_production.cdn_facet_minutes
+WHERE facet = 'cache_status'
+  AND minute >= now() - INTERVAL 1 HOUR
+  AND minute <= now()
+GROUP BY dim WITH TOTALS
+ORDER BY cnt DESC
+LIMIT 10;
 ```
 
 ## CLI Notes

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A real-time analytics dashboard for CDN log analysis, built with ClickHouse and 
 - **Flexible time ranges** - Last hour, 12 hours, 24 hours, or 7 days
 - **Dark mode support** - Automatic theme based on system preference
 - **Query caching** - Intelligent cache TTLs based on time range
+- **Fast facet queries** - Pre-aggregated facet table with proportional sampling for longer time ranges
 
 ## Architecture
 

--- a/js/anomaly-investigation.js
+++ b/js/anomaly-investigation.js
@@ -16,8 +16,7 @@
  */
 
 import { getTimeFilter } from './time.js';
-import { getFacetFilters } from './breakdowns/index.js';
-import { getBreakdowns } from './breakdowns/index.js';
+import { getFacetFilters, getBreakdowns } from './breakdowns/index.js';
 import { parseUTC } from './chart-state.js';
 import {
   CACHE_TOP_N,

--- a/js/anomaly-investigation.js
+++ b/js/anomaly-investigation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/breakdowns/definitions.js
+++ b/js/breakdowns/definitions.js
@@ -38,22 +38,27 @@ export function formatForwardedHost(dim) {
 
 export const allBreakdowns = [
   {
-    id: 'breakdown-status-range', col: "concat(toString(intDiv(`response.status`, 100)), 'xx')", summaryCountIf: '`response.status` >= 500', summaryLabel: 'error rate', summaryColor: 'error',
+    id: 'breakdown-status-range', col: "concat(toString(intDiv(`response.status`, 100)), 'xx')", facetName: 'status_range', summaryCountIf: '`response.status` >= 500', summaryLabel: 'error rate', summaryColor: 'error',
   },
   {
-    id: 'breakdown-source', col: '`source`', summaryCountIf: '`source` = \'fastly\'', summaryLabel: 'fastly',
+    id: 'breakdown-source', col: '`source`', facetName: 'source', summaryCountIf: '`source` = \'fastly\'', summaryLabel: 'fastly',
   },
   {
-    id: 'breakdown-hosts', col: COLUMN_DEFS.host.facetCol, linkFn: hostLink, dimPrefixes: ['main--'], summaryCountIf: "`request.host` LIKE '%.aem.live'", summaryLabel: 'live', highCardinality: true,
+    id: 'breakdown-hosts', col: COLUMN_DEFS.host.facetCol, facetName: 'host', linkFn: hostLink, dimPrefixes: ['main--'], summaryCountIf: "`request.host` LIKE '%.aem.live'", summaryLabel: 'live', highCardinality: true,
   },
   {
-    id: 'breakdown-forwarded-hosts', col: '`request.headers.x_forwarded_host`', linkFn: forwardedHostLink, dimFormatFn: formatForwardedHost, summaryCountIf: "`request.headers.x_forwarded_host` != ''", summaryLabel: 'production', highCardinality: true,
+    id: 'breakdown-forwarded-hosts', col: '`request.headers.x_forwarded_host`', facetName: 'x_forwarded_host', linkFn: forwardedHostLink, dimFormatFn: formatForwardedHost, summaryCountIf: "`request.headers.x_forwarded_host` != ''", summaryLabel: 'production', highCardinality: true,
   },
-  { id: 'breakdown-content-types', col: COLUMN_DEFS.contentType.facetCol, modeToggle: 'contentTypeMode' },
-  { id: 'breakdown-status', col: COLUMN_DEFS.status.facetCol, modeToggle: 'contentTypeMode' },
+  {
+    id: 'breakdown-content-types', col: COLUMN_DEFS.contentType.facetCol, facetName: 'content_type', modeToggle: 'contentTypeMode',
+  },
+  {
+    id: 'breakdown-status', col: COLUMN_DEFS.status.facetCol, facetName: 'status', modeToggle: 'contentTypeMode',
+  },
   {
     id: 'breakdown-errors',
     col: COLUMN_DEFS.errorGrouped.facetCol,
+    facetName: 'x_error_grouped',
     filterCol: '`response.headers.x_error`',
     // Convert grouped display value to LIKE pattern (replace /... with %)
     filterValueFn: (v) => v.replace(/\/\.\.\./g, '/%'),
@@ -61,50 +66,54 @@ export const allBreakdowns = [
     extraFilter: "AND `response.headers.x_error` != ''",
   },
   {
-    id: 'breakdown-cache', col: COLUMN_DEFS.cacheStatus.facetCol, summaryCountIf: "upper(`cdn.cache_status`) LIKE 'HIT%'", summaryLabel: 'cache efficiency',
+    id: 'breakdown-cache', col: COLUMN_DEFS.cacheStatus.facetCol, facetName: 'cache_status', summaryCountIf: "upper(`cdn.cache_status`) LIKE 'HIT%'", summaryLabel: 'cache efficiency',
   },
   {
-    id: 'breakdown-paths', col: COLUMN_DEFS.url.facetCol, linkFn: pathLink, modeToggle: 'contentTypeMode', highCardinality: true,
+    id: 'breakdown-paths', col: COLUMN_DEFS.url.facetCol, facetName: 'url', linkFn: pathLink, modeToggle: 'contentTypeMode', highCardinality: true,
   },
   {
-    id: 'breakdown-referers', col: COLUMN_DEFS.referer.facetCol, linkFn: refererLink, dimPrefixes: ['https://', 'http://'], highCardinality: true,
+    id: 'breakdown-referers', col: COLUMN_DEFS.referer.facetCol, facetName: 'referer', linkFn: refererLink, dimPrefixes: ['https://', 'http://'], highCardinality: true,
   },
   {
-    id: 'breakdown-user-agents', col: COLUMN_DEFS.userAgent.facetCol, dimPrefixes: ['Mozilla/5.0 '], summaryCountIf: "NOT `request.headers.user_agent` LIKE 'Mozilla/%' OR `request.headers.user_agent` LIKE '%+http%'", summaryLabel: 'bot rate', summaryColor: 'warning', highCardinality: true,
+    id: 'breakdown-user-agents', col: COLUMN_DEFS.userAgent.facetCol, facetName: 'user_agent', dimPrefixes: ['Mozilla/5.0 '], summaryCountIf: "NOT `request.headers.user_agent` LIKE 'Mozilla/%' OR `request.headers.user_agent` LIKE '%+http%'", summaryLabel: 'bot rate', summaryColor: 'warning', highCardinality: true,
   },
   {
-    id: 'breakdown-ips', col: COLUMN_DEFS.clientIp.facetCol, linkPrefix: 'https://centralops.net/co/DomainDossier?dom_whois=1&net_whois=1&addr=', summaryCountIf: "if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) LIKE '%:%'", summaryLabel: 'IPv6', highCardinality: true,
+    id: 'breakdown-ips', col: COLUMN_DEFS.clientIp.facetCol, facetName: 'client_ip', linkPrefix: 'https://centralops.net/co/DomainDossier?dom_whois=1&net_whois=1&addr=', summaryCountIf: "if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) LIKE '%:%'", summaryLabel: 'IPv6', highCardinality: true,
   },
   {
-    id: 'breakdown-request-type', col: COLUMN_DEFS.requestType.facetCol, extraFilter: "AND `helix.request_type` != ''", modeToggle: 'contentTypeMode',
+    id: 'breakdown-request-type', col: COLUMN_DEFS.requestType.facetCol, facetName: 'request_type', extraFilter: "AND `helix.request_type` != ''", modeToggle: 'contentTypeMode',
   },
   {
-    id: 'breakdown-tech-stack', col: COLUMN_DEFS.backendType.facetCol, modeToggle: 'contentTypeMode',
+    id: 'breakdown-tech-stack', col: COLUMN_DEFS.backendType.facetCol, facetName: 'backend_type', modeToggle: 'contentTypeMode',
   },
   {
-    id: 'breakdown-methods', col: COLUMN_DEFS.method.facetCol, summaryCountIf: "`request.method` IN ('POST', 'PUT', 'PATCH', 'DELETE')", summaryLabel: 'writes', summaryColor: 'warning',
-  },
-  { id: 'breakdown-datacenters', col: '`cdn.datacenter`', modeToggle: 'contentTypeMode' },
-  {
-    id: 'breakdown-asn', col: "concat(toString(`client.asn`), ' ', dictGet('helix_logs_production.asn_dict', 'name', `client.asn`))", filterCol: '`client.asn`', filterValueFn: (v) => parseInt(v.split(' ')[0], 10), dimFormatFn: formatAsn, extraFilter: 'AND `client.asn` != 0', linkPrefix: 'https://mxtoolbox.com/SuperTool.aspx?action=asn%3aAS', linkSuffix: '&run=toolpage', modeToggle: 'contentTypeMode',
+    id: 'breakdown-methods', col: COLUMN_DEFS.method.facetCol, facetName: 'method', summaryCountIf: "`request.method` IN ('POST', 'PUT', 'PATCH', 'DELETE')", summaryLabel: 'writes', summaryColor: 'warning',
   },
   {
-    id: 'breakdown-accept', col: COLUMN_DEFS.accept.facetCol, extraFilter: "AND `request.headers.accept` != ''", modeToggle: 'contentTypeMode',
+    id: 'breakdown-datacenters', col: '`cdn.datacenter`', facetName: 'datacenter', modeToggle: 'contentTypeMode',
   },
   {
-    id: 'breakdown-accept-encoding', col: COLUMN_DEFS.acceptEncoding.facetCol, extraFilter: "AND `request.headers.accept_encoding` != ''", modeToggle: 'contentTypeMode',
+    id: 'breakdown-asn', col: "concat(toString(`client.asn`), ' ', dictGet('helix_logs_production.asn_dict', 'name', `client.asn`))", facetName: 'asn', filterCol: '`client.asn`', filterValueFn: (v) => parseInt(v.split(' ')[0], 10), dimFormatFn: formatAsn, extraFilter: 'AND `client.asn` != 0', linkPrefix: 'https://mxtoolbox.com/SuperTool.aspx?action=asn%3aAS', linkSuffix: '&run=toolpage', modeToggle: 'contentTypeMode',
   },
   {
-    id: 'breakdown-req-cache-control', col: COLUMN_DEFS.cacheControl.facetCol, extraFilter: "AND `request.headers.cache_control` != ''", modeToggle: 'contentTypeMode',
+    id: 'breakdown-accept', col: COLUMN_DEFS.accept.facetCol, facetName: 'accept', extraFilter: "AND `request.headers.accept` != ''", modeToggle: 'contentTypeMode',
   },
   {
-    id: 'breakdown-byo-cdn', col: COLUMN_DEFS.byoCdn.facetCol, extraFilter: "AND `request.headers.x_byo_cdn_type` != ''", modeToggle: 'contentTypeMode',
+    id: 'breakdown-accept-encoding', col: COLUMN_DEFS.acceptEncoding.facetCol, facetName: 'accept_encoding', extraFilter: "AND `request.headers.accept_encoding` != ''", modeToggle: 'contentTypeMode',
+  },
+  {
+    id: 'breakdown-req-cache-control', col: COLUMN_DEFS.cacheControl.facetCol, facetName: 'cache_control', extraFilter: "AND `request.headers.cache_control` != ''", modeToggle: 'contentTypeMode',
+  },
+  {
+    id: 'breakdown-byo-cdn', col: COLUMN_DEFS.byoCdn.facetCol, facetName: 'byo_cdn', extraFilter: "AND `request.headers.x_byo_cdn_type` != ''", modeToggle: 'contentTypeMode',
   },
   { id: 'breakdown-push-invalidation', col: '`request.headers.x_push_invalidation`', extraFilter: "AND `request.headers.x_push_invalidation` != ''" },
   {
     id: 'breakdown-content-length', col: contentLengthBuckets, rawCol: '`response.headers.content_length`', orderBy: 'min(`response.headers.content_length`)', modeToggle: 'contentTypeMode', getExpectedLabels: getContentLengthLabels,
   },
-  { id: 'breakdown-location', col: COLUMN_DEFS.location.facetCol, extraFilter: "AND `response.headers.location` != ''" },
+  {
+    id: 'breakdown-location', col: COLUMN_DEFS.location.facetCol, facetName: 'location', extraFilter: "AND `response.headers.location` != ''",
+  },
   {
     id: 'breakdown-time-elapsed', col: timeElapsedBuckets, rawCol: '`cdn.time_elapsed_msec`', orderBy: 'min(`cdn.time_elapsed_msec`)', summaryCountIf: '`cdn.time_elapsed_msec` >= 1000', summaryLabel: 'slow (≥1s)', summaryColor: 'warning', getExpectedLabels: getTimeElapsedLabels,
   },

--- a/js/breakdowns/definitions.js
+++ b/js/breakdowns/definitions.js
@@ -112,7 +112,7 @@ export const allBreakdowns = [
     id: 'breakdown-content-length', col: contentLengthBuckets, rawCol: '`response.headers.content_length`', orderBy: 'min(`response.headers.content_length`)', modeToggle: 'contentTypeMode', getExpectedLabels: getContentLengthLabels,
   },
   {
-    id: 'breakdown-location', col: COLUMN_DEFS.location.facetCol, facetName: 'location', extraFilter: "AND `response.headers.location` != ''",
+    id: 'breakdown-location', col: COLUMN_DEFS.location.facetCol, facetName: 'location', extraFilter: "AND `response.headers.location` != ''", highCardinality: true,
   },
   {
     id: 'breakdown-time-elapsed', col: timeElapsedBuckets, rawCol: '`cdn.time_elapsed_msec`', orderBy: 'min(`cdn.time_elapsed_msec`)', summaryCountIf: '`cdn.time_elapsed_msec` >= 1000', summaryLabel: 'slow (≥1s)', summaryColor: 'warning', getExpectedLabels: getTimeElapsedLabels,

--- a/js/breakdowns/definitions.js
+++ b/js/breakdowns/definitions.js
@@ -38,16 +38,16 @@ export function formatForwardedHost(dim) {
 
 export const allBreakdowns = [
   {
-    id: 'breakdown-status-range', col: "concat(toString(intDiv(`response.status`, 100)), 'xx')", facetName: 'status_range', summaryCountIf: '`response.status` >= 500', summaryLabel: 'error rate', summaryColor: 'error',
+    id: 'breakdown-status-range', col: "concat(toString(intDiv(`response.status`, 100)), 'xx')", facetName: 'status_range', summaryCountIf: '`response.status` >= 500', summaryDimCondition: "dim = '5xx'", summaryLabel: 'error rate', summaryColor: 'error',
   },
   {
-    id: 'breakdown-source', col: '`source`', facetName: 'source', summaryCountIf: '`source` = \'fastly\'', summaryLabel: 'fastly',
+    id: 'breakdown-source', col: '`source`', facetName: 'source', summaryCountIf: '`source` = \'fastly\'', summaryDimCondition: "dim = 'fastly'", summaryLabel: 'fastly',
   },
   {
-    id: 'breakdown-hosts', col: COLUMN_DEFS.host.facetCol, facetName: 'host', linkFn: hostLink, dimPrefixes: ['main--'], summaryCountIf: "`request.host` LIKE '%.aem.live'", summaryLabel: 'live', highCardinality: true,
+    id: 'breakdown-hosts', col: COLUMN_DEFS.host.facetCol, facetName: 'host', linkFn: hostLink, dimPrefixes: ['main--'], summaryCountIf: "`request.host` LIKE '%.aem.live'", summaryDimCondition: "dim LIKE '%.aem.live'", summaryLabel: 'live', highCardinality: true,
   },
   {
-    id: 'breakdown-forwarded-hosts', col: '`request.headers.x_forwarded_host`', facetName: 'x_forwarded_host', linkFn: forwardedHostLink, dimFormatFn: formatForwardedHost, summaryCountIf: "`request.headers.x_forwarded_host` != ''", summaryLabel: 'production', highCardinality: true,
+    id: 'breakdown-forwarded-hosts', col: '`request.headers.x_forwarded_host`', facetName: 'x_forwarded_host', linkFn: forwardedHostLink, dimFormatFn: formatForwardedHost, summaryCountIf: "`request.headers.x_forwarded_host` != ''", summaryDimCondition: "dim != ''", summaryLabel: 'production', highCardinality: true,
   },
   {
     id: 'breakdown-content-types', col: COLUMN_DEFS.contentType.facetCol, facetName: 'content_type', modeToggle: 'contentTypeMode',
@@ -66,7 +66,7 @@ export const allBreakdowns = [
     extraFilter: "AND `response.headers.x_error` != ''",
   },
   {
-    id: 'breakdown-cache', col: COLUMN_DEFS.cacheStatus.facetCol, facetName: 'cache_status', summaryCountIf: "upper(`cdn.cache_status`) LIKE 'HIT%'", summaryLabel: 'cache efficiency',
+    id: 'breakdown-cache', col: COLUMN_DEFS.cacheStatus.facetCol, facetName: 'cache_status', summaryCountIf: "upper(`cdn.cache_status`) LIKE 'HIT%'", summaryDimCondition: "dim LIKE 'HIT%'", summaryLabel: 'cache efficiency',
   },
   {
     id: 'breakdown-paths', col: COLUMN_DEFS.url.facetCol, facetName: 'url', linkFn: pathLink, modeToggle: 'contentTypeMode', highCardinality: true,
@@ -75,10 +75,10 @@ export const allBreakdowns = [
     id: 'breakdown-referers', col: COLUMN_DEFS.referer.facetCol, facetName: 'referer', linkFn: refererLink, dimPrefixes: ['https://', 'http://'], highCardinality: true,
   },
   {
-    id: 'breakdown-user-agents', col: COLUMN_DEFS.userAgent.facetCol, facetName: 'user_agent', dimPrefixes: ['Mozilla/5.0 '], summaryCountIf: "NOT `request.headers.user_agent` LIKE 'Mozilla/%' OR `request.headers.user_agent` LIKE '%+http%'", summaryLabel: 'bot rate', summaryColor: 'warning', highCardinality: true,
+    id: 'breakdown-user-agents', col: COLUMN_DEFS.userAgent.facetCol, facetName: 'user_agent', dimPrefixes: ['Mozilla/5.0 '], summaryCountIf: "NOT `request.headers.user_agent` LIKE 'Mozilla/%' OR `request.headers.user_agent` LIKE '%+http%'", summaryDimCondition: "NOT dim LIKE 'Mozilla/%' OR dim LIKE '%+http%'", summaryLabel: 'bot rate', summaryColor: 'warning', highCardinality: true,
   },
   {
-    id: 'breakdown-ips', col: COLUMN_DEFS.clientIp.facetCol, facetName: 'client_ip', linkPrefix: 'https://centralops.net/co/DomainDossier?dom_whois=1&net_whois=1&addr=', summaryCountIf: "if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) LIKE '%:%'", summaryLabel: 'IPv6', highCardinality: true,
+    id: 'breakdown-ips', col: COLUMN_DEFS.clientIp.facetCol, facetName: 'client_ip', linkPrefix: 'https://centralops.net/co/DomainDossier?dom_whois=1&net_whois=1&addr=', summaryCountIf: "if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) LIKE '%:%'", summaryDimCondition: "dim LIKE '%:%'", summaryLabel: 'IPv6', highCardinality: true,
   },
   {
     id: 'breakdown-request-type', col: COLUMN_DEFS.requestType.facetCol, facetName: 'request_type', extraFilter: "AND `helix.request_type` != ''", modeToggle: 'contentTypeMode',
@@ -87,7 +87,7 @@ export const allBreakdowns = [
     id: 'breakdown-tech-stack', col: COLUMN_DEFS.backendType.facetCol, facetName: 'backend_type', modeToggle: 'contentTypeMode',
   },
   {
-    id: 'breakdown-methods', col: COLUMN_DEFS.method.facetCol, facetName: 'method', summaryCountIf: "`request.method` IN ('POST', 'PUT', 'PATCH', 'DELETE')", summaryLabel: 'writes', summaryColor: 'warning',
+    id: 'breakdown-methods', col: COLUMN_DEFS.method.facetCol, facetName: 'method', summaryCountIf: "`request.method` IN ('POST', 'PUT', 'PATCH', 'DELETE')", summaryDimCondition: "dim IN ('POST', 'PUT', 'PATCH', 'DELETE')", summaryLabel: 'writes', summaryColor: 'warning',
   },
   {
     id: 'breakdown-datacenters', col: '`cdn.datacenter`', facetName: 'datacenter', modeToggle: 'contentTypeMode',

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -23,6 +23,9 @@ import { getFiltersForColumn } from '../filters.js';
 import { loadSql } from '../sql-loader.js';
 import { createLimiter } from '../concurrency-limiter.js';
 
+// Intentionally limits only breakdown queries: breakdowns fan out 20+ parallel
+// queries (one per facet), the only code path with bulk parallelism. Chart, logs,
+// and autocomplete each fire 1-2 queries and don't need limiting.
 const queryLimiter = createLimiter(4);
 
 export function getBreakdowns() {

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -238,12 +238,19 @@ async function buildBreakdownSql(b, timeFilter, hostFilter) {
   if (canUseFacetTable(b)) {
     const { startTime, endTime } = getFacetTimeFilter();
     const dimFilter = b.extraFilter ? "AND dim != ''" : '';
+    const hasSummary = !!b.summaryDimCondition;
     const sql = await loadSql('breakdown-facet', {
       database: DATABASE,
       facetName: b.facetName,
       startTime,
       endTime,
       dimFilter,
+      innerSummaryCol: hasSummary
+        ? `,\n    if(${b.summaryDimCondition}, cnt, 0) as summary_cnt`
+        : '',
+      summaryCol: hasSummary
+        ? ',\n  sum(summary_cnt) as summary_cnt'
+        : '',
       orderBy: b.orderBy || 'cnt DESC',
       topN: String(state.topN),
     });

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -39,6 +39,7 @@ export const facetTimings = {};
 export function canUseFacetTable(b) {
   if (!b.facetName) return false;
   if (b.rawCol) return false; // bucketed facets need raw table
+  if (b.highCardinality) return false; // sampled raw table is faster
   if (state.hostFilter) return false;
   if (state.filters && state.filters.length > 0) return false;
   if (state.additionalWhereClause) return false;

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -14,50 +14,36 @@ import { state } from '../state.js';
 import { query, getQueryErrorDetails, isAbortError } from '../api.js';
 import { getRequestContext, isRequestCurrent, mergeAbortSignals } from '../request-context.js';
 import {
-  getTimeFilter, getHostFilter, getTable, getPeriodMs,
+  getTimeFilter, getHostFilter, getTable, getSamplingConfig, getFacetTimeFilter,
 } from '../time.js';
 import { allBreakdowns as defaultBreakdowns } from './definitions.js';
-
-export function getBreakdowns() {
-  return state.breakdowns?.length ? state.breakdowns : defaultBreakdowns;
-}
 import { renderBreakdownTable, renderBreakdownError, getNextTopN } from './render.js';
 import { compileFilters } from '../filter-sql.js';
 import { getFiltersForColumn } from '../filters.js';
 import { loadSql } from '../sql-loader.js';
 
+export function getBreakdowns() {
+  return state.breakdowns?.length ? state.breakdowns : defaultBreakdowns;
+}
+
 // Track elapsed time per facet id for slowest detection
 export const facetTimings = {};
 
-// Sampling thresholds: use sampling for high-cardinality facets when time range > 1 hour
-const ONE_HOUR_MS = 60 * 60 * 1000;
-
 /**
- * Get sampling configuration based on facet type and time range
- * @param {boolean} highCardinality - Whether this facet has high cardinality
- * @returns {{ sampleClause: string, multiplier: number }} - SQL SAMPLE clause and count multiplier
+ * Check whether a breakdown can use the pre-aggregated cdn_facet_minutes table.
+ * Requires: facetName set, no active filters, no bytes mode, not bucketed.
  */
-function getSamplingConfig(highCardinality) {
-  if (!highCardinality) {
-    return { sampleClause: '', multiplier: 1 };
-  }
-
-  const periodMs = getPeriodMs();
-
-  // No sampling for time ranges <= 1 hour
-  if (periodMs <= ONE_HOUR_MS) {
-    return { sampleClause: '', multiplier: 1 };
-  }
-
-  // Use 1% sampling for 7d (very large time ranges)
-  // 7d = 604800000ms
-  if (periodMs >= 7 * 24 * ONE_HOUR_MS) {
-    return { sampleClause: 'SAMPLE 0.01', multiplier: 100 };
-  }
-
-  // Use 10% sampling for medium time ranges (12h, 24h)
-  // This gives ~3x speedup while maintaining accurate top-K ranking
-  return { sampleClause: 'SAMPLE 0.1', multiplier: 10 };
+export function canUseFacetTable(b) {
+  if (!b.facetName) return false;
+  if (b.rawCol) return false; // bucketed facets need raw table
+  if (state.hostFilter) return false;
+  if (state.filters && state.filters.length > 0) return false;
+  if (state.additionalWhereClause) return false;
+  const mode = b.modeToggle ? state[b.modeToggle] : 'count';
+  if (mode === 'bytes') return false;
+  // ASN uses dictGet which produces different dim values than the facet table
+  if (b.id === 'breakdown-asn') return false;
+  return true;
 }
 
 export function resetFacetTimings() {
@@ -203,7 +189,7 @@ function buildBreakdownQueryParams(b, col, timeFilter, hostFilter) {
 
   const mode = b.modeToggle ? state[b.modeToggle] : 'count';
   const isBytes = mode === 'bytes';
-  const { sampleClause, multiplier } = getSamplingConfig(b.highCardinality);
+  const { sampleClause, multiplier } = getSamplingConfig();
   const mult = multiplier > 1 ? ` * ${multiplier}` : '';
 
   return {
@@ -244,6 +230,36 @@ function prepareBreakdownCard(card, b) {
 
 async function buildBreakdownSql(b, timeFilter, hostFilter) {
   const baseCol = typeof b.col === 'function' ? b.col(state.topN) : b.col;
+
+  // Use pre-aggregated facet table when no filters are active
+  if (canUseFacetTable(b)) {
+    const { startTime, endTime } = getFacetTimeFilter();
+    const dimFilter = b.extraFilter ? "AND dim != ''" : '';
+    const sql = await loadSql('breakdown-facet', {
+      database: DATABASE,
+      facetName: b.facetName,
+      startTime,
+      endTime,
+      dimFilter,
+      orderBy: b.orderBy || 'cnt DESC',
+      topN: String(state.topN),
+    });
+
+    const params = {
+      col: baseCol,
+      originalCol: baseCol,
+      hasActiveFilter: false,
+      isBytes: false,
+      sampleClause: '',
+      mult: '',
+      extra: '',
+      facetFilters: '',
+      timeFilter,
+      hostFilter,
+    };
+    return { sql, params, aggs: buildAggregations(false, '') };
+  }
+
   const params = buildBreakdownQueryParams(b, baseCol, timeFilter, hostFilter);
   const aggs = buildAggregations(params.isBytes, params.mult);
 

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -321,6 +321,7 @@ async function buildBreakdownSql(b, timeFilter, hostFilter) {
 
 function getSummaryRatio(b, totals) {
   if (!b.summaryCountIf || !totals || totals.cnt <= 0) return null;
+  if (totals.summary_cnt === undefined) return null;
   return parseInt(totals.summary_cnt, 10) / parseInt(totals.cnt, 10);
 }
 

--- a/js/breakdowns/index.test.js
+++ b/js/breakdowns/index.test.js
@@ -19,6 +19,7 @@ import {
   markSlowestFacet,
   increaseTopN,
   loadBreakdown,
+  canUseFacetTable,
   facetTimings,
 } from './index.js';
 import { allBreakdowns } from './definitions.js';
@@ -171,6 +172,63 @@ describe('increaseTopN', () => {
     );
     assert.isFalse(saveCalled);
     assert.isFalse(loadCalled);
+  });
+});
+
+describe('canUseFacetTable', () => {
+  beforeEach(() => {
+    state.hostFilter = '';
+    state.filters = [];
+    state.additionalWhereClause = '';
+  });
+
+  it('returns true for a simple facet with facetName and no filters', () => {
+    const b = { id: 'breakdown-status-range', col: 'x', facetName: 'status_range' };
+    assert.isTrue(canUseFacetTable(b));
+  });
+
+  it('returns false when facetName is missing', () => {
+    const b = { id: 'breakdown-push-invalidation', col: 'x' };
+    assert.isFalse(canUseFacetTable(b));
+  });
+
+  it('returns false for bucketed facets (rawCol set)', () => {
+    const b = {
+      id: 'breakdown-time-elapsed', col: () => 'x', facetName: 'time_elapsed', rawCol: '`cdn.time_elapsed_msec`',
+    };
+    assert.isFalse(canUseFacetTable(b));
+  });
+
+  it('returns false when host filter is active', () => {
+    state.hostFilter = 'example.com';
+    const b = { id: 'breakdown-status-range', col: 'x', facetName: 'status_range' };
+    assert.isFalse(canUseFacetTable(b));
+  });
+
+  it('returns false when facet filters are active', () => {
+    state.filters = [{ col: '`request.host`', value: 'a.com', exclude: false }];
+    const b = { id: 'breakdown-status-range', col: 'x', facetName: 'status_range' };
+    assert.isFalse(canUseFacetTable(b));
+  });
+
+  it('returns false for ASN breakdown (dictGet mismatch)', () => {
+    const b = { id: 'breakdown-asn', col: 'x', facetName: 'asn' };
+    assert.isFalse(canUseFacetTable(b));
+  });
+
+  it('returns false when bytes mode is active', () => {
+    state.contentTypeMode = 'bytes';
+    const b = {
+      id: 'breakdown-content-types', col: 'x', facetName: 'content_type', modeToggle: 'contentTypeMode',
+    };
+    assert.isFalse(canUseFacetTable(b));
+    state.contentTypeMode = 'count';
+  });
+
+  it('returns false when additionalWhereClause is set', () => {
+    state.additionalWhereClause = "AND source = 'fastly'";
+    const b = { id: 'breakdown-status-range', col: 'x', facetName: 'status_range' };
+    assert.isFalse(canUseFacetTable(b));
   });
 });
 

--- a/js/breakdowns/index.test.js
+++ b/js/breakdowns/index.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/chart.js
+++ b/js/chart.js
@@ -28,6 +28,7 @@ import {
   getTimeBucket,
   getTimeBucketStep,
   getTimeFilter,
+  getSamplingConfig,
   setCustomTimeRange,
   getTimeRangeBounds,
   getTimeRangeStart,
@@ -917,11 +918,16 @@ export async function loadTimeSeries(requestContext = getRequestContext('dashboa
   const rangeStart = getTimeRangeStart();
   const rangeEnd = getTimeRangeEnd();
 
+  const { sampleClause, multiplier } = getSamplingConfig();
+  const mult = multiplier > 1 ? ` * ${multiplier}` : '';
+
   const timeSeriesTemplate = state.timeSeriesTemplate || 'time-series';
   const sql = await loadSql(timeSeriesTemplate, {
     bucket,
     database: DATABASE,
     table: getTable(),
+    sampleClause,
+    mult,
     timeFilter,
     hostFilter,
     facetFilters,

--- a/js/concurrency-limiter.js
+++ b/js/concurrency-limiter.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Create a concurrency limiter that queues async tasks when the limit is reached.
+ * @param {number} maxConcurrent - Maximum number of tasks that can run simultaneously
+ * @returns {function(function(): Promise): Promise} - Wrapper that limits concurrency
+ */
+export function createLimiter(maxConcurrent = 4) {
+  let active = 0;
+  const queue = [];
+
+  function next() {
+    if (queue.length === 0 || active >= maxConcurrent) return;
+    active += 1;
+    const { resolve } = queue.shift();
+    resolve();
+  }
+
+  return async function limit(fn) {
+    if (active >= maxConcurrent) {
+      await new Promise((resolve) => {
+        queue.push({ resolve });
+      });
+    } else {
+      active += 1;
+    }
+    try {
+      return await fn();
+    } finally {
+      active -= 1;
+      next();
+    }
+  };
+}

--- a/js/concurrency-limiter.js
+++ b/js/concurrency-limiter.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/concurrency-limiter.test.js
+++ b/js/concurrency-limiter.test.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { createLimiter } from './concurrency-limiter.js';
+
+describe('createLimiter', () => {
+  it('returns a function', () => {
+    const limit = createLimiter(2);
+    assert.isFunction(limit);
+  });
+
+  it('runs tasks up to the concurrency limit in parallel', async () => {
+    const limit = createLimiter(2);
+    let active = 0;
+    let maxActive = 0;
+
+    const task = () => limit(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => {
+        setTimeout(r, 50);
+      });
+      active -= 1;
+    });
+
+    await Promise.all([task(), task(), task(), task()]);
+    assert.strictEqual(maxActive, 2);
+  });
+
+  it('queues tasks beyond the concurrency limit', async () => {
+    const limit = createLimiter(1);
+    const order = [];
+
+    const task = (id) => limit(async () => {
+      order.push(`start-${id}`);
+      await new Promise((r) => {
+        setTimeout(r, 10);
+      });
+      order.push(`end-${id}`);
+    });
+
+    await Promise.all([task('a'), task('b'), task('c')]);
+    assert.deepEqual(order, [
+      'start-a', 'end-a',
+      'start-b', 'end-b',
+      'start-c', 'end-c',
+    ]);
+  });
+
+  it('returns the result of the wrapped function', async () => {
+    const limit = createLimiter(2);
+    const result = await limit(async () => 42);
+    assert.strictEqual(result, 42);
+  });
+
+  it('propagates errors from the wrapped function', async () => {
+    const limit = createLimiter(2);
+    try {
+      await limit(async () => {
+        throw new Error('test error');
+      });
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.strictEqual(err.message, 'test error');
+    }
+  });
+
+  it('releases slot on error so queued tasks still run', async () => {
+    const limit = createLimiter(1);
+    let secondRan = false;
+
+    const failing = limit(async () => {
+      throw new Error('fail');
+    }).catch(() => {});
+    const passing = limit(async () => {
+      secondRan = true;
+    });
+
+    await Promise.all([failing, passing]);
+    assert.isTrue(secondRan, 'queued task should run after error');
+  });
+
+  it('defaults to concurrency of 4', async () => {
+    const limit = createLimiter();
+    let active = 0;
+    let maxActive = 0;
+
+    const task = () => limit(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => {
+        setTimeout(r, 30);
+      });
+      active -= 1;
+    });
+
+    await Promise.all(Array.from({ length: 8 }, () => task()));
+    assert.strictEqual(maxActive, 4);
+  });
+
+  it('handles synchronous functions', async () => {
+    const limit = createLimiter(2);
+    const result = await limit(() => 'sync-result');
+    assert.strictEqual(result, 'sync-result');
+  });
+});

--- a/js/concurrency-limiter.test.js
+++ b/js/concurrency-limiter.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/constants.js
+++ b/js/constants.js
@@ -75,7 +75,7 @@ export const TIME_RANGES = {
 };
 
 /** @type {string} */
-export const DEFAULT_TIME_RANGE = '1h';
+export const DEFAULT_TIME_RANGE = '7d';
 
 /** @type {number[]} */
 export const TOP_N_OPTIONS = [5, 10, 20, 50, 100];

--- a/js/filter-sql.js
+++ b/js/filter-sql.js
@@ -9,7 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { getBreakdowns } from './breakdowns/index.js';
+import { state } from './state.js';
+import { allBreakdowns } from './breakdowns/definitions.js';
 import { COLUMN_DEFS } from './columns.js';
 
 /**
@@ -33,7 +34,8 @@ let allowedColumnsCache = null;
 export function getAllowedColumns() {
   if (allowedColumnsCache) return allowedColumnsCache;
   const cols = new Set();
-  for (const b of getBreakdowns()) {
+  const breakdowns = state.breakdowns?.length ? state.breakdowns : allBreakdowns;
+  for (const b of breakdowns) {
     if (typeof b.col === 'string') cols.add(b.col);
     if (b.filterCol) cols.add(b.filterCol);
   }

--- a/js/filter-sql.js
+++ b/js/filter-sql.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/filters.js
+++ b/js/filters.js
@@ -11,7 +11,7 @@
  */
 import { state } from './state.js';
 import { getColorIndicatorHtml } from './colors/index.js';
-import { getBreakdowns } from './breakdowns/index.js';
+import { allBreakdowns } from './breakdowns/definitions.js';
 import { renderFilterTags } from './templates/filter-tags.js';
 
 // Callbacks set by main.js to avoid circular dependencies
@@ -31,7 +31,8 @@ export function updateHeaderFixed() {
 
 // Get facet title from breakdown column
 function getFacetTitle(col) {
-  const breakdown = getBreakdowns().find((b) => b.col === col);
+  const breakdowns = state.breakdowns?.length ? state.breakdowns : allBreakdowns;
+  const breakdown = breakdowns.find((b) => b.col === col);
   if (!breakdown) return null;
   const card = document.getElementById(breakdown.id);
   if (!card) return null;
@@ -166,7 +167,8 @@ export function addFilter(col, value, exclude, filterCol, filterValue, filterOp,
     }
   } else {
     // Fallback: look up breakdown to get filterCol and filterValueFn if defined
-    const breakdown = getBreakdowns().find((b) => b.col === col);
+    const bkdns = state.breakdowns?.length ? state.breakdowns : allBreakdowns;
+    const breakdown = bkdns.find((b) => b.col === col);
     if (breakdown?.filterCol) {
       filter.filterCol = breakdown.filterCol;
       filter.filterValue = breakdown.filterValueFn ? breakdown.filterValueFn(value) : value;

--- a/js/sql-loader.js
+++ b/js/sql-loader.js
@@ -63,6 +63,7 @@ const ALL_TEMPLATES = [
   'logs',
   'logs-more',
   'breakdown',
+  'breakdown-facet',
   'breakdown-missing',
   'autocomplete-hosts',
   'autocomplete-forwarded',

--- a/js/sql-loader.js
+++ b/js/sql-loader.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/time.js
+++ b/js/time.js
@@ -249,8 +249,8 @@ export function getSamplingConfig() {
 
   // Sample rate = 1h / period, so scanned rows stay roughly constant
   const ratio = HOUR_MS / periodMs;
-  // Round to 4 decimal places for clean SQL
-  const sampleRate = Math.round(ratio * 10000) / 10000;
+  // Round to 4 decimal places for clean SQL; floor at 0.0001 to avoid SAMPLE 0 / Infinity
+  const sampleRate = Math.max(Math.round(ratio * 10000) / 10000, 0.0001);
   const multiplier = Math.round(1 / sampleRate);
 
   return { sampleClause: `SAMPLE ${sampleRate}`, multiplier };

--- a/js/time.js
+++ b/js/time.js
@@ -194,6 +194,10 @@ export function getTimeBucket() {
 // Re-export getTimeBucketStep for external use
 export { getTimeBucketStep };
 
+// Pitfall: `timestamp` is DateTime64(3) (millisecond precision). Using toDateTime()
+// (second precision) for bounds causes sub-second rows at bucket edges to be
+// double-counted or missed. toStartOfMinute() normalises both sides to the same
+// minute-level precision, avoiding the DateTime64 truncation mismatch.
 export function getTimeFilter() {
   const { start, end } = getTimeFilterBounds();
   const startIso = formatSqlDateTime(start);

--- a/js/time.test.js
+++ b/js/time.test.js
@@ -183,6 +183,19 @@ describe('getSamplingConfig', () => {
     assert.include(sampleClause, 'SAMPLE');
     assert.strictEqual(multiplier, 6);
   });
+
+  it('never returns Infinity or NaN multiplier for extreme time ranges', () => {
+    // 30-day custom range — ratio rounds to 0 without the floor clamp
+    setCustomTimeRange(
+      new Date('2025-12-21T00:00:00Z'),
+      new Date('2026-01-20T00:00:00Z'),
+    );
+    const { sampleClause, multiplier } = getSamplingConfig();
+    assert.include(sampleClause, 'SAMPLE');
+    assert.isFinite(multiplier);
+    assert.isAbove(multiplier, 0);
+    assert.isFalse(Number.isNaN(multiplier));
+  });
 });
 
 describe('getFacetTimeFilter', () => {

--- a/js/time.test.js
+++ b/js/time.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/time.test.js
+++ b/js/time.test.js
@@ -16,6 +16,7 @@ import {
   getTimeFilter, getTimeBucket, getPeriodMs,
   getTimeRangeBounds, getTimeRangeStart, getTimeRangeEnd,
   getTable, getHostFilter,
+  getSamplingConfig, getFacetTimeFilter,
 } from './time.js';
 
 beforeEach(() => {
@@ -116,5 +117,81 @@ describe('getHostFilter', () => {
     state.hostFilterColumn = 'function_name';
     const result = getHostFilter();
     assert.include(result, "\\'");
+  });
+});
+
+describe('getSamplingConfig', () => {
+  it('returns no sampling for 15m range', () => {
+    state.timeRange = '15m';
+    clearCustomTimeRange();
+    const { sampleClause, multiplier } = getSamplingConfig();
+    assert.strictEqual(sampleClause, '');
+    assert.strictEqual(multiplier, 1);
+  });
+
+  it('returns no sampling for 1h range', () => {
+    state.timeRange = '1h';
+    clearCustomTimeRange();
+    const { sampleClause, multiplier } = getSamplingConfig();
+    assert.strictEqual(sampleClause, '');
+    assert.strictEqual(multiplier, 1);
+  });
+
+  it('returns sampling for 12h range', () => {
+    state.timeRange = '12h';
+    clearCustomTimeRange();
+    const { sampleClause, multiplier } = getSamplingConfig();
+    assert.include(sampleClause, 'SAMPLE');
+    assert.isAbove(multiplier, 1);
+    // 12h = 12× baseline, so multiplier should be ~12
+    assert.strictEqual(multiplier, 12);
+  });
+
+  it('returns sampling for 7d range', () => {
+    state.timeRange = '7d';
+    clearCustomTimeRange();
+    const { sampleClause, multiplier } = getSamplingConfig();
+    assert.include(sampleClause, 'SAMPLE');
+    // 7d = 168h; after rounding sample rate to 4 decimals, multiplier is 167
+    assert.strictEqual(multiplier, 167);
+  });
+
+  it('returns proportional sampling for 24h range', () => {
+    state.timeRange = '24h';
+    clearCustomTimeRange();
+    const { sampleClause, multiplier } = getSamplingConfig();
+    assert.include(sampleClause, 'SAMPLE');
+    assert.strictEqual(multiplier, 24);
+  });
+
+  it('returns no sampling for short custom range', () => {
+    setCustomTimeRange(
+      new Date('2026-01-20T12:00:00Z'),
+      new Date('2026-01-20T12:30:00Z'),
+    );
+    const { sampleClause, multiplier } = getSamplingConfig();
+    assert.strictEqual(sampleClause, '');
+    assert.strictEqual(multiplier, 1);
+  });
+
+  it('returns sampling for long custom range (6h)', () => {
+    setCustomTimeRange(
+      new Date('2026-01-20T06:00:00Z'),
+      new Date('2026-01-20T12:00:00Z'),
+    );
+    const { sampleClause, multiplier } = getSamplingConfig();
+    assert.include(sampleClause, 'SAMPLE');
+    assert.strictEqual(multiplier, 6);
+  });
+});
+
+describe('getFacetTimeFilter', () => {
+  it('returns formatted start and end times', () => {
+    state.timeRange = '1h';
+    clearCustomTimeRange();
+    setQueryTimestamp(new Date('2026-01-20T12:34:56Z'));
+    const { startTime, endTime } = getFacetTimeFilter();
+    assert.strictEqual(startTime, '2026-01-20 11:34:00');
+    assert.strictEqual(endTime, '2026-01-20 12:34:00');
   });
 });

--- a/js/url-state.test.js
+++ b/js/url-state.test.js
@@ -406,10 +406,10 @@ describe('saveStateToURL', () => {
   });
 
   it('encodes time range into URL', () => {
-    state.timeRange = '7d';
+    state.timeRange = '24h';
     saveStateToURL();
     const params = new URLSearchParams(window.location.search);
-    assert.strictEqual(params.get('t'), '7d');
+    assert.strictEqual(params.get('t'), '24h');
   });
 
   it('omits default time range', () => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ClickHouse CDN Analytics Dashboard",
   "type": "module",
   "scripts": {
-    "start": "live-server --port=5391 --open=/ --ignore=scripts,.github,.claude,hars,node_modules --ignorePattern=\"\\\\.md$|package.*\\\\.json$|screenshot\\.png$\"",
+    "start": "live-server --port=5391 --open=/ --ignore=scripts,.github,.claude,hars,node_modules,.playwright-cli --ignorePattern=\"\\\\.md$|package.*\\\\.json$|screenshot\\.png$\"",
     "test": "web-test-runner",
     "lint": "eslint .",
     "dead-code": "knip",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ClickHouse CDN Analytics Dashboard",
   "type": "module",
   "scripts": {
-    "start": "live-server --port=5391 --open=/ --ignore=scripts,.github,.claude,hars,node_modules,.playwright-cli --ignorePattern=\"\\\\.md$|package.*\\\\.json$|screenshot\\.png$\"",
+    "start": "live-server --port=5391 --open=/ --ignore=scripts,.github,.claude,hars,node_modules --ignorePattern=\"\\\\.md$|package.*\\\\.json$|screenshot\\.png$|\\.playwright-cli\"",
     "test": "web-test-runner",
     "lint": "eslint .",
     "dead-code": "knip",

--- a/scripts/add-user.mjs
+++ b/scripts/add-user.mjs
@@ -19,7 +19,7 @@
 const CLICKHOUSE_HOST = 's2p5b8wmt5.eastus2.azure.clickhouse.cloud';
 const CLICKHOUSE_PORT = 8443;
 const DATABASE = 'helix_logs_production';
-const TABLES = ['cdn_requests_combined', 'cdn_requests_v2', 'releases', 'oncall_shifts', 'lambda_logs'];
+const TABLES = ['cdn_requests_combined', 'cdn_requests_v2', 'cdn_facet_minutes', 'releases', 'oncall_shifts', 'lambda_logs'];
 const DICTIONARIES = ['asn_dict'];
 
 function generatePassword(length = 16) {

--- a/sql/backup-projections.sql
+++ b/sql/backup-projections.sql
@@ -1,0 +1,222 @@
+-- Backup of all 25 projections on cdn_requests_v2
+-- Created 2026-02-11 before dropping to free memory
+-- To restore: run each ALTER TABLE ... ADD PROJECTION, then MATERIALIZE PROJECTION
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_url (
+    SELECT toStartOfMinute(timestamp) AS minute, `request.url`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `request.url`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_referer (
+    SELECT toStartOfMinute(timestamp) AS minute, `request.headers.referer`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `request.headers.referer`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_x_error (
+    SELECT toStartOfMinute(timestamp) AS minute, `response.headers.x_error`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `response.headers.x_error`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_datacenter (
+    SELECT toStartOfMinute(timestamp) AS minute, `cdn.datacenter`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `cdn.datacenter`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_request_type (
+    SELECT toStartOfMinute(timestamp) AS minute, `helix.request_type`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `helix.request_type`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_backend_type (
+    SELECT toStartOfMinute(timestamp) AS minute, `helix.backend_type`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `helix.backend_type`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_content_type (
+    SELECT toStartOfMinute(timestamp) AS minute, `response.headers.content_type`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx,
+        sum(`response.headers.content_length`) AS bytes,
+        sumIf(`response.headers.content_length`, `response.status` < 400) AS bytes_ok,
+        sumIf(`response.headers.content_length`, `response.status` >= 400 AND `response.status` < 500) AS bytes_4xx,
+        sumIf(`response.headers.content_length`, `response.status` >= 500) AS bytes_5xx
+    GROUP BY minute, `response.headers.content_type`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_status (
+    SELECT toStartOfMinute(timestamp) AS minute, toString(`response.status`) AS dim,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, dim
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_asn (
+    SELECT toStartOfMinute(timestamp) AS minute, `client.asn`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `client.asn`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_accept (
+    SELECT toStartOfMinute(timestamp) AS minute, `request.headers.accept`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `request.headers.accept`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_accept_encoding (
+    SELECT toStartOfMinute(timestamp) AS minute, `request.headers.accept_encoding`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `request.headers.accept_encoding`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_cache_control (
+    SELECT toStartOfMinute(timestamp) AS minute, `request.headers.cache_control`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `request.headers.cache_control`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_byo_cdn (
+    SELECT toStartOfMinute(timestamp) AS minute, `request.headers.x_byo_cdn_type`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `request.headers.x_byo_cdn_type`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_location (
+    SELECT toStartOfMinute(timestamp) AS minute, `response.headers.location`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `response.headers.location`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_x_error_grouped (
+    SELECT toStartOfMinute(timestamp) AS minute,
+        replaceRegexpAll(`response.headers.x_error`, '/[a-zA-Z0-9/_.-]+', '/...') AS dim,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, dim
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_user_agent (
+    SELECT toStartOfMinute(timestamp) AS minute, `request.headers.user_agent` AS dim,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx,
+        countIf(NOT (`request.headers.user_agent` LIKE 'Mozilla/%') OR (`request.headers.user_agent` LIKE '%+http%')) AS summary_cnt
+    GROUP BY minute, dim
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_method (
+    SELECT toStartOfMinute(timestamp) AS minute, `request.method` AS dim,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx,
+        countIf(`request.method` IN ('POST', 'PUT', 'PATCH', 'DELETE')) AS summary_cnt
+    GROUP BY minute, dim
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_host (
+    SELECT toStartOfMinute(timestamp) AS minute, `request.host` AS dim,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx,
+        countIf(`request.host` LIKE '%.aem.live') AS summary_cnt
+    GROUP BY minute, dim
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_client_ip (
+    SELECT toStartOfMinute(timestamp) AS minute,
+        if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) AS dim,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx,
+        countIf(if(`request.headers.x_forwarded_for` != '', `request.headers.x_forwarded_for`, `client.ip`) LIKE '%:%') AS summary_cnt
+    GROUP BY minute, dim
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_cache_status (
+    SELECT toStartOfMinute(timestamp) AS minute, upper(`cdn.cache_status`) AS dim,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx,
+        countIf(upper(`cdn.cache_status`) LIKE 'HIT%') AS summary_cnt
+    GROUP BY minute, dim
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_status_range (
+    SELECT toStartOfMinute(timestamp) AS minute,
+        concat(toString(intDiv(`response.status`, 100)), 'xx') AS dim,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx,
+        countIf(`response.status` >= 500) AS summary_cnt
+    GROUP BY minute, dim
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_x_forwarded_host (
+    SELECT toStartOfMinute(timestamp) AS minute, `request.headers.x_forwarded_host` AS dim,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx,
+        countIf(`request.headers.x_forwarded_host` != '') AS summary_cnt
+    GROUP BY minute, dim
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_source (
+    SELECT toStartOfMinute(timestamp) AS minute, source,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, source
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_time_elapsed (
+    SELECT toStartOfMinute(timestamp) AS minute, `cdn.time_elapsed_msec`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `cdn.time_elapsed_msec`
+);
+
+ALTER TABLE helix_logs_production.cdn_requests_v2 ADD PROJECTION proj_minute_content_length (
+    SELECT toStartOfMinute(timestamp) AS minute, `response.headers.content_length`,
+        count() AS cnt, countIf(`response.status` < 400) AS cnt_ok,
+        countIf(`response.status` >= 400 AND `response.status` < 500) AS cnt_4xx,
+        countIf(`response.status` >= 500) AS cnt_5xx
+    GROUP BY minute, `response.headers.content_length`
+);
+
+-- After adding projections, materialize each one (run one at a time):
+-- ALTER TABLE helix_logs_production.cdn_requests_v2 MATERIALIZE PROJECTION proj_minute_url;
+-- ALTER TABLE helix_logs_production.cdn_requests_v2 MATERIALIZE PROJECTION proj_minute_referer;
+-- ... etc for each projection

--- a/sql/queries/breakdown-facet.sql
+++ b/sql/queries/breakdown-facet.sql
@@ -3,12 +3,15 @@ SELECT
   sum(cnt) as cnt,
   sum(cnt_ok) as cnt_ok,
   sum(cnt_4xx) as cnt_4xx,
-  sum(cnt_5xx) as cnt_5xx
-FROM {{database}}.cdn_facet_minutes
-WHERE facet = '{{facetName}}'
-  AND minute >= toDateTime('{{startTime}}')
-  AND minute <= toDateTime('{{endTime}}')
-  {{dimFilter}}
+  sum(cnt_5xx) as cnt_5xx{{summaryCol}}
+FROM (
+  SELECT dim, cnt, cnt_ok, cnt_4xx, cnt_5xx{{innerSummaryCol}}
+  FROM {{database}}.cdn_facet_minutes
+  WHERE facet = '{{facetName}}'
+    AND minute >= toDateTime('{{startTime}}')
+    AND minute <= toDateTime('{{endTime}}')
+    {{dimFilter}}
+)
 GROUP BY dim WITH TOTALS
 ORDER BY {{orderBy}}
 LIMIT {{topN}}

--- a/sql/queries/breakdown-facet.sql
+++ b/sql/queries/breakdown-facet.sql
@@ -1,0 +1,14 @@
+SELECT
+  dim,
+  sum(cnt) as cnt,
+  sum(cnt_ok) as cnt_ok,
+  sum(cnt_4xx) as cnt_4xx,
+  sum(cnt_5xx) as cnt_5xx
+FROM {{database}}.cdn_facet_minutes
+WHERE facet = '{{facetName}}'
+  AND minute >= toDateTime('{{startTime}}')
+  AND minute <= toDateTime('{{endTime}}')
+  {{dimFilter}}
+GROUP BY dim WITH TOTALS
+ORDER BY {{orderBy}}
+LIMIT {{topN}}

--- a/sql/queries/time-series.sql
+++ b/sql/queries/time-series.sql
@@ -1,9 +1,10 @@
 SELECT
   {{bucket}} as t,
-  countIf(`response.status` < 400) as cnt_ok,
-  countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
-  countIf(`response.status` >= 500) as cnt_5xx
+  countIf(`response.status` < 400){{mult}} as cnt_ok,
+  countIf(`response.status` >= 400 AND `response.status` < 500){{mult}} as cnt_4xx,
+  countIf(`response.status` >= 500){{mult}} as cnt_5xx
 FROM {{database}}.{{table}}
+{{sampleClause}}
 WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{additionalWhereClause}}
 GROUP BY t
 ORDER BY t WITH FILL FROM {{rangeStart}} TO {{rangeEnd}} STEP {{step}}


### PR DESCRIPTION
## Summary

Replaces the 25 per-facet projections on `cdn_requests_v2` (which caused OOM errors on ClickHouse Cloud) with a more efficient architecture:

- **`cdn_facet_minutes` SummingMergeTree table + MV**: Pre-aggregates 14 low-cardinality facets into a compact minute-level table (~7M rows vs 384M before trimming). Dashboard queries against this table complete in 3-50ms.
- **Proportional sampling for longer time ranges**: Queries beyond 1 hour use `SAMPLE` (e.g., 7d → SAMPLE 0.006) with a multiplier to estimate totals. Applied to both time-series chart and breakdown queries.
- **Concurrency limiter (4 max concurrent queries)**: Reduces ClickHouse resource contention. At concurrency 4, individual queries stay ~1s; at 8+, they balloon to 12s+.
- **High-cardinality facet routing**: Facets with millions of distinct values (hosts, paths, referers, user agents, IPs, location) skip the facet table and use the sampled raw table instead — 3-7x faster for these facets.
- **Summary badge fixes**: Summary metrics (error rate, cache efficiency, etc.) now compute correctly from the facet table using `summaryDimCondition` on the dim column.

### Server-side changes (not in this PR)
- 25 projections dropped from `cdn_requests_v2` (backed up in `sql/backup-projections.sql`)
- `cdn_facet_minutes` table and `cdn_facet_minutes_mv` materialized view created
- MV trimmed from 25 to 14 facets after benchmarking

### Performance results
| Metric | Before | After |
|--------|--------|-------|
| Low-cardinality facets (status, source, method) | 1-3s | 3-50ms |
| High-cardinality facets (referer, user_agent) | 8-15s | 0.1-0.4s (sampled) |
| Time-series chart (7d) | 8-12s | 1-2s (sampled) |
| Concurrent query contention | 12s+ at 8 queries | ~1s at 4 queries |

### Closes

- Closes #86 — Limit facet query fan-out / add staged loading
- Closes #16 — Facet counting inconsistency (10x discrepancy)
- Related: #34 — Long-running queries block dashboard UI

## Testing Done
- All 483 unit tests pass (`npm test`)
- Lint passes (`npm run lint`)
- Manual browser testing across all time periods (1h, 3h, 12h, 24h, 3d, 7d)
- Summary badges verified showing correct values (no NaN%)
- Benchmarked facet table vs raw+sampling for high-cardinality facets
- Benchmarked concurrency levels (4, 6, 8) against ClickHouse Cloud

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)