### PR TITLE
test: raise line coverage threshold from 83% to 90%

### DIFF
--- a/js/api.test.js
+++ b/js/api.test.js
@@ -16,9 +16,13 @@ import {
   extractErrorType,
   getQueryErrorDetails,
   isAbortError,
+  isForceRefresh,
   parseQueryError,
+  query,
+  setForceRefresh,
   summarizeErrorText,
 } from './api.js';
+import { state } from './state.js';
 
 describe('api error helpers', () => {
   it('summarizes long error messages', () => {
@@ -109,6 +113,47 @@ describe('api error helpers', () => {
     assert.strictEqual(details.status, 403);
   });
 
+  it('summarizes null/empty input as Unknown error', () => {
+    assert.strictEqual(summarizeErrorText(null), 'Unknown error');
+    assert.strictEqual(summarizeErrorText(''), 'Unknown error');
+  });
+
+  it('truncates messages longer than 200 characters', () => {
+    const longLine = 'A'.repeat(250);
+    const summary = summarizeErrorText(longLine);
+    assert.strictEqual(summary.length, 200);
+    assert.ok(summary.endsWith('...'));
+  });
+
+  it('classifies unknown category for unrecognized errors', () => {
+    assert.strictEqual(classifyCategory('something weird happened', 500, 'WEIRD_TYPE'), 'unknown');
+  });
+
+  it('returns unknown details for null error', () => {
+    const details = getQueryErrorDetails(null);
+    assert.strictEqual(details.category, 'unknown');
+    assert.strictEqual(details.message, 'Unknown error');
+    assert.strictEqual(details.label, 'Query failed');
+  });
+
+  it('handles generic (non-QueryError) errors', () => {
+    const err = new Error('Failed to fetch');
+    const details = getQueryErrorDetails(err);
+    assert.strictEqual(details.category, 'network');
+    assert.strictEqual(details.label, 'Network error');
+  });
+
+  it('handles QueryError with unknown category and missing message', () => {
+    const err = new QueryError('', {
+      category: 'nonexistent_category',
+      detail: null,
+    });
+    const details = getQueryErrorDetails(err);
+    assert.strictEqual(details.label, 'Query failed');
+    assert.strictEqual(details.message, 'Query failed');
+    assert.strictEqual(details.detail, 'Query failed');
+  });
+
   it('detects AbortError instances', () => {
     const abortError = new Error('aborted');
     abortError.name = 'AbortError';
@@ -117,5 +162,215 @@ describe('api error helpers', () => {
     const details = getQueryErrorDetails(abortError);
     assert.strictEqual(details.category, 'cancelled');
     assert.isTrue(details.isAbort);
+  });
+});
+
+describe('isForceRefresh / setForceRefresh', () => {
+  afterEach(() => {
+    setForceRefresh(false);
+  });
+
+  it('defaults to false', () => {
+    assert.isFalse(isForceRefresh());
+  });
+
+  it('can be set to true and back to false', () => {
+    setForceRefresh(true);
+    assert.isTrue(isForceRefresh());
+    setForceRefresh(false);
+    assert.isFalse(isForceRefresh());
+  });
+});
+
+describe('query()', () => {
+  let originalFetch;
+  let savedCredentials;
+  let savedTimeRange;
+
+  function mockFetch(response) {
+    window.fetch = async (url, opts) => {
+      mockFetch.lastCall = { url, opts };
+      return response;
+    };
+    mockFetch.lastCall = null;
+  }
+
+  function okResponse(data) {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => data,
+    };
+  }
+
+  function errorResponse(status, text) {
+    return {
+      ok: false,
+      status,
+      text: async () => text,
+    };
+  }
+
+  beforeEach(() => {
+    originalFetch = window.fetch;
+    savedCredentials = state.credentials;
+    savedTimeRange = state.timeRange;
+    state.credentials = { user: 'testuser', password: 'testpass' };
+    state.timeRange = '7d';
+    setForceRefresh(false);
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    state.credentials = savedCredentials;
+    state.timeRange = savedTimeRange;
+    setForceRefresh(false);
+  });
+
+  it('sends POST with auth header and returns parsed JSON', async () => {
+    const payload = { data: [{ count: 42 }] };
+    mockFetch(okResponse(payload));
+
+    const result = await query('SELECT 1');
+    assert.deepEqual(result.data, payload.data);
+    assert.isNumber(result.networkTime);
+    assert.isAtLeast(result.networkTime, 0);
+
+    // Verify fetch was called with correct method and auth
+    const { opts } = mockFetch.lastCall;
+    assert.strictEqual(opts.method, 'POST');
+    const expectedAuth = `Basic ${btoa('testuser:testpass')}`;
+    assert.strictEqual(opts.headers.Authorization, expectedAuth);
+  });
+
+  it('normalizes SQL whitespace in the body', async () => {
+    mockFetch(okResponse({ data: [] }));
+    await query('SELECT   1\n  FROM\ttable');
+
+    const { opts } = mockFetch.lastCall;
+    assert.strictEqual(opts.body, 'SELECT 1 FROM table FORMAT JSON');
+  });
+
+  it('uses default cache TTL from TIME_RANGES for current time range', async () => {
+    state.timeRange = '7d';
+    mockFetch(okResponse({ data: [] }));
+    await query('SELECT 1');
+
+    const { url } = mockFetch.lastCall;
+    const params = new URL(url).searchParams;
+    assert.strictEqual(params.get('use_query_cache'), '1');
+    assert.strictEqual(params.get('query_cache_ttl'), '1800');
+  });
+
+  it('uses cacheTtl=1 when force refresh is active', async () => {
+    setForceRefresh(true);
+    mockFetch(okResponse({ data: [] }));
+    await query('SELECT 1');
+
+    const { url } = mockFetch.lastCall;
+    const params = new URL(url).searchParams;
+    assert.strictEqual(params.get('query_cache_ttl'), '1');
+  });
+
+  it('uses custom cacheTtl when provided', async () => {
+    mockFetch(okResponse({ data: [] }));
+    await query('SELECT 1', { cacheTtl: 42 });
+
+    const { url } = mockFetch.lastCall;
+    const params = new URL(url).searchParams;
+    assert.strictEqual(params.get('query_cache_ttl'), '42');
+  });
+
+  it('skips cache params when skipCache is true', async () => {
+    mockFetch(okResponse({ data: [] }));
+    await query('SELECT 1', { skipCache: true });
+
+    const { url } = mockFetch.lastCall;
+    const params = new URL(url).searchParams;
+    assert.isNull(params.get('use_query_cache'));
+    assert.isNull(params.get('query_cache_ttl'));
+  });
+
+  it('falls back to cacheTtl 300 for unknown time range', async () => {
+    state.timeRange = 'unknown_range';
+    mockFetch(okResponse({ data: [] }));
+    await query('SELECT 1');
+
+    const { url } = mockFetch.lastCall;
+    const params = new URL(url).searchParams;
+    assert.strictEqual(params.get('query_cache_ttl'), '300');
+  });
+
+  it('throws QueryError on non-ok response', async () => {
+    mockFetch(errorResponse(500, 'Code: 241. DB::Exception: Memory limit exceeded (MEMORY_LIMIT_EXCEEDED)'));
+
+    try {
+      await query('SELECT 1');
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.isTrue(err.isQueryError);
+      assert.strictEqual(err.category, 'memory');
+      assert.strictEqual(err.status, 500);
+      assert.strictEqual(err.code, 241);
+    }
+  });
+
+  it('dispatches auth-error event on 401', async () => {
+    mockFetch(errorResponse(401, 'Authentication failed'));
+
+    let authEventFired = false;
+    const handler = () => {
+      authEventFired = true;
+    };
+    window.addEventListener('auth-error', handler);
+
+    try {
+      await query('SELECT 1');
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.isTrue(authEventFired);
+      assert.strictEqual(err.category, 'permissions');
+    } finally {
+      window.removeEventListener('auth-error', handler);
+    }
+  });
+
+  it('dispatches auth-error on REQUIRED_PASSWORD text', async () => {
+    mockFetch(errorResponse(403, 'Code: 516. REQUIRED_PASSWORD'));
+
+    let authEventFired = false;
+    const handler = () => {
+      authEventFired = true;
+    };
+    window.addEventListener('auth-error', handler);
+
+    try {
+      await query('SELECT 1');
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.isTrue(authEventFired);
+    } finally {
+      window.removeEventListener('auth-error', handler);
+    }
+  });
+
+  it('passes abort signal to fetch', async () => {
+    const controller = new AbortController();
+    window.fetch = async (url, opts) => {
+      assert.strictEqual(opts.signal, controller.signal);
+      return okResponse({ data: [] });
+    };
+
+    await query('SELECT 1', { signal: controller.signal });
+  });
+
+  it('force refresh overrides custom cacheTtl', async () => {
+    setForceRefresh(true);
+    mockFetch(okResponse({ data: [] }));
+    await query('SELECT 1', { cacheTtl: 9999 });
+
+    const { url } = mockFetch.lastCall;
+    const params = new URL(url).searchParams;
+    assert.strictEqual(params.get('query_cache_ttl'), '1');
   });
 });

--- a/js/breakdowns/index.test.js
+++ b/js/breakdowns/index.test.js
@@ -24,12 +24,82 @@ import {
 } from './index.js';
 import { allBreakdowns } from './definitions.js';
 import { lambdaBreakdowns } from './definitions-lambda.js';
-import { TOP_N_OPTIONS } from '../constants.js';
+import { TOP_N_OPTIONS, DEFAULT_TOP_N } from '../constants.js';
+import { startRequestContext } from '../request-context.js';
+import { setQueryTimestamp } from '../time.js';
+
+// SQL templates used by loadBreakdown
+const BREAKDOWN_SQL_TEMPLATE = 'SELECT\n  {{col}} as dim,\n  {{aggTotal}} as cnt,\n  {{aggOk}} as cnt_ok,\n  {{agg4xx}} as cnt_4xx,\n  {{agg5xx}} as cnt_5xx{{summaryCol}}\nFROM {{database}}.{{table}}\n{{sampleClause}}\nWHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{extra}} {{additionalWhereClause}}\nGROUP BY dim WITH TOTALS\nORDER BY {{orderBy}}\nLIMIT {{topN}}\n';
+
+const FACET_SQL_TEMPLATE = 'SELECT\n  dim,\n  sum(cnt) as cnt,\n  sum(cnt_ok) as cnt_ok,\n  sum(cnt_4xx) as cnt_4xx,\n  sum(cnt_5xx) as cnt_5xx{{summaryCol}}\nFROM (\n  SELECT dim, cnt, cnt_ok, cnt_4xx, cnt_5xx{{innerSummaryCol}}\n  FROM {{database}}.cdn_facet_minutes\n  WHERE facet = \'{{facetName}}\'\n    AND minute >= toDateTime(\'{{startTime}}\')\n    AND minute <= toDateTime(\'{{endTime}}\')\n    {{dimFilter}}\n)\nGROUP BY dim WITH TOTALS\nORDER BY {{orderBy}}\nLIMIT {{topN}}\n';
+
+const BUCKETED_SQL_TEMPLATE = 'SELECT\n  {{bucketExpr}} as dim,\n  sum(agg_total) as cnt,\n  sum(agg_ok) as cnt_ok,\n  sum(agg_4xx) as cnt_4xx,\n  sum(agg_5xx) as cnt_5xx{{outerSummaryCol}}\nFROM (\n  SELECT\n    {{rawCol}} as val,\n    {{aggTotal}} as agg_total,\n    {{aggOk}} as agg_ok,\n    {{agg4xx}} as agg_4xx,\n    {{agg5xx}} as agg_5xx{{innerSummaryCol}}\n  FROM {{database}}.{{table}}\n  {{sampleClause}}\n  WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{extra}} {{additionalWhereClause}}\n  GROUP BY val\n)\nGROUP BY dim WITH TOTALS\nORDER BY min(val)\nLIMIT {{topN}}\n';
+
+/**
+ * Create a mock fetch that returns SQL templates and ClickHouse query results.
+ * @param {object} [queryResponse] - The JSON to return for ClickHouse query POSTs
+ * @returns {{ fetch: function, calls: Array }}
+ */
+function createMockFetch(queryResponse = {
+  data: [{
+    dim: 'test', cnt: '100', cnt_ok: '90', cnt_4xx: '8', cnt_5xx: '2',
+  }],
+  totals: {
+    cnt: '100', cnt_ok: '90', cnt_4xx: '8', cnt_5xx: '2',
+  },
+}) {
+  const calls = [];
+  const mockFetch = async (url, options) => {
+    calls.push({ url, options });
+    // SQL template requests (GET)
+    if (typeof url === 'string' && url.endsWith('.sql')) {
+      let template = BREAKDOWN_SQL_TEMPLATE;
+      if (url.includes('breakdown-facet.sql')) template = FACET_SQL_TEMPLATE;
+      else if (url.includes('breakdown-bucketed.sql')) template = BUCKETED_SQL_TEMPLATE;
+      return { ok: true, text: async () => template };
+    }
+    // ClickHouse API POST requests
+    if (options && options.method === 'POST') {
+      return {
+        ok: true,
+        json: async () => ({ ...queryResponse, networkTime: 42 }),
+      };
+    }
+    return { ok: false, status: 404 };
+  };
+  return { fetch: mockFetch, calls };
+}
+
+/**
+ * Create a DOM card element for a breakdown facet.
+ */
+function createCard(id, title) {
+  let card = document.getElementById(id);
+  if (card) card.remove();
+  card = document.createElement('div');
+  card.id = id;
+  const h3 = document.createElement('h3');
+  h3.textContent = title;
+  card.appendChild(h3);
+  document.body.appendChild(card);
+  return card;
+}
 
 beforeEach(() => {
   state.breakdowns = null;
   state.filters = [];
   state.hiddenFacets = [];
+  state.hostFilter = '';
+  state.additionalWhereClause = '';
+  state.contentTypeMode = 'count';
+  state.topN = DEFAULT_TOP_N;
+  state.aggregations = null;
+  state.tableName = 'cdn_requests_v2';
+  state.credentials = { user: 'test', password: 'test' };
+  state.timeRange = '1h';
+  state.pinnedFacets = [];
+  setQueryTimestamp(new Date('2025-06-01T12:00:00Z'));
+  startRequestContext('facets');
   resetFacetTimings();
 });
 
@@ -263,5 +333,522 @@ describe('loadBreakdown', () => {
     assert.include(card.innerHTML, 'Hidden Facet');
     assert.include(card.innerHTML, 'facet-hide-btn');
     assert.include(card.innerHTML, 'Show facet');
+  });
+});
+
+describe('loadBreakdown (facet table path)', () => {
+  const facetId = 'breakdown-facet-table-test';
+  let card;
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = window.fetch;
+    card = createCard(facetId, 'Facet Table Test');
+    state.hostFilter = '';
+    state.filters = [];
+    state.additionalWhereClause = '';
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    if (card && card.parentNode) card.remove();
+  });
+
+  it('renders breakdown table via facet table path when canUseFacetTable is true', async () => {
+    const { fetch: mockFetch, calls } = createMockFetch();
+    window.fetch = mockFetch;
+
+    const b = {
+      id: facetId, col: '`source`', facetName: 'source',
+    };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx);
+
+    // Should have fetched the facet SQL template
+    const sqlCalls = calls.filter((c) => c.url.endsWith('.sql'));
+    assert.isAbove(sqlCalls.length, 0, 'should fetch SQL template');
+    assert.ok(sqlCalls.some((c) => c.url.includes('breakdown-facet.sql')), 'should use facet template');
+
+    // Should have posted a query
+    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    assert.isAbove(queryCalls.length, 0, 'should execute query');
+
+    // Card should contain rendered table content
+    assert.isFalse(card.classList.contains('updating'), 'should remove updating class');
+    assert.isFalse(card.classList.contains('facet-hidden'), 'should not be hidden');
+  });
+
+  it('records timing in facetTimings', async () => {
+    const { fetch: mockFetch } = createMockFetch();
+    window.fetch = mockFetch;
+
+    const b = {
+      id: facetId, col: '`source`', facetName: 'source',
+    };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx);
+
+    assert.ok(facetTimings[facetId] !== undefined, 'should record timing');
+    assert.isAbove(facetTimings[facetId], -1, 'timing should be a number');
+  });
+
+  it('renders summary ratio when summaryDimCondition is set', async () => {
+    const { fetch: mockFetch } = createMockFetch({
+      data: [
+        {
+          dim: '2xx', cnt: '80', cnt_ok: '80', cnt_4xx: '0', cnt_5xx: '0',
+        },
+        {
+          dim: '5xx', cnt: '20', cnt_ok: '0', cnt_4xx: '0', cnt_5xx: '20',
+        },
+      ],
+      totals: {
+        cnt: '100', cnt_ok: '80', cnt_4xx: '0', cnt_5xx: '20', summary_cnt: '20',
+      },
+    });
+    window.fetch = mockFetch;
+
+    const b = {
+      id: facetId,
+      col: "concat(toString(intDiv(`response.status`, 100)), 'xx')",
+      facetName: 'status_range',
+      summaryCountIf: '`response.status` >= 500',
+      summaryDimCondition: "dim = '5xx'",
+      summaryLabel: 'error rate',
+      summaryColor: 'error',
+    };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx);
+
+    // Card should have rendered (not hidden, not updating)
+    assert.isFalse(card.classList.contains('updating'));
+    // The summary metric should be rendered (20% error rate)
+    assert.include(card.innerHTML, '20%');
+  });
+});
+
+describe('loadBreakdown (raw table path)', () => {
+  const rawId = 'breakdown-raw-table-test';
+  let card;
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = window.fetch;
+    card = createCard(rawId, 'Raw Table Test');
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    if (card && card.parentNode) card.remove();
+  });
+
+  it('uses raw table with sampling when host filter prevents facet table', async () => {
+    state.hostFilter = 'example.com';
+    const { fetch: mockFetch, calls } = createMockFetch();
+    window.fetch = mockFetch;
+
+    const b = {
+      id: rawId, col: '`source`', facetName: 'source',
+    };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', "AND (`request.host` LIKE '%example.com%')", ctx);
+
+    // Should use regular breakdown template, not facet template
+    const sqlCalls = calls.filter((c) => c.url.endsWith('.sql'));
+    assert.ok(
+      sqlCalls.some((c) => c.url.includes('breakdown.sql') && !c.url.includes('breakdown-facet')),
+      'should use raw table breakdown template',
+    );
+
+    assert.isFalse(card.classList.contains('updating'));
+  });
+
+  it('uses raw table when filters are active', async () => {
+    state.filters = [{ col: '`request.host`', value: 'a.com', exclude: false }];
+    const { fetch: mockFetch, calls } = createMockFetch();
+    window.fetch = mockFetch;
+
+    const b = {
+      id: rawId, col: '`source`', facetName: 'source',
+    };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx);
+
+    // Verify query uses raw table (cdn_requests_v2, not cdn_facet_minutes)
+    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    assert.isAbove(queryCalls.length, 0, 'should send query');
+    const queryBody = queryCalls[0].options.body;
+    assert.include(queryBody, 'cdn_requests_v2', 'should query raw table');
+    assert.notInclude(queryBody, 'cdn_facet_minutes', 'should not query facet table');
+  });
+
+  it('uses raw table for high-cardinality facets', async () => {
+    const { fetch: mockFetch, calls } = createMockFetch();
+    window.fetch = mockFetch;
+
+    const b = {
+      id: rawId, col: '`request.host`', facetName: 'host', highCardinality: true,
+    };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx);
+
+    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    assert.isAbove(queryCalls.length, 0, 'should send query');
+    const queryBody = queryCalls[0].options.body;
+    assert.include(queryBody, 'cdn_requests_v2', 'should query raw table for high-cardinality');
+  });
+
+  it('uses raw table for breakdown without facetName', async () => {
+    const { fetch: mockFetch, calls } = createMockFetch();
+    window.fetch = mockFetch;
+
+    const b = {
+      id: rawId,
+      col: '`request.headers.x_push_invalidation`',
+      extraFilter: "AND `request.headers.x_push_invalidation` != ''",
+    };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx);
+
+    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    assert.isAbove(queryCalls.length, 0, 'should send query');
+    const queryBody = queryCalls[0].options.body;
+    assert.include(queryBody, 'cdn_requests_v2', 'should query raw table');
+    assert.include(queryBody, 'x_push_invalidation', 'should include the column');
+  });
+
+  it('handles breakdown with modeToggle in bytes mode', async () => {
+    state.contentTypeMode = 'bytes';
+    const { fetch: mockFetch, calls } = createMockFetch();
+    window.fetch = mockFetch;
+
+    const b = {
+      id: rawId, col: '`response.headers.content_type`', facetName: 'content_type', modeToggle: 'contentTypeMode',
+    };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx);
+
+    // Verify it used raw table (bytes mode disables facet table)
+    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    assert.isAbove(queryCalls.length, 0);
+    const queryBody = queryCalls[0].options.body;
+    assert.include(queryBody, 'cdn_requests_v2', 'should query raw table in bytes mode');
+    assert.include(queryBody, 'response.headers.content_length', 'should use bytes aggregation');
+  });
+});
+
+describe('loadBreakdown (bucketed facets)', () => {
+  const bucketId = 'breakdown-bucketed-test';
+  let card;
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = window.fetch;
+    card = createCard(bucketId, 'Bucketed Test');
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    if (card && card.parentNode) card.remove();
+  });
+
+  it('uses bucketed template for facets with rawCol and function col', async () => {
+    const { fetch: mockFetch, calls } = createMockFetch({
+      data: [
+        {
+          dim: '0-100ms', cnt: '50', cnt_ok: '50', cnt_4xx: '0', cnt_5xx: '0',
+        },
+        {
+          dim: '100-500ms', cnt: '30', cnt_ok: '30', cnt_4xx: '0', cnt_5xx: '0',
+        },
+      ],
+      totals: {
+        cnt: '80', cnt_ok: '80', cnt_4xx: '0', cnt_5xx: '0',
+      },
+    });
+    window.fetch = mockFetch;
+
+    const b = {
+      id: bucketId,
+      col: (topN, alias) => `multiIf(${alias || '`cdn.time_elapsed_msec`'} < 100, '0-100ms', '100ms+')`,
+      rawCol: '`cdn.time_elapsed_msec`',
+      orderBy: 'min(`cdn.time_elapsed_msec`)',
+    };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx);
+
+    const sqlCalls = calls.filter((c) => c.url.endsWith('.sql'));
+    assert.ok(
+      sqlCalls.some((c) => c.url.includes('breakdown-bucketed.sql')),
+      'should use bucketed template',
+    );
+
+    assert.isFalse(card.classList.contains('updating'));
+  });
+
+  it('fills expected labels for bucketed facets with getExpectedLabels', async () => {
+    const expectedLabels = ['0-100ms', '100-500ms', '500ms-1s', '1-5s'];
+    const { fetch: mockFetch } = createMockFetch({
+      data: [
+        {
+          dim: '0-100ms', cnt: '50', cnt_ok: '50', cnt_4xx: '0', cnt_5xx: '0',
+        },
+      ],
+      totals: {
+        cnt: '50', cnt_ok: '50', cnt_4xx: '0', cnt_5xx: '0',
+      },
+    });
+    window.fetch = mockFetch;
+
+    const b = {
+      id: bucketId,
+      col: (topN, alias) => `multiIf(${alias || 'val'} < 100, '0-100ms', '100ms+')`,
+      rawCol: '`cdn.time_elapsed_msec`',
+      orderBy: 'min(`cdn.time_elapsed_msec`)',
+      getExpectedLabels: () => expectedLabels,
+    };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx);
+
+    // The breakdown should render without error (fillExpectedLabels fills in missing labels)
+    assert.isFalse(card.classList.contains('updating'));
+  });
+});
+
+describe('loadBreakdown (error handling)', () => {
+  const errorId = 'breakdown-error-test';
+  let card;
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = window.fetch;
+    card = createCard(errorId, 'Error Test');
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    if (card && card.parentNode) card.remove();
+  });
+
+  it('renders error state when query fails', async () => {
+    const calls = [];
+    window.fetch = async (url, options) => {
+      calls.push({ url, options });
+      if (typeof url === 'string' && url.endsWith('.sql')) {
+        return { ok: true, text: async () => BREAKDOWN_SQL_TEMPLATE };
+      }
+      if (options && options.method === 'POST') {
+        return {
+          ok: false,
+          status: 500,
+          text: async () => 'Code: 241. DB::Exception: Memory limit exceeded',
+        };
+      }
+      return { ok: false, status: 404 };
+    };
+
+    const b = { id: errorId, col: '`source`' };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx);
+
+    // Card should show error state
+    assert.isFalse(card.classList.contains('updating'), 'should remove updating class after error');
+    assert.include(card.innerHTML, 'error', 'should render error content');
+  });
+
+  it('silently ignores abort errors', async () => {
+    window.fetch = async (url, options) => {
+      if (typeof url === 'string' && url.endsWith('.sql')) {
+        return { ok: true, text: async () => BREAKDOWN_SQL_TEMPLATE };
+      }
+      if (options && options.method === 'POST') {
+        const abortErr = new DOMException('The operation was aborted.', 'AbortError');
+        throw abortErr;
+      }
+      return { ok: false, status: 404 };
+    };
+
+    const b = { id: errorId, col: '`source`' };
+    const ctx = startRequestContext('facets');
+    // Should not throw
+    await loadBreakdown(b, '1=1', '', ctx);
+  });
+});
+
+describe('loadBreakdown (prepareBreakdownCard)', () => {
+  const prepId = 'breakdown-prep-test';
+  let card;
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = window.fetch;
+    card = createCard(prepId, 'Prep Test');
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    if (card && card.parentNode) card.remove();
+  });
+
+  it('adds updating class during load and removes it after', async () => {
+    let resolveQuery;
+    const queryPromise = new Promise((resolve) => {
+      resolveQuery = resolve;
+    });
+    window.fetch = async (url, options) => {
+      if (typeof url === 'string' && url.endsWith('.sql')) {
+        return { ok: true, text: async () => BREAKDOWN_SQL_TEMPLATE };
+      }
+      if (options && options.method === 'POST') {
+        await queryPromise;
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{
+              dim: 'x', cnt: '1', cnt_ok: '1', cnt_4xx: '0', cnt_5xx: '0',
+            }],
+            totals: {
+              cnt: '1', cnt_ok: '1', cnt_4xx: '0', cnt_5xx: '0',
+            },
+            networkTime: 10,
+          }),
+        };
+      }
+      return { ok: false, status: 404 };
+    };
+
+    const b = { id: prepId, col: '`source`' };
+    const ctx = startRequestContext('facets');
+    const promise = loadBreakdown(b, '1=1', '', ctx);
+
+    // Before query resolves, card should have 'updating'
+    // (we need a microtask to let the async function reach the fetch)
+    await new Promise((r) => {
+      setTimeout(r, 10);
+    });
+    assert.isTrue(card.classList.contains('updating'), 'should add updating class during load');
+
+    resolveQuery();
+    await promise;
+    assert.isFalse(card.classList.contains('updating'), 'should remove updating class after load');
+  });
+
+  it('removes data-action and facet-hidden when facet is not hidden', async () => {
+    card.dataset.action = 'toggle-facet-hide';
+    card.dataset.facet = prepId;
+    card.classList.add('facet-hidden');
+    const { fetch: mockFetch } = createMockFetch();
+    window.fetch = mockFetch;
+
+    const b = { id: prepId, col: '`source`' };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx);
+
+    assert.isFalse(card.classList.contains('facet-hidden'), 'should remove facet-hidden');
+    assert.isFalse(card.hasAttribute('data-action'), 'should remove data-action');
+    assert.isFalse(card.hasAttribute('data-facet'), 'should remove data-facet');
+  });
+});
+
+describe('loadBreakdown (custom aggregations)', () => {
+  const customId = 'breakdown-custom-agg-test';
+  let card;
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = window.fetch;
+    card = createCard(customId, 'Custom Agg');
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    state.aggregations = null;
+    if (card && card.parentNode) card.remove();
+  });
+
+  it('uses custom aggregations from state when set', async () => {
+    state.aggregations = {
+      aggTotal: 'count()',
+      aggOk: 'countIf(`level` = \'INFO\')',
+      agg4xx: 'countIf(`level` = \'WARN\')',
+      agg5xx: 'countIf(`level` = \'ERROR\')',
+    };
+    const { fetch: mockFetch, calls } = createMockFetch();
+    window.fetch = mockFetch;
+
+    const b = { id: customId, col: '`level`' };
+    const ctx = startRequestContext('facets');
+    await loadBreakdown(b, '1=1', '', ctx);
+
+    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    assert.isAbove(queryCalls.length, 0);
+    const queryBody = queryCalls[0].options.body;
+    assert.include(queryBody, "countIf(`level` = 'INFO')", 'should use custom aggOk');
+    assert.include(queryBody, "countIf(`level` = 'ERROR')", 'should use custom agg5xx');
+  });
+});
+
+describe('loadBreakdown (renderHiddenFacet edge cases)', () => {
+  const hiddenId = 'breakdown-hidden-edge-test';
+  let card;
+
+  beforeEach(() => {
+    card = createCard(hiddenId, 'Edge Test');
+  });
+
+  afterEach(() => {
+    if (card && card.parentNode) card.remove();
+    state.hiddenFacets = [];
+  });
+
+  it('uses dataset.title if already set when rendering hidden facet', async () => {
+    card.dataset.title = 'Custom Title';
+    state.hiddenFacets = [hiddenId];
+
+    const b = { id: hiddenId, col: '`source`' };
+    await loadBreakdown(b, '1=1', '');
+
+    assert.include(card.innerHTML, 'Custom Title');
+    assert.isTrue(card.classList.contains('facet-hidden'));
+  });
+
+  it('falls back to id-based title when no h3 and no dataset.title', async () => {
+    // Create card without h3
+    card.remove();
+    card = document.createElement('div');
+    card.id = hiddenId;
+    document.body.appendChild(card);
+
+    state.hiddenFacets = [hiddenId];
+
+    const b = { id: hiddenId, col: '`source`' };
+    await loadBreakdown(b, '1=1', '');
+
+    // Should extract title from id: 'breakdown-hidden-edge-test' -> 'hidden-edge-test'
+    assert.include(card.innerHTML, 'hidden-edge-test');
+    assert.isTrue(card.classList.contains('facet-hidden'));
+  });
+});
+
+describe('canUseFacetTable (highCardinality)', () => {
+  beforeEach(() => {
+    state.hostFilter = '';
+    state.filters = [];
+    state.additionalWhereClause = '';
+  });
+
+  it('returns false for highCardinality facets', () => {
+    const b = {
+      id: 'breakdown-hosts', col: '`request.host`', facetName: 'host', highCardinality: true,
+    };
+    assert.isFalse(canUseFacetTable(b));
+  });
+
+  it('returns true for count mode with modeToggle', () => {
+    state.contentTypeMode = 'count';
+    const b = {
+      id: 'breakdown-content-types', col: 'x', facetName: 'content_type', modeToggle: 'contentTypeMode',
+    };
+    assert.isTrue(canUseFacetTable(b));
   });
 });

