### PR TITLE
feat: dynamic dev server port and no-reload mode

### DIFF
--- a/.claude/skills/playwright-cli/SKILL.md
+++ b/.claude/skills/playwright-cli/SKILL.md
@@ -13,10 +13,20 @@ allowed-tools: Bash(npx playwright-cli:*)
 The dashboard stores credentials in `localStorage` under the key `clickhouse_credentials`. To log in programmatically (look up the password in `README.local.md`):
 
 ```bash
-npx playwright-cli open http://localhost:5391/dashboard.html
+npx playwright-cli open http://localhost:$(node scripts/dev-server.js --dry-run)/dashboard.html
 npx playwright-cli eval 'localStorage.setItem("clickhouse_credentials", JSON.stringify({user: "<username>", password: "<password>"}))'
 npx playwright-cli reload
 ```
+
+## Starting the dev server for testing
+
+When using playwright-cli to test the local dashboard, start the dev server with auto-reload disabled. This prevents live-server from reloading the page when files change, which interferes with browser automation:
+
+```bash
+npm run start:no-reload
+```
+
+You can also use the environment variable: `NO_RELOAD=1 npm start`.
 
 ## Quick start
 

--- a/.claude/skills/playwright-cli/SKILL.md
+++ b/.claude/skills/playwright-cli/SKILL.md
@@ -13,7 +13,7 @@ allowed-tools: Bash(npx playwright-cli:*)
 The dashboard stores credentials in `localStorage` under the key `clickhouse_credentials`. To log in programmatically (look up the password in `README.local.md`):
 
 ```bash
-npx playwright-cli open http://localhost:$(node scripts/dev-server.js --dry-run)/dashboard.html
+npx playwright-cli open http://localhost:$(node scripts/dev-server.mjs --dry-run)/dashboard.html
 npx playwright-cli eval 'localStorage.setItem("clickhouse_credentials", JSON.stringify({user: "<username>", password: "<password>"}))'
 npx playwright-cli reload
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ npm install
 npm start
 ```
 
-This starts a dev server with auto-reload at http://localhost:5391/dashboard.html.
+This starts a dev server with auto-reload. The port is deterministic per worktree and printed on startup. Use `node scripts/dev-server.js --dry-run` to get the port without starting the server.
 
 ## Browser Exploration with playwright-cli
 
