### PR TITLE
fix: harden login-success handler to preserve deep link state

### DIFF
--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -399,9 +399,17 @@ export function initDashboard(config = {}) {
     elements.viewToggleBtn.addEventListener('click', () => toggleLogsView(saveStateToURL));
 
     window.addEventListener('login-success', () => {
-      preloadAllTemplates();
-      syncUIFromState();
-      showDashboard();
+      try {
+        preloadAllTemplates();
+        syncUIFromState();
+        reorderFacets();
+        showDashboard();
+        updateTimeRangeHint();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Error during login-success setup:', err);
+        showDashboard();
+      }
       loadDashboard();
     });
   }


### PR DESCRIPTION
## Summary

When following a deep link (e.g. from Slack) and being intercepted by the login form, the dashboard could fail to appear after login. The `login-success` event handler had no error handling — if `preloadAllTemplates()` or `syncUIFromState()` threw, `showDashboard()` never ran and the user was stuck on the login screen with no feedback.

This PR:
- Wraps pre-dashboard setup in try/catch so `showDashboard()` always runs
- Adds missing `reorderFacets()` and `updateTimeRangeHint()` calls to match the stored-credentials path
- Keeps `loadDashboard()` outside try/catch so it always executes
- Logs errors to console instead of silently swallowing them

## Manual Test

Open the following deep link in a private/incognito window (to trigger the login form), then log in and verify the filters and time range are applied:

[Test deep link (PR preview)](https://klickhaus.aemstatus.net/preview/pr-124/dashboard.html?t=1h&ts=2026-02-12T10%3A36%3A25.164Z&filters=%5B%7B%22col%22%3A%22toString%28%60response.status%60%29%22%2C%22value%22%3A%22429%22%2C%22exclude%22%3Afalse%2C%22filterCol%22%3A%22toString%28%60response.status%60%29%22%2C%22filterValue%22%3A%22429%22%7D%5D)

**Expected**: After login, dashboard loads with 1h time range, the specified timestamp, and a 429 status filter active.

## Testing Done

- `npm run lint` passes
- `npm test` passes (all 485 tests)
- Code reviewed by verifier agent: login-success handler now mirrors stored-credentials path with error resilience

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)