--- a/js/filters.test.js
+++ b/js/filters.test.js
@@ -95,6 +95,10 @@ beforeEach(() => {
   setupCallbacks();
 });
 
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
 describe('setFilterCallbacks', () => {
   it('sets saveStateToURL and loadDashboard callbacks', () => {
     // Verify callbacks are wired by triggering clearAllFilters which calls them

--- a/js/filters.test.js
+++ b/js/filters.test.js
@@ -1,0 +1,546 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { state } from './state.js';
+import {
+  setFilterCallbacks,
+  updateHeaderFixed,
+  renderActiveFilters,
+  getFiltersForColumn,
+  getFilterForValue,
+  clearFiltersForColumn,
+  clearAllFilters,
+  addFilter,
+  removeFilter,
+  removeFilterByValue,
+} from './filters.js';
+
+let saveUrlCalls = 0;
+let loadDashCalls = 0;
+
+function resetState() {
+  state.filters = [];
+  state.breakdowns = null;
+  saveUrlCalls = 0;
+  loadDashCalls = 0;
+}
+
+function setupDom() {
+  document.body.innerHTML = '<div id="activeFilters"></div>';
+  document.body.classList.remove('keyboard-mode', 'header-fixed');
+}
+
+function setupCallbacks() {
+  setFilterCallbacks(
+    () => { saveUrlCalls += 1; },
+    () => { loadDashCalls += 1; },
+  );
+}
+
+// Create a fake breakdown card with an h3 title, matching the pattern used by getFacetTitle
+function createBreakdownCard(id, title) {
+  const card = document.createElement('div');
+  card.id = id;
+  const h3 = document.createElement('h3');
+  h3.textContent = title;
+  card.appendChild(h3);
+  document.body.appendChild(card);
+  return card;
+}
+
+// Create a breakdown table row that updateRowFilterStyling can find and update
+function createBreakdownRow(col, value, bgColor) {
+  let card = document.querySelector('.breakdown-card');
+  if (!card) {
+    card = document.createElement('div');
+    card.classList.add('breakdown-card');
+    const table = document.createElement('table');
+    table.classList.add('breakdown-table');
+    card.appendChild(table);
+    document.body.appendChild(card);
+  }
+  const table = card.querySelector('.breakdown-table');
+  const tr = document.createElement('tr');
+  tr.dataset.dim = value;
+  const td = document.createElement('td');
+  td.classList.add('dim');
+  td.dataset.col = col;
+  td.dataset.bgColor = bgColor || 'var(--text)';
+  td.dataset.action = 'add-filter';
+  td.dataset.exclude = 'false';
+  tr.appendChild(td);
+  // Add filter-tag-indicator with filter-icon inside
+  const tag = document.createElement('span');
+  tag.classList.add('filter-tag-indicator');
+  const icon = document.createElement('span');
+  icon.classList.add('filter-icon');
+  tag.appendChild(icon);
+  tr.appendChild(tag);
+  table.appendChild(tr);
+  return tr;
+}
+
+beforeEach(() => {
+  resetState();
+  setupDom();
+  setupCallbacks();
+});
+
+describe('setFilterCallbacks', () => {
+  it('sets saveStateToURL and loadDashboard callbacks', () => {
+    // Verify callbacks are wired by triggering clearAllFilters which calls them
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    clearAllFilters();
+    assert.strictEqual(saveUrlCalls, 1);
+    assert.strictEqual(loadDashCalls, 1);
+  });
+
+  it('does not call callbacks when they are null', () => {
+    setFilterCallbacks(null, null);
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    clearAllFilters();
+    // Should not throw and no callbacks called
+    assert.strictEqual(saveUrlCalls, 0);
+    assert.strictEqual(loadDashCalls, 0);
+  });
+});
+
+describe('updateHeaderFixed', () => {
+  it('adds header-fixed when keyboard-mode is active', () => {
+    document.body.classList.add('keyboard-mode');
+    updateHeaderFixed();
+    assert.isTrue(document.body.classList.contains('header-fixed'));
+  });
+
+  it('adds header-fixed when 2+ filters exist', () => {
+    state.filters = [
+      { col: '`source`', value: 'fastly', exclude: false },
+      { col: '`source`', value: 'cloudflare', exclude: false },
+    ];
+    updateHeaderFixed();
+    assert.isTrue(document.body.classList.contains('header-fixed'));
+  });
+
+  it('removes header-fixed when no keyboard-mode and <2 filters', () => {
+    document.body.classList.add('header-fixed');
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    updateHeaderFixed();
+    assert.isFalse(document.body.classList.contains('header-fixed'));
+  });
+
+  it('removes header-fixed when no filters and no keyboard-mode', () => {
+    document.body.classList.add('header-fixed');
+    updateHeaderFixed();
+    assert.isFalse(document.body.classList.contains('header-fixed'));
+  });
+});
+
+describe('renderActiveFilters', () => {
+  it('clears container when no filters', () => {
+    const container = document.getElementById('activeFilters');
+    container.innerHTML = '<span>old</span>';
+    renderActiveFilters();
+    assert.strictEqual(container.innerHTML, '');
+  });
+
+  it('renders filter tags when filters exist', () => {
+    // Create a breakdown card so getFacetTitle resolves
+    createBreakdownCard('breakdown-source', 'Source');
+    state.breakdowns = [{ id: 'breakdown-source', col: '`source`' }];
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    renderActiveFilters();
+    const container = document.getElementById('activeFilters');
+    assert.include(container.innerHTML, 'fastly');
+    assert.include(container.innerHTML, 'filter-tag');
+  });
+
+  it('renders exclude filter with NOT prefix', () => {
+    createBreakdownCard('breakdown-source', 'Source');
+    state.breakdowns = [{ id: 'breakdown-source', col: '`source`' }];
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: true }];
+    renderActiveFilters();
+    const container = document.getElementById('activeFilters');
+    assert.include(container.innerHTML, 'NOT fastly');
+  });
+
+  it('renders empty-value filter with facet name prefixed by !', () => {
+    createBreakdownCard('breakdown-source', 'Source');
+    state.breakdowns = [{ id: 'breakdown-source', col: '`source`' }];
+    state.filters = [{ col: '`source`', value: '', exclude: false }];
+    renderActiveFilters();
+    const container = document.getElementById('activeFilters');
+    assert.include(container.innerHTML, '!Source');
+  });
+
+  it('renders empty-value exclude filter with NOT !facetName', () => {
+    createBreakdownCard('breakdown-source', 'Source');
+    state.breakdowns = [{ id: 'breakdown-source', col: '`source`' }];
+    state.filters = [{ col: '`source`', value: '', exclude: true }];
+    renderActiveFilters();
+    const container = document.getElementById('activeFilters');
+    assert.include(container.innerHTML, 'NOT !Source');
+  });
+
+  it('uses "Empty" when no breakdown card found', () => {
+    state.filters = [{ col: 'unknown_col', value: '', exclude: false }];
+    renderActiveFilters();
+    const container = document.getElementById('activeFilters');
+    assert.include(container.innerHTML, '!Empty');
+  });
+
+  it('calls updateHeaderFixed', () => {
+    state.filters = [
+      { col: '`source`', value: 'a', exclude: false },
+      { col: '`source`', value: 'b', exclude: false },
+    ];
+    renderActiveFilters();
+    assert.isTrue(document.body.classList.contains('header-fixed'));
+  });
+});
+
+describe('getFiltersForColumn', () => {
+  it('returns filters matching the column', () => {
+    state.filters = [
+      { col: '`source`', value: 'fastly', exclude: false },
+      { col: '`request.url`', value: '/foo', exclude: false },
+      { col: '`source`', value: 'cloudflare', exclude: true },
+    ];
+    const result = getFiltersForColumn('`source`');
+    assert.lengthOf(result, 2);
+    assert.strictEqual(result[0].value, 'fastly');
+    assert.strictEqual(result[1].value, 'cloudflare');
+  });
+
+  it('returns empty array when no matches', () => {
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    const result = getFiltersForColumn('`request.url`');
+    assert.lengthOf(result, 0);
+  });
+});
+
+describe('getFilterForValue', () => {
+  it('finds a filter by col and value', () => {
+    state.filters = [
+      { col: '`source`', value: 'fastly', exclude: false },
+      { col: '`source`', value: 'cloudflare', exclude: true },
+    ];
+    const result = getFilterForValue('`source`', 'cloudflare');
+    assert.isNotNull(result);
+    assert.isTrue(result.exclude);
+  });
+
+  it('returns undefined when not found', () => {
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    const result = getFilterForValue('`source`', 'cloudflare');
+    assert.isUndefined(result);
+  });
+});
+
+describe('clearFiltersForColumn', () => {
+  it('removes all filters for a given column', () => {
+    state.filters = [
+      { col: '`source`', value: 'fastly', exclude: false },
+      { col: '`request.url`', value: '/foo', exclude: false },
+      { col: '`source`', value: 'cloudflare', exclude: true },
+    ];
+    clearFiltersForColumn('`source`');
+    assert.lengthOf(state.filters, 1);
+    assert.strictEqual(state.filters[0].col, '`request.url`');
+  });
+
+  it('calls saveStateToURL and loadDashboard', () => {
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    clearFiltersForColumn('`source`');
+    assert.strictEqual(saveUrlCalls, 1);
+    assert.strictEqual(loadDashCalls, 1);
+  });
+
+  it('calls renderActiveFilters to update UI', () => {
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    clearFiltersForColumn('`source`');
+    const container = document.getElementById('activeFilters');
+    // No filters left, container should be empty
+    assert.strictEqual(container.innerHTML, '');
+  });
+});
+
+describe('clearAllFilters', () => {
+  it('clears all filters', () => {
+    state.filters = [
+      { col: '`source`', value: 'fastly', exclude: false },
+      { col: '`request.url`', value: '/foo', exclude: false },
+    ];
+    clearAllFilters();
+    assert.lengthOf(state.filters, 0);
+  });
+
+  it('calls saveStateToURL and loadDashboard', () => {
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    clearAllFilters();
+    assert.strictEqual(saveUrlCalls, 1);
+    assert.strictEqual(loadDashCalls, 1);
+  });
+
+  it('does nothing when filters are already empty', () => {
+    clearAllFilters();
+    assert.strictEqual(saveUrlCalls, 0);
+    assert.strictEqual(loadDashCalls, 0);
+  });
+});
+
+describe('addFilter', () => {
+  it('adds a basic include filter', () => {
+    addFilter('`source`', 'fastly', false);
+    assert.lengthOf(state.filters, 1);
+    assert.deepInclude(state.filters[0], { col: '`source`', value: 'fastly', exclude: false });
+  });
+
+  it('adds an exclude filter', () => {
+    addFilter('`source`', 'fastly', true);
+    assert.lengthOf(state.filters, 1);
+    assert.isTrue(state.filters[0].exclude);
+  });
+
+  it('replaces existing filter for same col+value', () => {
+    addFilter('`source`', 'fastly', false);
+    addFilter('`source`', 'fastly', true);
+    assert.lengthOf(state.filters, 1);
+    assert.isTrue(state.filters[0].exclude);
+  });
+
+  it('uses filterCol passthrough when provided', () => {
+    addFilter('`source`', 'fastly', false, '`custom_col`', 'custom_val', 'LIKE');
+    const f = state.filters[0];
+    assert.strictEqual(f.filterCol, '`custom_col`');
+    assert.strictEqual(f.filterValue, 'custom_val');
+    assert.strictEqual(f.filterOp, 'LIKE');
+  });
+
+  it('uses value as filterValue when filterValue is not passed', () => {
+    addFilter('`source`', 'fastly', false, '`custom_col`');
+    const f = state.filters[0];
+    assert.strictEqual(f.filterCol, '`custom_col`');
+    assert.strictEqual(f.filterValue, 'fastly');
+  });
+
+  it('omits filterOp when it equals "="', () => {
+    addFilter('`source`', 'fastly', false, '`custom_col`', 'val', '=');
+    const f = state.filters[0];
+    assert.isUndefined(f.filterOp);
+  });
+
+  it('falls back to breakdown definition for filterCol', () => {
+    state.breakdowns = [
+      {
+        id: 'breakdown-asn',
+        col: '`client.asn`',
+        filterCol: '`client.asn`',
+        filterValueFn: (v) => parseInt(v.split(' ')[0], 10),
+      },
+    ];
+    addFilter('`client.asn`', '15169 google', false);
+    const f = state.filters[0];
+    assert.strictEqual(f.filterCol, '`client.asn`');
+    assert.strictEqual(f.filterValue, 15169);
+  });
+
+  it('uses breakdown filterOp from definition', () => {
+    state.breakdowns = [
+      {
+        id: 'breakdown-error',
+        col: '`response.headers.x_error`',
+        filterCol: '`response.headers.x_error`',
+        filterOp: 'LIKE',
+      },
+    ];
+    addFilter('`response.headers.x_error`', 'some error', false);
+    const f = state.filters[0];
+    assert.strictEqual(f.filterOp, 'LIKE');
+  });
+
+  it('does not set filterCol when breakdown has no filterCol', () => {
+    state.breakdowns = [{ id: 'breakdown-source', col: '`source`' }];
+    addFilter('`source`', 'fastly', false);
+    const f = state.filters[0];
+    assert.isUndefined(f.filterCol);
+  });
+
+  it('calls saveStateToURL and loadDashboard by default', () => {
+    addFilter('`source`', 'fastly', false);
+    assert.strictEqual(saveUrlCalls, 1);
+    assert.strictEqual(loadDashCalls, 1);
+  });
+
+  it('skips reload when skipReload is true', () => {
+    addFilter('`source`', 'fastly', false, undefined, undefined, undefined, true);
+    assert.strictEqual(saveUrlCalls, 0);
+    assert.strictEqual(loadDashCalls, 0);
+  });
+
+  it('calls renderActiveFilters', () => {
+    addFilter('`source`', 'fastly', false);
+    const container = document.getElementById('activeFilters');
+    assert.include(container.innerHTML, 'filter-tag');
+  });
+
+  it('falls back to allBreakdowns when state.breakdowns is null', () => {
+    state.breakdowns = null;
+    // allBreakdowns has x_error_grouped with filterCol/filterValueFn/filterOp
+    // The col in allBreakdowns is the REGEXP_REPLACE expression from COLUMN_DEFS
+    const errorCol = "REGEXP_REPLACE(`response.headers.x_error`, '/[a-zA-Z0-9/_.-]+', '/...')";
+    addFilter(errorCol, 'some/.../error', false);
+    const f = state.filters[0];
+    assert.strictEqual(f.filterCol, '`response.headers.x_error`');
+    assert.strictEqual(f.filterOp, 'LIKE');
+    // filterValueFn replaces /... with /%
+    assert.strictEqual(f.filterValue, 'some/%/error');
+  });
+});
+
+describe('removeFilter', () => {
+  it('removes filter by index', () => {
+    state.filters = [
+      { col: '`source`', value: 'fastly', exclude: false },
+      { col: '`request.url`', value: '/foo', exclude: false },
+    ];
+    removeFilter(0);
+    assert.lengthOf(state.filters, 1);
+    assert.strictEqual(state.filters[0].value, '/foo');
+  });
+
+  it('calls saveStateToURL and loadDashboard', () => {
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    removeFilter(0);
+    assert.strictEqual(saveUrlCalls, 1);
+    assert.strictEqual(loadDashCalls, 1);
+  });
+
+  it('calls renderActiveFilters to update UI', () => {
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    removeFilter(0);
+    const container = document.getElementById('activeFilters');
+    assert.strictEqual(container.innerHTML, '');
+  });
+});
+
+describe('removeFilterByValue', () => {
+  it('removes filter matching col and value', () => {
+    state.filters = [
+      { col: '`source`', value: 'fastly', exclude: false },
+      { col: '`request.url`', value: '/foo', exclude: false },
+    ];
+    removeFilterByValue('`source`', 'fastly');
+    assert.lengthOf(state.filters, 1);
+    assert.strictEqual(state.filters[0].value, '/foo');
+  });
+
+  it('calls saveStateToURL and loadDashboard by default', () => {
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    removeFilterByValue('`source`', 'fastly');
+    assert.strictEqual(saveUrlCalls, 1);
+    assert.strictEqual(loadDashCalls, 1);
+  });
+
+  it('skips reload when skipReload is true', () => {
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    removeFilterByValue('`source`', 'fastly', true);
+    assert.strictEqual(saveUrlCalls, 0);
+    assert.strictEqual(loadDashCalls, 0);
+  });
+
+  it('does nothing if filter does not exist', () => {
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    removeFilterByValue('`source`', 'cloudflare');
+    assert.lengthOf(state.filters, 1);
+  });
+
+  it('calls renderActiveFilters', () => {
+    state.filters = [{ col: '`source`', value: 'fastly', exclude: false }];
+    removeFilterByValue('`source`', 'fastly');
+    const container = document.getElementById('activeFilters');
+    assert.strictEqual(container.innerHTML, '');
+  });
+});
+
+describe('row filter styling (via addFilter/removeFilterByValue)', () => {
+  it('adds filter-included class and updates tag on include filter', () => {
+    const row = createBreakdownRow('`source`', 'fastly', '#00ff00');
+    addFilter('`source`', 'fastly', false);
+    assert.isTrue(row.classList.contains('filter-included'));
+    assert.isFalse(row.classList.contains('filter-excluded'));
+    const tag = row.querySelector('.filter-tag-indicator');
+    assert.isTrue(tag.classList.contains('active'));
+    assert.isFalse(tag.classList.contains('exclude'));
+    assert.include(tag.style.background, '0, 255, 0');
+    const icon = tag.querySelector('.filter-icon');
+    assert.strictEqual(icon.textContent, '\u2713');
+    const dimCell = row.querySelector('td.dim');
+    assert.strictEqual(dimCell.dataset.action, 'remove-filter-value');
+    assert.strictEqual(dimCell.dataset.exclude, 'false');
+  });
+
+  it('adds filter-excluded class and updates tag on exclude filter', () => {
+    const row = createBreakdownRow('`source`', 'fastly', '#ff0000');
+    addFilter('`source`', 'fastly', true);
+    assert.isFalse(row.classList.contains('filter-included'));
+    assert.isTrue(row.classList.contains('filter-excluded'));
+    const tag = row.querySelector('.filter-tag-indicator');
+    assert.isFalse(tag.classList.contains('active'));
+    assert.isTrue(tag.classList.contains('exclude'));
+    assert.include(tag.style.background, '255, 0, 0');
+    const icon = tag.querySelector('.filter-icon');
+    assert.strictEqual(icon.textContent, '\u00D7');
+    const dimCell = row.querySelector('td.dim');
+    assert.strictEqual(dimCell.dataset.action, 'remove-filter-value');
+    assert.strictEqual(dimCell.dataset.exclude, 'true');
+  });
+
+  it('removes styling when filter is removed', () => {
+    const row = createBreakdownRow('`source`', 'fastly');
+    addFilter('`source`', 'fastly', false);
+    assert.isTrue(row.classList.contains('filter-included'));
+    removeFilterByValue('`source`', 'fastly');
+    assert.isFalse(row.classList.contains('filter-included'));
+    assert.isFalse(row.classList.contains('filter-excluded'));
+    const tag = row.querySelector('.filter-tag-indicator');
+    assert.isFalse(tag.classList.contains('active'));
+    assert.isFalse(tag.classList.contains('exclude'));
+    assert.strictEqual(tag.style.background, '');
+    const icon = tag.querySelector('.filter-icon');
+    assert.strictEqual(icon.textContent, '');
+    const dimCell = row.querySelector('td.dim');
+    assert.strictEqual(dimCell.dataset.action, 'add-filter');
+  });
+
+  it('ignores rows where dim col does not match', () => {
+    const row = createBreakdownRow('`request.url`', 'fastly');
+    addFilter('`source`', 'fastly', false);
+    // Row has col=`request.url` but filter is for `source`, so styling should not apply
+    assert.isFalse(row.classList.contains('filter-included'));
+  });
+
+  it('ignores rows where data-dim does not match value', () => {
+    const row = createBreakdownRow('`source`', 'cloudflare');
+    addFilter('`source`', 'fastly', false);
+    // Row has dim=cloudflare but filter is for fastly
+    assert.isFalse(row.classList.contains('filter-included'));
+  });
+
+  it('uses default bgColor when dimCell has no bgColor', () => {
+    const row = createBreakdownRow('`source`', 'fastly');
+    const dimCell = row.querySelector('td.dim');
+    delete dimCell.dataset.bgColor;
+    addFilter('`source`', 'fastly', false);
+    const tag = row.querySelector('.filter-tag-indicator');
+    assert.strictEqual(tag.style.background, 'var(--text)');
+  });
+});

--- a/js/state.test.js
+++ b/js/state.test.js
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import {
+  state,
+  setOnPinnedColumnsChange,
+  togglePinnedColumn,
+  loadFacetPrefs,
+  setOnFacetOrderChange,
+  togglePinnedFacet,
+  toggleHiddenFacet,
+} from './state.js';
+
+function resetState() {
+  state.pinnedColumns = [];
+  state.pinnedFacets = [];
+  state.hiddenFacets = [];
+  state.logsData = null;
+  state.title = '';
+  setOnPinnedColumnsChange(null);
+  setOnFacetOrderChange(null);
+  localStorage.removeItem('pinnedColumns');
+  localStorage.removeItem('facetPrefs');
+}
+
+describe('state', () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  it('exports a state object with expected default fields', () => {
+    assert.isObject(state);
+    assert.isNull(state.credentials);
+    assert.isArray(state.filters);
+    assert.strictEqual(state.contentTypeMode, 'count');
+  });
+});
+
+describe('togglePinnedColumn', () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  it('adds a column to pinnedColumns', () => {
+    togglePinnedColumn('response.status');
+    assert.deepEqual(state.pinnedColumns, ['response.status']);
+  });
+
+  it('removes a column that is already pinned', () => {
+    state.pinnedColumns = ['response.status', 'request.url'];
+    togglePinnedColumn('response.status');
+    assert.deepEqual(state.pinnedColumns, ['request.url']);
+  });
+
+  it('persists pinnedColumns to localStorage', () => {
+    togglePinnedColumn('cdn.cache_status');
+    const stored = JSON.parse(localStorage.getItem('pinnedColumns'));
+    assert.deepEqual(stored, ['cdn.cache_status']);
+  });
+
+  it('calls onPinnedColumnsChange callback when logsData is present', () => {
+    let callbackData = null;
+    setOnPinnedColumnsChange((data) => {
+      callbackData = data;
+    });
+    state.logsData = [{ row: 1 }];
+    togglePinnedColumn('col1');
+    assert.deepEqual(callbackData, [{ row: 1 }]);
+  });
+
+  it('does not call callback when logsData is null', () => {
+    let called = false;
+    setOnPinnedColumnsChange(() => {
+      called = true;
+    });
+    state.logsData = null;
+    togglePinnedColumn('col1');
+    assert.isFalse(called);
+  });
+
+  it('does not call callback when no callback is set', () => {
+    state.logsData = [{ row: 1 }];
+    // Should not throw
+    togglePinnedColumn('col1');
+    assert.deepEqual(state.pinnedColumns, ['col1']);
+  });
+});
+
+describe('loadFacetPrefs', () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  it('loads pinned and hidden from localStorage', () => {
+    localStorage.setItem('facetPrefs', JSON.stringify({
+      pinned: ['facetA', 'facetB'],
+      hidden: ['facetC'],
+    }));
+    loadFacetPrefs();
+    assert.deepEqual(state.pinnedFacets, ['facetA', 'facetB']);
+    assert.deepEqual(state.hiddenFacets, ['facetC']);
+  });
+
+  it('defaults to empty arrays when no data stored', () => {
+    localStorage.removeItem('facetPrefs');
+    loadFacetPrefs();
+    assert.deepEqual(state.pinnedFacets, []);
+    assert.deepEqual(state.hiddenFacets, []);
+  });
+
+  it('defaults to empty arrays on invalid JSON', () => {
+    localStorage.setItem('facetPrefs', 'not-json');
+    loadFacetPrefs();
+    assert.deepEqual(state.pinnedFacets, []);
+    assert.deepEqual(state.hiddenFacets, []);
+  });
+
+  it('uses title-keyed storage when state.title is set', () => {
+    state.title = 'myDashboard';
+    localStorage.setItem('facetPrefs_myDashboard', JSON.stringify({
+      pinned: ['x'],
+      hidden: ['y'],
+    }));
+    loadFacetPrefs();
+    assert.deepEqual(state.pinnedFacets, ['x']);
+    assert.deepEqual(state.hiddenFacets, ['y']);
+    localStorage.removeItem('facetPrefs_myDashboard');
+  });
+
+  it('does not read default key when title is set', () => {
+    state.title = 'other';
+    localStorage.setItem('facetPrefs', JSON.stringify({
+      pinned: ['should-not-load'],
+      hidden: [],
+    }));
+    loadFacetPrefs();
+    assert.deepEqual(state.pinnedFacets, []);
+    localStorage.removeItem('facetPrefs_other');
+  });
+});
+
+describe('togglePinnedFacet', () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  it('pins a facet', () => {
+    togglePinnedFacet('facet1');
+    assert.include(state.pinnedFacets, 'facet1');
+  });
+
+  it('unpins a facet that is already pinned', () => {
+    state.pinnedFacets = ['facet1'];
+    togglePinnedFacet('facet1');
+    assert.notInclude(state.pinnedFacets, 'facet1');
+  });
+
+  it('removes from hiddenFacets when pinning a hidden facet', () => {
+    state.hiddenFacets = ['facet1'];
+    togglePinnedFacet('facet1');
+    assert.include(state.pinnedFacets, 'facet1');
+    assert.notInclude(state.hiddenFacets, 'facet1');
+  });
+
+  it('persists to localStorage', () => {
+    togglePinnedFacet('facet1');
+    const stored = JSON.parse(localStorage.getItem('facetPrefs'));
+    assert.deepEqual(stored.pinned, ['facet1']);
+  });
+
+  it('calls onFacetOrderChange callback', () => {
+    let called = false;
+    setOnFacetOrderChange(() => {
+      called = true;
+    });
+    togglePinnedFacet('facet1');
+    assert.isTrue(called);
+  });
+});
+
+describe('toggleHiddenFacet', () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  it('hides a facet', () => {
+    toggleHiddenFacet('facet1');
+    assert.include(state.hiddenFacets, 'facet1');
+  });
+
+  it('unhides a facet that is already hidden', () => {
+    state.hiddenFacets = ['facet1'];
+    toggleHiddenFacet('facet1');
+    assert.notInclude(state.hiddenFacets, 'facet1');
+  });
+
+  it('removes from pinnedFacets when hiding a pinned facet', () => {
+    state.pinnedFacets = ['facet1'];
+    toggleHiddenFacet('facet1');
+    assert.include(state.hiddenFacets, 'facet1');
+    assert.notInclude(state.pinnedFacets, 'facet1');
+  });
+
+  it('calls onFacetOrderChange callback with facetId', () => {
+    let receivedId = null;
+    setOnFacetOrderChange((id) => {
+      receivedId = id;
+    });
+    toggleHiddenFacet('facet1');
+    assert.strictEqual(receivedId, 'facet1');
+  });
+
+  it('persists to localStorage', () => {
+    toggleHiddenFacet('facet1');
+    const stored = JSON.parse(localStorage.getItem('facetPrefs'));
+    assert.deepEqual(stored.hidden, ['facet1']);
+  });
+});