@@ -70,7 +70,7 @@ This project includes the `playwright-cli` skill (`.claude/skills/playwright-cli
 npm start
 
 # Open the dashboard and explore
-playwright-cli open http://localhost:5391/dashboard.html
+playwright-cli open http://localhost:$(node scripts/dev-server.js --dry-run)/dashboard.html
 playwright-cli snapshot
 playwright-cli fill e3 "<username>"
 playwright-cli fill e5 "<password>"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ npm install
 npm start
 ```
 
-This starts a dev server with auto-reload. The port is deterministic per worktree and printed on startup. Use `node scripts/dev-server.js --dry-run` to get the port without starting the server.
+This starts a dev server with auto-reload. The port is deterministic per worktree and printed on startup. Use `node scripts/dev-server.mjs --dry-run` to get the port without starting the server.
 
 ## Browser Exploration with playwright-cli
 
@@ -70,7 +70,7 @@ This project includes the `playwright-cli` skill (`.claude/skills/playwright-cli
 npm start
 
 # Open the dashboard and explore
-playwright-cli open http://localhost:$(node scripts/dev-server.js --dry-run)/dashboard.html
+playwright-cli open http://localhost:$(node scripts/dev-server.mjs --dry-run)/dashboard.html
 playwright-cli snapshot
 playwright-cli fill e3 "<username>"
 playwright-cli fill e5 "<password>"

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ npm install
 npm start
 ```
 
-This starts a development server with auto-reload at http://localhost:5391/dashboard.html.
+This starts a development server with auto-reload. The port is deterministic per worktree and printed on startup. Use `node scripts/dev-server.js --dry-run` to get the port without starting the server.
 
 For ClickHouse CLI access:
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ npm install
 npm start
 ```
 
-This starts a development server with auto-reload. The port is deterministic per worktree and printed on startup. Use `node scripts/dev-server.js --dry-run` to get the port without starting the server.
+This starts a development server with auto-reload. The port is deterministic per worktree and printed on startup. Use `node scripts/dev-server.mjs --dry-run` to get the port without starting the server.
 
 For ClickHouse CLI access:
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "ClickHouse CDN Analytics Dashboard",
   "type": "module",
   "scripts": {
-    "start": "live-server --port=5391 --open=/ --ignore=scripts,.github,.claude,hars,node_modules --ignorePattern=\"\\\\.md$|package.*\\\\.json$|screenshot\\.png$|\\.playwright-cli\"",
+    "start": "node scripts/dev-server.js",
+    "start:no-reload": "node scripts/dev-server.js --no-reload",
     "test": "web-test-runner",
     "lint": "eslint .",
     "dead-code": "knip",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "ClickHouse CDN Analytics Dashboard",
   "type": "module",
   "scripts": {
-    "start": "node scripts/dev-server.js",
-    "start:no-reload": "node scripts/dev-server.js --no-reload",
+    "start": "node scripts/dev-server.mjs",
+    "start:no-reload": "node scripts/dev-server.mjs --no-reload",
     "test": "web-test-runner",
     "lint": "eslint .",
     "dead-code": "knip",

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { spawn } from 'node:child_process';
+
+const PORT_MIN = 5000;
+const PORT_RANGE = 1000;
+
+/**
+ * djb2 string hash — deterministic hash of a string to an unsigned 32-bit int.
+ */
+function hashString(str) {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+function getPort() {
+  const cwd = process.cwd();
+  const hash = hashString(cwd);
+  return PORT_MIN + (hash % PORT_RANGE);
+}
+
+const port = getPort();
+const noReload = process.argv.includes('--no-reload') || process.env.NO_RELOAD === '1';
+
+if (process.argv.includes('--dry-run')) {
+  console.log(port);
+  process.exit(0);
+}
+
+console.log(`Starting dev server on port ${port}...`);
+
+const args = [
+  `--port=${port}`,
+  '--ignore=scripts,.github,.claude,hars,node_modules',
+  '--ignorePattern=\\.md$|package.*\\.json$|screenshot\\.png$|\\.playwright-cli',
+];
+
+if (noReload) {
+  args.push('--no-browser', '--watch=/dev/null');
+} else {
+  args.push('--open=/');
+}
+
+const child = spawn('live-server', args, {
+  stdio: 'inherit',
+  shell: true,
+});
+
+child.on('exit', (code) => {
+  process.exit(code ?? 0);
+});

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -12,10 +12,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { spawn } from 'node:child_process';
-
-const NULL_DEVICE = process.platform === 'win32' ? 'NUL' : '/dev/null';
-const PATH_SEP = process.platform === 'win32' ? ';' : ':';
+import liveServer from 'live-server';
 
 const PORT_MIN = 5000;
 const PORT_RANGE = 1000;
@@ -47,29 +44,11 @@ if (process.argv.includes('--dry-run')) {
 
 console.log(`Starting dev server on port ${port}...`);
 
-const args = [
-  `--port=${port}`,
-  '--ignore=scripts,.github,.claude,hars,node_modules',
-  '--ignorePattern=\\.md$|package.*\\.json$|screenshot\\.png$|\\.playwright-cli',
-];
-
-if (noReload) {
-  args.push('--no-browser', `--watch=${NULL_DEVICE}`);
-} else {
-  args.push('--open=/');
-}
-
-const child = spawn('live-server', args, {
-  stdio: 'inherit',
-  shell: false,
-  env: { ...process.env, PATH: `./node_modules/.bin${PATH_SEP}${process.env.PATH}` },
-});
-
-child.on('error', (err) => {
-  console.error('Failed to start dev server:', err.message);
-  process.exit(1);
-});
-
-child.on('exit', (code) => {
-  process.exit(code ?? 0);
+liveServer.start({
+  port,
+  root: '.',
+  ignore: 'scripts,.github,.claude,hars,node_modules',
+  ignorePattern: /\.md$|package.*\.json$|screenshot\.png$|\.playwright-cli/,
+  open: noReload ? false : '/',
+  watch: noReload ? [] : undefined,
 });


### PR DESCRIPTION
## Summary

Makes the dev server work reliably across multiple git worktrees and adds a no-reload mode for browser automation:

- **Dynamic port**: `scripts/dev-server.js` hashes the working directory to derive a deterministic port in 5000–5999, so multiple worktrees can run `npm start` simultaneously without port conflicts
- **No-reload mode**: `npm run start:no-reload` (or `--no-reload` flag / `NO_RELOAD=1` env var) disables live-reload and browser auto-open, preventing interference with playwright-cli automation
- **Dry-run**: `node scripts/dev-server.js --dry-run` prints the port without starting the server

## Testing Done

- `npm run lint` passes
- `node scripts/dev-server.js --dry-run` prints a deterministic port (same directory = same port)
- Verified two different directories produce different ports
- `start:no-reload` starts the server without opening browser or watching files

## Checklist
- [ ] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)