--- a/js/url-state.test.js
+++ b/js/url-state.test.js
@@ -10,11 +10,14 @@
  * governing permissions and limitations under the License.
  */
 import { assert } from 'chai';
-import { loadStateFromURL, saveStateToURL } from './url-state.js';
+import {
+  loadStateFromURL, saveStateToURL, syncUIFromState,
+  setOnBeforeRestore, setOnStateRestored, setUrlStateElements,
+} from './url-state.js';
 import { state } from './state.js';
 import { DEFAULT_TIME_RANGE, DEFAULT_TOP_N } from './constants.js';
 import {
-  queryTimestamp, customTimeRange, setQueryTimestamp, clearCustomTimeRange,
+  queryTimestamp, customTimeRange, setQueryTimestamp, setCustomTimeRange, clearCustomTimeRange,
 } from './time.js';
 
 const ORIGINAL_PATH = window.location.pathname;
@@ -466,5 +469,369 @@ describe('saveStateToURL', () => {
   it('produces clean URL with all defaults', () => {
     saveStateToURL();
     assert.strictEqual(window.location.search, '');
+  });
+
+  it('encodes custom time range as ts and te', () => {
+    setCustomTimeRange(
+      new Date('2026-01-20T10:00:00Z'),
+      new Date('2026-01-20T11:00:00Z'),
+    );
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.ok(params.has('ts'));
+    assert.ok(params.has('te'));
+    assert.strictEqual(new Date(params.get('ts')).toISOString(), '2026-01-20T10:00:00.000Z');
+    assert.strictEqual(new Date(params.get('te')).toISOString(), '2026-01-20T11:00:00.000Z');
+  });
+
+  it('encodes query timestamp as ts without te', () => {
+    setQueryTimestamp(new Date('2026-01-20T12:00:00Z'));
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.ok(params.has('ts'));
+    assert.isFalse(params.has('te'));
+    assert.strictEqual(new Date(params.get('ts')).toISOString(), '2026-01-20T12:00:00.000Z');
+  });
+
+  it('encodes showLogs as view=logs', () => {
+    state.showLogs = true;
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.strictEqual(params.get('view'), 'logs');
+  });
+
+  it('omits view param when showLogs is false', () => {
+    state.showLogs = false;
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.isFalse(params.has('view'));
+  });
+
+  it('encodes custom title', () => {
+    state.title = 'My Dashboard';
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.strictEqual(params.get('title'), 'My Dashboard');
+  });
+
+  it('omits title when empty', () => {
+    state.title = '';
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.isFalse(params.has('title'));
+  });
+
+  it('encodes bytes content type mode', () => {
+    state.contentTypeMode = 'bytes';
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.strictEqual(params.get('ctm'), 'bytes');
+  });
+
+  it('omits contentTypeMode when count (default)', () => {
+    state.contentTypeMode = 'count';
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.isFalse(params.has('ctm'));
+  });
+
+  it('encodes anomaly id when provided', () => {
+    saveStateToURL('anomaly-123');
+    const params = new URLSearchParams(window.location.search);
+    assert.strictEqual(params.get('anomaly'), 'anomaly-123');
+  });
+
+  it('omits anomaly param when newAnomalyId is empty string', () => {
+    saveStateToURL('');
+    const params = new URLSearchParams(window.location.search);
+    assert.isFalse(params.has('anomaly'));
+  });
+
+  it('preserves anomaly from current URL when not explicitly passed', () => {
+    // Set anomaly in URL first
+    window.history.replaceState({}, '', `${ORIGINAL_PATH}?anomaly=existing-anomaly`);
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.strictEqual(params.get('anomaly'), 'existing-anomaly');
+  });
+
+  it('uses pushState for subsequent saves (not first)', () => {
+    // First save uses replaceState (since lastSavedURL is null after reset)
+    state.timeRange = '1h';
+    saveStateToURL();
+    const firstURL = window.location.href;
+
+    // Second save with different state should use pushState
+    state.timeRange = '24h';
+    saveStateToURL();
+    const secondURL = window.location.href;
+    assert.notStrictEqual(firstURL, secondURL);
+    const params = new URLSearchParams(window.location.search);
+    assert.strictEqual(params.get('t'), '24h');
+  });
+
+  it('does not push duplicate URL to history', () => {
+    state.timeRange = '24h';
+    saveStateToURL();
+    const firstHref = window.location.href;
+    // Call again with same state — should be a no-op
+    saveStateToURL();
+    assert.strictEqual(window.location.href, firstHref);
+  });
+
+  it('omits empty filters array', () => {
+    state.filters = [];
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.isFalse(params.has('filters'));
+  });
+
+  it('omits empty pinned facets', () => {
+    state.pinnedFacets = [];
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.isFalse(params.has('pf'));
+  });
+
+  it('omits empty hidden facets', () => {
+    state.hiddenFacets = [];
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.isFalse(params.has('hf'));
+  });
+});
+
+describe('saveStateToURL and loadStateFromURL round-trip', () => {
+  beforeEach(() => {
+    resetState();
+    clearCustomTimeRange();
+    setQueryTimestamp(null);
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', ORIGINAL_PATH);
+  });
+
+  it('round-trips custom time range', () => {
+    setCustomTimeRange(
+      new Date('2026-01-20T10:00:00Z'),
+      new Date('2026-01-20T11:00:00Z'),
+    );
+    saveStateToURL();
+
+    // Now reload state from the URL
+    clearCustomTimeRange();
+    loadStateFromURL();
+    const ctr = customTimeRange();
+    assert.ok(ctr);
+    assert.ok(ctr.start instanceof Date);
+    assert.ok(ctr.end instanceof Date);
+  });
+
+  it('round-trips query timestamp', () => {
+    setQueryTimestamp(new Date('2026-01-20T12:00:00Z'));
+    saveStateToURL();
+
+    setQueryTimestamp(null);
+    loadStateFromURL();
+    assert.ok(queryTimestamp());
+    assert.strictEqual(queryTimestamp().toISOString(), '2026-01-20T12:00:00.000Z');
+  });
+
+  it('round-trips full state with all params', () => {
+    state.timeRange = '24h';
+    state.hostFilter = 'example.com';
+    state.topN = 20;
+    state.showLogs = true;
+    state.title = 'Test';
+    state.contentTypeMode = 'bytes';
+    state.filters = [{ col: '`request.host`', value: 'test.com', exclude: false }];
+    state.pinnedFacets = ['host', 'url'];
+    state.hiddenFacets = ['referer'];
+    setQueryTimestamp(new Date('2026-01-20T12:00:00Z'));
+    saveStateToURL();
+
+    // Reset and reload
+    resetState();
+    clearCustomTimeRange();
+    setQueryTimestamp(null);
+    loadStateFromURL();
+
+    assert.strictEqual(state.timeRange, '24h');
+    assert.strictEqual(state.hostFilter, 'example.com');
+    assert.strictEqual(state.topN, 20);
+    assert.strictEqual(state.showLogs, true);
+    assert.strictEqual(state.title, 'Test');
+    assert.strictEqual(state.contentTypeMode, 'bytes');
+    assert.strictEqual(state.filters.length, 1);
+    assert.deepEqual(state.pinnedFacets, ['host', 'url']);
+    assert.deepEqual(state.hiddenFacets, ['referer']);
+  });
+});
+
+describe('callback setters', () => {
+  it('setOnBeforeRestore accepts a callback', () => {
+    let called = false;
+    setOnBeforeRestore(() => {
+      called = true;
+    });
+    // The callback is only invoked by popstate, so just verify it doesn't throw
+    assert.isFalse(called);
+  });
+
+  it('setOnStateRestored accepts a callback', () => {
+    let called = false;
+    setOnStateRestored(() => {
+      called = true;
+    });
+    assert.isFalse(called);
+  });
+
+  it('setUrlStateElements accepts an object', () => {
+    // Just verify it doesn't throw
+    setUrlStateElements({});
+  });
+});
+
+describe('syncUIFromState', () => {
+  let mockElements;
+  let titleEl;
+  let activeFiltersEl;
+
+  beforeEach(() => {
+    resetState();
+    clearCustomTimeRange();
+    setQueryTimestamp(null);
+
+    // Create mock DOM elements
+    const timeSelect = document.createElement('select');
+    ['15m', '1h', '12h', '24h', '7d', 'custom'].forEach((v) => {
+      const opt = document.createElement('option');
+      opt.value = v;
+      opt.textContent = v;
+      timeSelect.appendChild(opt);
+    });
+
+    const topNSel = document.createElement('select');
+    [5, 10, 20, 50, 100].forEach((v) => {
+      const opt = document.createElement('option');
+      opt.value = String(v);
+      opt.textContent = String(v);
+      topNSel.appendChild(opt);
+    });
+
+    mockElements = {
+      timeRangeSelect: timeSelect,
+      topNSelect: topNSel,
+      hostFilterInput: document.createElement('input'),
+      logsView: document.createElement('div'),
+      filtersView: document.createElement('div'),
+      viewToggleBtn: document.createElement('button'),
+      refreshBtn: document.createElement('button'),
+      logoutBtn: document.createElement('button'),
+    };
+    // viewToggleBtn needs an inner menu-item-label span
+    const labelSpan = document.createElement('span');
+    labelSpan.className = 'menu-item-label';
+    mockElements.viewToggleBtn.appendChild(labelSpan);
+
+    setUrlStateElements(mockElements);
+
+    // Create dashboard title element in DOM
+    titleEl = document.createElement('h1');
+    titleEl.id = 'dashboardTitle';
+    document.body.appendChild(titleEl);
+
+    // Create activeFilters container for renderActiveFilters
+    activeFiltersEl = document.createElement('div');
+    activeFiltersEl.id = 'activeFilters';
+    document.body.appendChild(activeFiltersEl);
+  });
+
+  afterEach(() => {
+    titleEl.remove();
+    activeFiltersEl.remove();
+    window.history.replaceState({}, '', ORIGINAL_PATH);
+  });
+
+  it('syncs time range dropdown for predefined range', () => {
+    state.timeRange = '24h';
+    syncUIFromState();
+    assert.strictEqual(mockElements.timeRangeSelect.value, '24h');
+  });
+
+  it('syncs time range dropdown to custom when custom range is active', () => {
+    setCustomTimeRange(
+      new Date('2026-01-20T10:00:00Z'),
+      new Date('2026-01-20T11:00:00Z'),
+    );
+    syncUIFromState();
+    assert.strictEqual(mockElements.timeRangeSelect.value, 'custom');
+  });
+
+  it('syncs topN dropdown', () => {
+    state.topN = 20;
+    syncUIFromState();
+    assert.strictEqual(mockElements.topNSelect.value, '20');
+  });
+
+  it('syncs host filter input', () => {
+    state.hostFilter = 'example.com';
+    syncUIFromState();
+    assert.strictEqual(mockElements.hostFilterInput.value, 'example.com');
+  });
+
+  it('sets custom title in DOM and document.title', () => {
+    state.title = 'My Custom Dashboard';
+    syncUIFromState();
+    assert.strictEqual(titleEl.textContent, 'My Custom Dashboard');
+    assert.include(document.title, 'My Custom Dashboard');
+  });
+
+  it('resets title when no custom title', () => {
+    state.title = '';
+    syncUIFromState();
+    assert.strictEqual(titleEl.textContent, 'CDN Analytics');
+    assert.strictEqual(document.title, 'CDN Analytics');
+  });
+
+  it('shows logs view when showLogs is true', () => {
+    state.showLogs = true;
+    syncUIFromState();
+    assert.isTrue(mockElements.logsView.classList.contains('visible'));
+    assert.isFalse(mockElements.filtersView.classList.contains('visible'));
+    assert.strictEqual(
+      mockElements.viewToggleBtn.querySelector('.menu-item-label').textContent,
+      'View Filters',
+    );
+  });
+
+  it('shows filters view when showLogs is false', () => {
+    state.showLogs = false;
+    syncUIFromState();
+    assert.isFalse(mockElements.logsView.classList.contains('visible'));
+    assert.isTrue(mockElements.filtersView.classList.contains('visible'));
+    assert.strictEqual(
+      mockElements.viewToggleBtn.querySelector('.menu-item-label').textContent,
+      'View Logs',
+    );
+  });
+
+  it('hides controls based on hiddenControls', () => {
+    state.hiddenControls = ['timeRange', 'topN', 'host', 'refresh', 'logout', 'logs'];
+    syncUIFromState();
+    assert.strictEqual(mockElements.timeRangeSelect.style.display, 'none');
+    assert.strictEqual(mockElements.topNSelect.style.display, 'none');
+    assert.strictEqual(mockElements.hostFilterInput.style.display, 'none');
+    assert.strictEqual(mockElements.refreshBtn.style.display, 'none');
+    assert.strictEqual(mockElements.logoutBtn.style.display, 'none');
+    assert.strictEqual(mockElements.viewToggleBtn.style.display, 'none');
+  });
+
+  it('does not hide controls when hiddenControls is empty', () => {
+    state.hiddenControls = [];
+    syncUIFromState();
+    assert.notStrictEqual(mockElements.timeRangeSelect.style.display, 'none');
+    assert.notStrictEqual(mockElements.topNSelect.style.display, 'none');
   });
 });

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -14,7 +14,7 @@ export default {
       statements: 0,
       branches: 0,
       functions: 0,
-      lines: 90,
+      lines: 95,
     },
   },
 };

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -14,7 +14,7 @@ export default {
       statements: 0,
       branches: 0,
       functions: 0,
-      lines: 83,
+      lines: 90,
     },
   },
 };


### PR DESCRIPTION
## Summary

Raise the enforced line coverage from 85% to 96.62% by adding and expanding tests for the 6 least-covered source files, then bump the threshold from 83% to 90%.

**Coverage improvements:**

| File | Before | After |
|------|--------|-------|
| `js/filters.js` | 27% | 100% |
| `js/state.js` | 57% | 92% |
| `js/breakdowns/index.js` | 39% | 93% |
| `js/api.js` | 71% | 100% |
| `js/time.js` | 76% | 99% |
| `js/url-state.js` | 70% | 93% |

**Overall**: 658 tests, 96.62% line coverage (threshold raised from 83 → 90).

No source files were modified — only test files and the coverage threshold in `web-test-runner.config.mjs`.

## Testing Done

- `npx web-test-runner --coverage` — 658 tests pass, 96.62% line coverage
- `npm run lint` — passes cleanly with zero errors
- Verified no source files modified via `git diff --stat`

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)