### PR TITLE
feat: virtual scrolling for logs view

### DIFF
--- a/css/chart.css
+++ b/css/chart.css
@@ -149,13 +149,6 @@
   opacity: 0.6;
 }
 
-.chart-scrubber-line.range-mode {
-  background: rgba(59, 130, 246, 0.12);
-  border-left: 2px solid rgba(59, 130, 246, 0.5);
-  border-right: 2px solid rgba(59, 130, 246, 0.5);
-  opacity: 1;
-}
-
 .chart-scrubber-status {
   position: absolute;
   bottom: 0;

--- a/css/chart.css
+++ b/css/chart.css
@@ -149,6 +149,13 @@
   opacity: 0.6;
 }
 
+.chart-scrubber-line.range-mode {
+  background: rgba(59, 130, 246, 0.12);
+  border-left: 2px solid rgba(59, 130, 246, 0.5);
+  border-right: 2px solid rgba(59, 130, 246, 0.5);
+  opacity: 1;
+}
+
 .chart-scrubber-status {
   position: absolute;
   bottom: 0;

--- a/css/chart.css
+++ b/css/chart.css
@@ -9,10 +9,9 @@
   margin: 0 -24px 24px -24px;
 }
 
-/* Sticky chart when logs view is active */
+/* Chart section takes its natural size in flex layout */
 .logs-active .chart-section {
-  position: sticky;
-  top: 0;
+  flex-shrink: 0;
   z-index: 20;
 }
 

--- a/css/chart.css
+++ b/css/chart.css
@@ -9,6 +9,50 @@
   margin: 0 -24px 24px -24px;
 }
 
+/* Sticky chart when logs view is active */
+.logs-active .chart-section {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+/* Collapse/expand toggle */
+.chart-collapse-toggle {
+  display: none;
+  width: 100%;
+  height: 24px;
+  border: none;
+  background: var(--chart-bg);
+  border-top: 1px solid var(--border);
+  cursor: pointer;
+  padding: 0;
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 24px;
+  text-align: center;
+  opacity: 0.6;
+  transition: opacity 0.15s ease;
+}
+
+.chart-collapse-toggle:hover {
+  opacity: 1;
+}
+
+.logs-active .chart-collapse-toggle {
+  display: block;
+}
+
+/* Collapsed state */
+.chart-section.chart-collapsed .chart-container {
+  height: 0;
+  overflow: hidden;
+  transition: height 0.2s ease;
+}
+
+.chart-section:not(.chart-collapsed) .chart-container {
+  transition: height 0.2s ease;
+}
+
 @media (max-width: 600px) {
   .chart-section {
     margin: 0 -12px 16px -12px;

--- a/css/logs.css
+++ b/css/logs.css
@@ -240,6 +240,10 @@
   white-space: nowrap;
 }
 
+.bucket-table .bucket-row:nth-child(even) .bucket-placeholder {
+  background: rgba(0, 0, 0, 0.02);
+}
+
 .bucket-table .bucket-row:hover .bucket-placeholder {
   background: var(--bg);
 }

--- a/css/logs.css
+++ b/css/logs.css
@@ -48,6 +48,7 @@
 .logs-table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
   font-size: 12px;
   font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
 }
@@ -61,6 +62,8 @@
   position: sticky;
   top: 0;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   cursor: pointer;
   user-select: none;
 }
@@ -105,7 +108,7 @@
   padding: 8px 12px;
   border-bottom: 1px solid var(--border);
   vertical-align: top;
-  max-width: 300px;
+  max-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/css/logs.css
+++ b/css/logs.css
@@ -14,6 +14,28 @@
   display: block;
 }
 
+/* Logs-active: make main a flex column that fills the viewport */
+.logs-active#dashboardContent {
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+body.header-fixed .logs-active#dashboardContent {
+  height: calc(100vh - 70px);
+}
+
+/* Logs View fills remaining flex space */
+.logs-active #logsView.visible {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
 /* Logs View */
 #logsView {
   padding: 16px 0 24px 0;
@@ -27,6 +49,14 @@
   transition: filter 0.2s ease-out;
   height: calc(100vh - 200px);
   min-height: 400px;
+}
+
+/* In logs-active mode, container fills remaining flex space */
+.logs-active .logs-table-container {
+  flex: 1;
+  min-height: 0;
+  height: auto;
+  overflow: auto;
 }
 
 @media (max-width: 600px) {
@@ -46,7 +76,7 @@
 }
 
 .logs-table {
-  width: 100%;
+  min-width: 100%;
   border-collapse: collapse;
   table-layout: fixed;
   font-size: 12px;

--- a/css/logs.css
+++ b/css/logs.css
@@ -247,10 +247,6 @@
   );
 }
 
-.bucket-table .bucket-row:hover .bucket-placeholder {
-  background: var(--bg);
-}
-
 /* Copy feedback toast */
 .copy-feedback {
   position: fixed;

--- a/css/logs.css
+++ b/css/logs.css
@@ -25,6 +25,8 @@
   border: 1px solid var(--border);
   overflow-x: auto;
   transition: filter 0.2s ease-out;
+  height: calc(100vh - 200px);
+  min-height: 400px;
 }
 
 @media (max-width: 600px) {
@@ -173,6 +175,12 @@
   justify-content: center;
   padding: 60px;
   color: var(--text-secondary);
+}
+
+/* Virtual table loading placeholder rows */
+.logs-table .loading-row td {
+  background: var(--card-bg);
+  color: transparent;
 }
 
 /* Copy feedback toast */

--- a/css/logs.css
+++ b/css/logs.css
@@ -247,6 +247,13 @@
   );
 }
 
+/* Bucket table data rows (loaded on demand) */
+.bucket-table tr[data-row-idx] td {
+  height: 28px;
+  padding: 4px 8px;
+  box-sizing: border-box;
+}
+
 /* Copy feedback toast */
 .copy-feedback {
   position: fixed;

--- a/css/logs.css
+++ b/css/logs.css
@@ -238,10 +238,13 @@
   border-bottom: 1px solid var(--border);
   padding: 0 12px;
   white-space: nowrap;
-}
-
-.bucket-table .bucket-row:nth-child(even) .bucket-placeholder {
-  background: rgba(0, 0, 0, 0.02);
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0px,
+    transparent 28px,
+    rgba(0, 0, 0, 0.02) 28px,
+    rgba(0, 0, 0, 0.02) 56px
+  );
 }
 
 .bucket-table .bucket-row:hover .bucket-placeholder {

--- a/css/logs.css
+++ b/css/logs.css
@@ -14,16 +14,24 @@
   display: block;
 }
 
-/* Logs-active: make main a flex column that fills the viewport */
-.logs-active#dashboardContent {
+/* Logs-active: make #dashboard a flex column so header + main fill exactly 100vh */
+#dashboard:has(.logs-active) {
   height: 100vh;
   overflow: hidden;
   display: flex;
   flex-direction: column;
 }
 
-body.header-fixed .logs-active#dashboardContent {
-  height: calc(100vh - 70px);
+#dashboard:has(.logs-active) > header {
+  flex-shrink: 0;
+}
+
+.logs-active#dashboardContent {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Logs View fills remaining flex space */

--- a/css/logs.css
+++ b/css/logs.css
@@ -224,6 +224,26 @@
   color: transparent;
 }
 
+/* Bucket-row table placeholder rows */
+.bucket-table .bucket-row {
+  cursor: default;
+}
+
+.bucket-table .bucket-row .bucket-placeholder {
+  max-width: none;
+  vertical-align: middle;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 11px;
+  border-bottom: 1px solid var(--border);
+  padding: 0 12px;
+  white-space: nowrap;
+}
+
+.bucket-table .bucket-row:hover .bucket-placeholder {
+  background: var(--bg);
+}
+
 /* Copy feedback toast */
 .copy-feedback {
   position: fixed;

--- a/css/modals.css
+++ b/css/modals.css
@@ -365,6 +365,13 @@
   margin-bottom: 12px;
 }
 
+.log-detail-loading {
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
 @media (max-width: 600px) {
   #logDetailModal {
     width: 100vw;

--- a/dashboard.html
+++ b/dashboard.html
@@ -80,7 +80,7 @@
         <div class="chart-container">
           <canvas id="chart"></canvas>
         </div>
-        <button class="chart-collapse-toggle" id="chartCollapseToggle" title="Collapse chart">&#9650; Hide chart</button>
+        <button class="chart-collapse-toggle" id="chartCollapseToggle" title="Collapse chart"><span aria-hidden="true">&#9650;</span> Hide chart</button>
       </section>
 
       <!-- Filters View (Breakdowns) -->

--- a/dashboard.html
+++ b/dashboard.html
@@ -80,6 +80,7 @@
         <div class="chart-container">
           <canvas id="chart"></canvas>
         </div>
+        <button class="chart-collapse-toggle" id="chartCollapseToggle" title="Collapse chart">&#9650; Hide chart</button>
       </section>
 
       <!-- Filters View (Breakdowns) -->

--- a/js/bucket-loader.js
+++ b/js/bucket-loader.js
@@ -13,7 +13,8 @@
 /**
  * Bucket data loader — extracted from logs.js to stay within the
  * max-lines lint limit. Handles per-bucket on-demand data fetching,
- * IntersectionObserver setup, and placeholder replacement.
+ * IntersectionObserver setup, placeholder replacement, and DOM
+ * virtualization with a 2000-row cap.
  */
 
 import { DATABASE } from './config.js';
@@ -32,6 +33,10 @@ const SECOND_MS = 1000;
 const MINUTE_MS = 60 * SECOND_MS;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
+
+const MAX_DOM_ROWS = 2000;
+const HEAD_CACHE_SIZE = 20;
+const ROW_HEIGHT = 28;
 
 /**
  * Parse a ClickHouse INTERVAL string to milliseconds.
@@ -68,8 +73,32 @@ const bucketFetchLimiter = createLimiter(4);
 // eslint-disable-next-line prefer-const -- reassigned in setup/teardown
 let fetchController = null;
 // eslint-disable-next-line prefer-const -- reassigned in setup/teardown
-let observer = null;
+let loadObserver = null;
+// eslint-disable-next-line prefer-const -- reassigned in setup/teardown
+let evictionObserver = null;
 const loadedBuckets = new Set();
+
+// Per-bucket AbortControllers for cancelling in-flight fetches
+const bucketControllers = new Map();
+
+// LRU head-data cache (ts → rows)
+const headCache = new Map();
+
+// Stored container reference for eviction observer sentinel wiring
+// eslint-disable-next-line prefer-const -- reassigned in setup/teardown
+let storedContainer = null;
+
+/**
+ * Store rows in the LRU head cache.
+ */
+function cacheHead(ts, rows) {
+  headCache.delete(ts);
+  headCache.set(ts, rows);
+  if (headCache.size > HEAD_CACHE_SIZE) {
+    const oldest = headCache.keys().next().value;
+    headCache.delete(oldest);
+  }
+}
 
 /**
  * Fetch log rows for a specific bucket time window.
@@ -110,35 +139,168 @@ async function fetchBucketRows(bucketTs, limit, offset, signal) {
 }
 
 /**
- * Replace a placeholder <tr> with actual data rows.
+ * Count data rows currently in the DOM.
  */
-function replacePlaceholder(placeholder, rows, cols, pin, offsets) {
+function countDataRows(container) {
+  return container.querySelectorAll('tr[data-bucket]').length;
+}
+
+/**
+ * Evict a loaded bucket back to a placeholder.
+ */
+function evictBucket(ts, container, cols) {
+  // Abort any in-flight fetch
+  const ctrl = bucketControllers.get(ts);
+  if (ctrl) {
+    ctrl.abort();
+    bucketControllers.delete(ts);
+  }
+
+  // Find sentinel
+  const sentinel = container.querySelector(`tr.bucket-sentinel[data-bucket="${ts}"]`);
+  if (!sentinel) return;
+
+  // Stop observing sentinel before removal
+  if (evictionObserver) evictionObserver.unobserve(sentinel);
+
+  // Collect data rows following the sentinel
+  const rows = [];
+  let next = sentinel.nextElementSibling;
+  while (next && next.dataset.bucket === ts) {
+    rows.push(next);
+    next = next.nextElementSibling;
+  }
+
+  // Calculate replacement height
+  const totalHeight = rows.length * ROW_HEIGHT;
+  const numColumns = cols.length;
+
+  // Create placeholder
+  const placeholder = document.createElement('tr');
+  placeholder.id = `bucket-head-${ts}`;
+  placeholder.className = 'bucket-row bucket-head';
+  placeholder.style.height = `${totalHeight}px`;
+  // eslint-disable-next-line no-irregular-whitespace
+  placeholder.innerHTML = `<td colspan="${numColumns}" class="bucket-placeholder">${rows.length.toLocaleString()} rows (evicted)</td>`;
+
+  // Replace sentinel with placeholder, remove data rows
+  sentinel.parentNode.insertBefore(placeholder, sentinel);
+  sentinel.remove();
+  for (const r of rows) r.remove();
+
+  // Remove from loaded set
+  loadedBuckets.delete(ts);
+
+  // Re-observe with load observer
+  if (loadObserver) loadObserver.observe(placeholder);
+}
+
+/**
+ * Enforce the MAX_DOM_ROWS budget by evicting the farthest bucket.
+ */
+function enforceRowBudget(container, cols) {
+  const viewportCenter = window.innerHeight / 2;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const currentCount = countDataRows(container);
+    if (currentCount <= MAX_DOM_ROWS) break;
+
+    // Find farthest loaded bucket from viewport center
+    let farthestTs = null;
+    let farthestDist = -1;
+
+    for (const ts of loadedBuckets) {
+      const sentinel = container.querySelector(
+        `tr.bucket-sentinel[data-bucket="${ts}"]`,
+      );
+      if (sentinel) {
+        const rect = sentinel.getBoundingClientRect();
+        const dist = Math.abs(rect.top - viewportCenter);
+        if (dist > farthestDist) {
+          farthestDist = dist;
+          farthestTs = ts;
+        }
+      }
+    }
+
+    if (!farthestTs) break;
+    evictBucket(farthestTs, container, cols);
+  }
+}
+
+/**
+ * Replace a placeholder <tr> with a sentinel and actual data rows.
+ */
+function replacePlaceholder(placeholder, rows, cols, pin, offsets, ts) {
   if (!placeholder || !placeholder.parentNode) return;
 
-  let html = '';
+  // Build sentinel + data rows HTML
+  let html = `<tr class="bucket-sentinel" data-bucket="${ts}" `
+    + 'style="height:0;padding:0;border:0;line-height:0;visibility:hidden;"></tr>';
+
   for (let i = 0; i < rows.length; i += 1) {
-    html += buildLogRowHtml({
+    const rowHtml = buildLogRowHtml({
       row: rows[i], columns: cols, rowIdx: i, pinned: pin, pinnedOffsets: offsets,
     });
+    // Inject data-bucket attribute into the <tr> tag
+    html += rowHtml.replace('<tr ', `<tr data-bucket="${ts}" `);
   }
 
   if (html) {
     placeholder.insertAdjacentHTML('afterend', html);
   }
   placeholder.remove();
+
+  // Observe the new sentinel with the eviction observer
+  if (evictionObserver && storedContainer) {
+    const sentinel = storedContainer.querySelector(
+      `tr.bucket-sentinel[data-bucket="${ts}"]`,
+    );
+    if (sentinel) evictionObserver.observe(sentinel);
+  }
+}
+
+/**
+ * Create a per-bucket AbortController and return its signal.
+ * Also listens to the global signal so navigation abort cancels everything.
+ */
+function createBucketSignal(ts, globalSignal) {
+  const controller = new AbortController();
+  bucketControllers.set(ts, controller);
+
+  // If the global signal aborts, abort the per-bucket one too
+  if (globalSignal) {
+    if (globalSignal.aborted) {
+      controller.abort();
+    } else {
+      globalSignal.addEventListener('abort', () => controller.abort(), { once: true });
+    }
+  }
+
+  return controller.signal;
 }
 
 /**
  * Load data for a single bucket (head and optionally tail).
  */
-async function loadBucket(ts, bucket, cols, pin, offsets, signal) {
+async function loadBucket(ts, bucket, cols, pin, offsets, globalSignal, container) {
+  const signal = createBucketSignal(ts, globalSignal);
+
   const headEl = document.getElementById(`bucket-head-${ts}`);
   if (headEl) {
     try {
-      const fn = () => fetchBucketRows(ts, bucket.headCount, 0, signal);
-      const rows = await bucketFetchLimiter(fn);
+      let rows;
+      if (headCache.has(ts)) {
+        rows = headCache.get(ts);
+      } else {
+        const fn = () => fetchBucketRows(ts, bucket.headCount, 0, signal);
+        rows = await bucketFetchLimiter(fn);
+        if (!signal.aborted) cacheHead(ts, rows);
+      }
       if (!signal.aborted) {
-        replacePlaceholder(headEl, rows, cols, pin, offsets);
+        replacePlaceholder(headEl, rows, cols, pin, offsets, ts);
+        enforceRowBudget(container, cols);
       }
     } catch (err) {
       if (!isAbortError(err)) {
@@ -150,11 +312,18 @@ async function loadBucket(ts, bucket, cols, pin, offsets, signal) {
 
   const tailEl = document.getElementById(`bucket-tail-${ts}`);
   if (tailEl && bucket.tailCount > 0) {
+    // Budget-awareness: check remaining room before tail fetch
+    const currentRows = countDataRows(container);
+    const budget = MAX_DOM_ROWS - currentRows;
+    if (budget <= 0) return;
+    const effectiveTailLimit = Math.min(bucket.tailCount, budget);
+
     try {
-      const fn = () => fetchBucketRows(ts, bucket.tailCount, 500, signal);
+      const fn = () => fetchBucketRows(ts, effectiveTailLimit, 500, signal);
       const rows = await bucketFetchLimiter(fn);
       if (!signal.aborted) {
-        replacePlaceholder(tailEl, rows, cols, pin, offsets);
+        replacePlaceholder(tailEl, rows, cols, pin, offsets, ts);
+        enforceRowBudget(container, cols);
       }
     } catch (err) {
       if (!isAbortError(err)) {
@@ -163,6 +332,9 @@ async function loadBucket(ts, bucket, cols, pin, offsets, signal) {
       }
     }
   }
+
+  // Clean up per-bucket controller after completion
+  bucketControllers.delete(ts);
 }
 
 /**
@@ -180,7 +352,7 @@ export function buildBucketHeader() {
 }
 
 /**
- * Set up an IntersectionObserver for lazy bucket data loading.
+ * Set up IntersectionObservers for lazy bucket data loading and eviction.
  * @param {HTMLElement} container - Scroll container with bucket rows
  * @param {Map<string, Object>} bucketMap - timestamp → bucket metadata
  * @param {string[]} columns
@@ -191,44 +363,94 @@ export function setupBucketObserver(container, bucketMap, columns, pinned, pinne
   // Abort previous fetches
   if (fetchController) fetchController.abort();
   fetchController = new AbortController();
-  if (observer) observer.disconnect();
+  if (loadObserver) loadObserver.disconnect();
+  if (evictionObserver) evictionObserver.disconnect();
   loadedBuckets.clear();
+  bucketControllers.forEach((c) => c.abort());
+  bucketControllers.clear();
+  headCache.clear();
+
+  // Store container reference for eviction observer sentinel wiring
+  storedContainer = container;
 
   const { signal } = fetchController;
-  observer = new IntersectionObserver((entries) => {
+
+  // Load observer: triggers data fetch when placeholder enters viewport
+  loadObserver = new IntersectionObserver((entries) => {
     for (const entry of entries) {
       if (entry.isIntersecting) {
         const row = entry.target;
         const ts = row.id.replace('bucket-head-', '');
         if (!loadedBuckets.has(ts)) {
           loadedBuckets.add(ts);
-          observer.unobserve(row);
+          loadObserver.unobserve(row);
           const bucket = bucketMap.get(ts);
           if (bucket) {
-            loadBucket(ts, bucket, columns, pinned, pinnedOffsets, signal);
+            loadBucket(ts, bucket, columns, pinned, pinnedOffsets, signal, container);
           }
         }
       }
     }
   }, { rootMargin: '200px 0px', threshold: 0 });
 
+  // Eviction observer: evicts buckets that scroll far out of view
+  evictionObserver = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) {
+        const sentinel = entry.target;
+        const ts = sentinel.dataset.bucket;
+        if (ts && loadedBuckets.has(ts)) {
+          evictBucket(ts, container, columns);
+        }
+      }
+    }
+  }, { rootMargin: '800px 0px', threshold: 0 });
+
   const headRows = container.querySelectorAll('tbody tr.bucket-head');
   for (const row of headRows) {
-    observer.observe(row);
+    loadObserver.observe(row);
   }
 }
 
 /**
- * Clean up observer and abort in-flight bucket fetches.
+ * Clean up observers and abort in-flight bucket fetches.
  */
 export function teardownBucketLoader() {
+  // Abort all per-bucket controllers
+  bucketControllers.forEach((c) => c.abort());
+  bucketControllers.clear();
+
+  // Abort global controller
   if (fetchController) {
     fetchController.abort();
     fetchController = null;
   }
-  if (observer) {
-    observer.disconnect();
-    observer = null;
+
+  // Disconnect both observers
+  if (loadObserver) {
+    loadObserver.disconnect();
+    loadObserver = null;
   }
+  if (evictionObserver) {
+    evictionObserver.disconnect();
+    evictionObserver = null;
+  }
+
   loadedBuckets.clear();
+  headCache.clear();
+
+  // Clear stored container reference
+  storedContainer = null;
 }
+
+// Exported for testing only
+export {
+  evictBucket as _evictBucket,
+  enforceRowBudget as _enforceRowBudget,
+  countDataRows as _countDataRows,
+  replacePlaceholder as _replacePlaceholder,
+  cacheHead as _cacheHead,
+  headCache as _headCache,
+  loadedBuckets as _loadedBuckets,
+  MAX_DOM_ROWS as _MAX_DOM_ROWS,
+};

--- a/js/bucket-loader.js
+++ b/js/bucket-loader.js
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Bucket data loader — extracted from logs.js to stay within the
+ * max-lines lint limit. Handles per-bucket on-demand data fetching,
+ * IntersectionObserver setup, and placeholder replacement.
+ */
+
+import { DATABASE } from './config.js';
+import { state } from './state.js';
+import { query, isAbortError } from './api.js';
+import { getHostFilter, getTable, getTimeBucketStep } from './time.js';
+import { getFacetFilters } from './breakdowns/index.js';
+import { buildLogColumnsSql, LOG_COLUMN_ORDER } from './columns.js';
+import { loadSql } from './sql-loader.js';
+import {
+  buildLogRowHtml, buildLogTableHeaderHtml,
+} from './templates/logs-table.js';
+import { createLimiter } from './concurrency-limiter.js';
+
+const SECOND_MS = 1000;
+const MINUTE_MS = 60 * SECOND_MS;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * Parse a ClickHouse INTERVAL string to milliseconds.
+ * @param {string} interval
+ * @returns {number}
+ */
+function parseIntervalToMs(interval) {
+  const match = interval.match(/INTERVAL\s+(\d+)\s+(\w+)/i);
+  if (!match) return MINUTE_MS;
+  const amount = parseInt(match[1], 10);
+  const unit = match[2].toUpperCase().replace(/S$/, '');
+  const multipliers = {
+    SECOND: SECOND_MS,
+    MINUTE: MINUTE_MS,
+    HOUR: HOUR_MS,
+    DAY: DAY_MS,
+  };
+  return amount * (multipliers[unit] || MINUTE_MS);
+}
+
+/**
+ * Format a Date as 'YYYY-MM-DD HH:MM:SS.mmm' in UTC.
+ * @param {Date} date
+ * @returns {string}
+ */
+function formatTimestampUTC(date) {
+  const pad = (n) => String(n).padStart(2, '0');
+  const ms = String(date.getUTCMilliseconds()).padStart(3, '0');
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}.${ms}`;
+}
+
+// Concurrency limiter and abort state
+const bucketFetchLimiter = createLimiter(4);
+// eslint-disable-next-line prefer-const -- reassigned in setup/teardown
+let fetchController = null;
+// eslint-disable-next-line prefer-const -- reassigned in setup/teardown
+let observer = null;
+const loadedBuckets = new Set();
+
+/**
+ * Fetch log rows for a specific bucket time window.
+ * @param {string} bucketTs - Bucket start timestamp
+ * @param {number} limit - Max rows to fetch
+ * @param {number} offset - Row offset within the bucket
+ * @param {AbortSignal} signal - Abort signal
+ * @returns {Promise<Object[]>}
+ */
+async function fetchBucketRows(bucketTs, limit, offset, signal) {
+  const stepMs = parseIntervalToMs(getTimeBucketStep());
+  const start = new Date(`${bucketTs.replace(' ', 'T')}Z`);
+  const end = new Date(start.getTime() + stepMs);
+
+  const startStr = formatTimestampUTC(start);
+  const endStr = formatTimestampUTC(end);
+
+  const timeFilter = `timestamp >= toDateTime64('${startStr}', 3)`
+    + ` AND timestamp < toDateTime64('${endStr}', 3)`;
+
+  const sql = await loadSql('logs', {
+    database: DATABASE,
+    table: getTable(),
+    columns: buildLogColumnsSql(state.pinnedColumns),
+    timeFilter,
+    hostFilter: getHostFilter(),
+    facetFilters: getFacetFilters(),
+    additionalWhereClause: state.additionalWhereClause,
+    pageSize: String(limit),
+  });
+
+  const finalSql = offset > 0
+    ? `${sql.trimEnd().replace(/\n$/, '')} OFFSET ${offset}\n`
+    : sql;
+
+  const result = await query(finalSql, { signal });
+  return result.data;
+}
+
+/**
+ * Replace a placeholder <tr> with actual data rows.
+ */
+function replacePlaceholder(placeholder, rows, cols, pin, offsets) {
+  if (!placeholder || !placeholder.parentNode) return;
+
+  let html = '';
+  for (let i = 0; i < rows.length; i += 1) {
+    html += buildLogRowHtml({
+      row: rows[i], columns: cols, rowIdx: i, pinned: pin, pinnedOffsets: offsets,
+    });
+  }
+
+  if (html) {
+    placeholder.insertAdjacentHTML('afterend', html);
+  }
+  placeholder.remove();
+}
+
+/**
+ * Load data for a single bucket (head and optionally tail).
+ */
+async function loadBucket(ts, bucket, cols, pin, offsets, signal) {
+  const headEl = document.getElementById(`bucket-head-${ts}`);
+  if (headEl) {
+    try {
+      const fn = () => fetchBucketRows(ts, bucket.headCount, 0, signal);
+      const rows = await bucketFetchLimiter(fn);
+      if (!signal.aborted) {
+        replacePlaceholder(headEl, rows, cols, pin, offsets);
+      }
+    } catch (err) {
+      if (!isAbortError(err)) {
+        // eslint-disable-next-line no-console
+        console.error('Bucket head fetch error:', err);
+      }
+    }
+  }
+
+  const tailEl = document.getElementById(`bucket-tail-${ts}`);
+  if (tailEl && bucket.tailCount > 0) {
+    try {
+      const fn = () => fetchBucketRows(ts, bucket.tailCount, 500, signal);
+      const rows = await bucketFetchLimiter(fn);
+      if (!signal.aborted) {
+        replacePlaceholder(tailEl, rows, cols, pin, offsets);
+      }
+    } catch (err) {
+      if (!isAbortError(err)) {
+        // eslint-disable-next-line no-console
+        console.error('Bucket tail fetch error:', err);
+      }
+    }
+  }
+}
+
+/**
+ * Build the <thead> header HTML using real log column definitions.
+ * @returns {{ headerHtml: string, columns: string[], numColumns: number }}
+ */
+export function buildBucketHeader() {
+  const columns = LOG_COLUMN_ORDER;
+  const pinned = state.pinnedColumns;
+  const pinnedOffsets = {};
+  const headerHtml = buildLogTableHeaderHtml(columns, pinned, pinnedOffsets);
+  return {
+    headerHtml, columns, numColumns: columns.length, pinned, pinnedOffsets,
+  };
+}
+
+/**
+ * Set up an IntersectionObserver for lazy bucket data loading.
+ * @param {HTMLElement} container - Scroll container with bucket rows
+ * @param {Map<string, Object>} bucketMap - timestamp → bucket metadata
+ * @param {string[]} columns
+ * @param {string[]} pinned
+ * @param {Record<string, number>} pinnedOffsets
+ */
+export function setupBucketObserver(container, bucketMap, columns, pinned, pinnedOffsets) {
+  // Abort previous fetches
+  if (fetchController) fetchController.abort();
+  fetchController = new AbortController();
+  if (observer) observer.disconnect();
+  loadedBuckets.clear();
+
+  const { signal } = fetchController;
+  observer = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        const row = entry.target;
+        const ts = row.id.replace('bucket-head-', '');
+        if (!loadedBuckets.has(ts)) {
+          loadedBuckets.add(ts);
+          observer.unobserve(row);
+          const bucket = bucketMap.get(ts);
+          if (bucket) {
+            loadBucket(ts, bucket, columns, pinned, pinnedOffsets, signal);
+          }
+        }
+      }
+    }
+  }, { rootMargin: '200px 0px', threshold: 0 });
+
+  const headRows = container.querySelectorAll('tbody tr.bucket-head');
+  for (const row of headRows) {
+    observer.observe(row);
+  }
+}
+
+/**
+ * Clean up observer and abort in-flight bucket fetches.
+ */
+export function teardownBucketLoader() {
+  if (fetchController) {
+    fetchController.abort();
+    fetchController = null;
+  }
+  if (observer) {
+    observer.disconnect();
+    observer = null;
+  }
+  loadedBuckets.clear();
+}

--- a/js/bucket-loader.test.js
+++ b/js/bucket-loader.test.js
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import {
+  teardownBucketLoader,
+  _evictBucket,
+  _enforceRowBudget,
+  _countDataRows,
+  _replacePlaceholder,
+  _cacheHead,
+  _headCache,
+  _loadedBuckets,
+  _MAX_DOM_ROWS,
+} from './bucket-loader.js';
+import { LOG_COLUMN_ORDER } from './columns.js';
+
+const COLS = LOG_COLUMN_ORDER;
+const TS = '2026-01-15 00:00:00.000';
+const TS2 = '2026-01-15 00:01:00.000';
+const TS3 = '2026-01-15 00:02:00.000';
+
+/**
+ * Build a minimal fake row matching the column order.
+ */
+function fakeRow(idx) {
+  const row = {};
+  for (const col of COLS) {
+    if (col === 'timestamp') row[col] = `2026-01-15T00:00:0${idx}.000Z`;
+    else if (col === 'response.status') row[col] = 200;
+    else if (col === 'response.body_size') row[col] = 1024;
+    else if (col === 'request.method') row[col] = 'GET';
+    else row[col] = `val-${idx}`;
+  }
+  return row;
+}
+
+/**
+ * Create a container with a <tbody> containing a bucket-head placeholder.
+ */
+function createContainer(ts, numRows) {
+  const container = document.createElement('div');
+  const table = document.createElement('table');
+  const tbody = document.createElement('tbody');
+  const tr = document.createElement('tr');
+  tr.id = `bucket-head-${ts}`;
+  tr.className = 'bucket-row bucket-head';
+  tr.style.height = `${numRows * 28}px`;
+  tr.innerHTML = `<td colspan="${COLS.length}" class="bucket-placeholder">${numRows} rows</td>`;
+  tbody.appendChild(tr);
+  table.appendChild(tbody);
+  container.appendChild(table);
+  document.body.appendChild(container);
+  return container;
+}
+
+/**
+ * Manually insert sentinel + data rows to simulate a loaded bucket.
+ */
+function insertLoadedBucket(container, ts, rowCount) {
+  const tbody = container.querySelector('tbody');
+  // Sentinel
+  const sentinel = document.createElement('tr');
+  sentinel.className = 'bucket-sentinel';
+  sentinel.dataset.bucket = ts;
+  sentinel.style.cssText = 'height:0;padding:0;border:0;line-height:0;visibility:hidden;';
+  tbody.appendChild(sentinel);
+  // Data rows
+  for (let i = 0; i < rowCount; i += 1) {
+    const tr = document.createElement('tr');
+    tr.dataset.bucket = ts;
+    tr.dataset.rowIdx = String(i);
+    tr.innerHTML = `<td>row ${i}</td>`;
+    tbody.appendChild(tr);
+  }
+  _loadedBuckets.add(ts);
+}
+
+describe('bucket-loader virtualization', () => {
+  let container;
+
+  afterEach(() => {
+    teardownBucketLoader();
+    if (container && container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+    container = null;
+  });
+
+  describe('countDataRows', () => {
+    it('counts rows with data-bucket attribute', () => {
+      container = createContainer(TS, 10);
+      insertLoadedBucket(container, TS, 5);
+      const count = _countDataRows(container);
+      // 5 data rows + 1 sentinel = 6 tr[data-bucket]
+      assert.strictEqual(count, 6);
+    });
+
+    it('returns 0 for empty container', () => {
+      container = createContainer(TS, 0);
+      assert.strictEqual(_countDataRows(container), 0);
+    });
+  });
+
+  describe('replacePlaceholder', () => {
+    it('inserts sentinel before data rows', () => {
+      container = createContainer(TS, 3);
+      const placeholder = document.getElementById(`bucket-head-${TS}`);
+      const rows = [fakeRow(0), fakeRow(1), fakeRow(2)];
+
+      _replacePlaceholder(placeholder, rows, COLS, [], {}, TS);
+
+      const sentinel = container.querySelector('tr.bucket-sentinel');
+      assert.ok(sentinel, 'sentinel should exist');
+      assert.strictEqual(sentinel.dataset.bucket, TS);
+    });
+
+    it('tags each data row with data-bucket', () => {
+      container = createContainer(TS, 2);
+      const placeholder = document.getElementById(`bucket-head-${TS}`);
+      const rows = [fakeRow(0), fakeRow(1)];
+
+      _replacePlaceholder(placeholder, rows, COLS, [], {}, TS);
+
+      const dataRows = container.querySelectorAll('tr[data-bucket]');
+      // 1 sentinel + 2 data rows
+      assert.strictEqual(dataRows.length, 3);
+    });
+
+    it('removes the placeholder element', () => {
+      container = createContainer(TS, 1);
+      const placeholder = document.getElementById(`bucket-head-${TS}`);
+      const rows = [fakeRow(0)];
+
+      _replacePlaceholder(placeholder, rows, COLS, [], {}, TS);
+
+      assert.isNull(document.getElementById(`bucket-head-${TS}`));
+    });
+
+    it('handles null placeholder gracefully', () => {
+      container = createContainer(TS, 0);
+      // Should not throw
+      _replacePlaceholder(null, [fakeRow(0)], COLS, [], {}, TS);
+    });
+
+    it('handles empty rows', () => {
+      container = createContainer(TS, 0);
+      const placeholder = document.getElementById(`bucket-head-${TS}`);
+
+      _replacePlaceholder(placeholder, [], COLS, [], {}, TS);
+
+      // Sentinel should still be inserted
+      const sentinel = container.querySelector('tr.bucket-sentinel');
+      assert.ok(sentinel, 'sentinel should exist even with no data rows');
+    });
+  });
+
+  describe('evictBucket', () => {
+    it('replaces sentinel + data rows with a placeholder', () => {
+      container = createContainer(TS, 10);
+      // Remove the initial placeholder first
+      const initial = document.getElementById(`bucket-head-${TS}`);
+      if (initial) initial.remove();
+
+      insertLoadedBucket(container, TS, 5);
+
+      _evictBucket(TS, container, COLS);
+
+      // Sentinel should be gone
+      assert.isNull(container.querySelector('tr.bucket-sentinel'));
+      // Data rows should be gone
+      assert.strictEqual(container.querySelectorAll('tr[data-bucket]').length, 0);
+      // New placeholder should exist
+      const placeholder = document.getElementById(`bucket-head-${TS}`);
+      assert.ok(placeholder, 'placeholder should be recreated');
+      assert.include(placeholder.className, 'bucket-head');
+      assert.include(placeholder.textContent, 'evicted');
+    });
+
+    it('removes ts from loadedBuckets', () => {
+      container = createContainer(TS, 5);
+      const initial = document.getElementById(`bucket-head-${TS}`);
+      if (initial) initial.remove();
+
+      insertLoadedBucket(container, TS, 3);
+      assert.isTrue(_loadedBuckets.has(TS));
+
+      _evictBucket(TS, container, COLS);
+      assert.isFalse(_loadedBuckets.has(TS));
+    });
+
+    it('does nothing if sentinel not found', () => {
+      container = createContainer(TS, 5);
+      // No sentinel inserted, just placeholder
+      _evictBucket(TS, container, COLS);
+      // Should not crash, placeholder should still be there
+      assert.ok(document.getElementById(`bucket-head-${TS}`));
+    });
+
+    it('placeholder height matches evicted row count', () => {
+      container = createContainer(TS, 10);
+      const initial = document.getElementById(`bucket-head-${TS}`);
+      if (initial) initial.remove();
+
+      insertLoadedBucket(container, TS, 7);
+
+      _evictBucket(TS, container, COLS);
+
+      const placeholder = document.getElementById(`bucket-head-${TS}`);
+      assert.strictEqual(placeholder.style.height, `${7 * 28}px`);
+    });
+  });
+
+  describe('enforceRowBudget', () => {
+    it('does not evict when under budget', () => {
+      container = createContainer(TS, 10);
+      const initial = document.getElementById(`bucket-head-${TS}`);
+      if (initial) initial.remove();
+
+      insertLoadedBucket(container, TS, 5);
+
+      _enforceRowBudget(container, COLS);
+
+      // Should still be loaded
+      assert.isTrue(_loadedBuckets.has(TS));
+    });
+
+    it('evicts farthest bucket when over budget', () => {
+      container = document.createElement('div');
+      const table = document.createElement('table');
+      const tbody = document.createElement('tbody');
+      table.appendChild(tbody);
+      container.appendChild(table);
+      document.body.appendChild(container);
+
+      // Insert three loaded buckets, each with MAX_DOM_ROWS/2 rows
+      const halfBudget = Math.ceil(_MAX_DOM_ROWS / 2);
+      insertLoadedBucket(container, TS, halfBudget);
+      insertLoadedBucket(container, TS2, halfBudget);
+      insertLoadedBucket(container, TS3, halfBudget);
+
+      _enforceRowBudget(container, COLS);
+
+      // At least one bucket should have been evicted
+      const remaining = _loadedBuckets.size;
+      assert.isBelow(remaining, 3, 'at least one bucket should be evicted');
+    });
+  });
+
+  describe('headCache (LRU)', () => {
+    afterEach(() => {
+      _headCache.clear();
+    });
+
+    it('stores and retrieves rows', () => {
+      const rows = [fakeRow(0)];
+      _cacheHead(TS, rows);
+      assert.strictEqual(_headCache.get(TS), rows);
+    });
+
+    it('evicts oldest entry when over capacity', () => {
+      // Fill cache to capacity (20) + 1
+      for (let i = 0; i < 21; i += 1) {
+        const ts = `2026-01-15 00:${String(i).padStart(2, '0')}:00.000`;
+        _cacheHead(ts, [fakeRow(i)]);
+      }
+      assert.strictEqual(_headCache.size, 20);
+      // First entry should be evicted
+      assert.isFalse(_headCache.has('2026-01-15 00:00:00.000'));
+      // Last entry should exist
+      assert.isTrue(_headCache.has('2026-01-15 00:20:00.000'));
+    });
+
+    it('re-accessing entry moves it to end (LRU refresh)', () => {
+      _cacheHead(TS, [fakeRow(0)]);
+      _cacheHead(TS2, [fakeRow(1)]);
+      // Re-cache TS to move it to end
+      _cacheHead(TS, [fakeRow(0)]);
+
+      const keys = Array.from(_headCache.keys());
+      assert.strictEqual(keys[keys.length - 1], TS, 'TS should be at end after re-access');
+    });
+  });
+
+  describe('teardownBucketLoader', () => {
+    it('clears loadedBuckets', () => {
+      _loadedBuckets.add(TS);
+      _loadedBuckets.add(TS2);
+      teardownBucketLoader();
+      assert.strictEqual(_loadedBuckets.size, 0);
+    });
+
+    it('clears headCache', () => {
+      _cacheHead(TS, [fakeRow(0)]);
+      teardownBucketLoader();
+      assert.strictEqual(_headCache.size, 0);
+    });
+  });
+
+  describe('MAX_DOM_ROWS constant', () => {
+    it('is set to 2000', () => {
+      assert.strictEqual(_MAX_DOM_ROWS, 2000);
+    });
+  });
+});

--- a/js/bucket-table.test.js
+++ b/js/bucket-table.test.js
@@ -11,6 +11,7 @@
  */
 import { assert } from 'chai';
 import { computeBucketHeights, renderBucketTable } from './logs.js';
+import { LOG_COLUMN_ORDER } from './columns.js';
 
 function makeChartData(count, baseCnt = 10) {
   return Array.from({ length: count }, (_, i) => ({
@@ -331,5 +332,36 @@ describe('renderBucketTable', () => {
     const headH = parseInt(headRow.style.height, 10);
     const tailH = parseInt(tailRow.style.height, 10);
     assert.strictEqual(headH + tailH, 800 * 28);
+  });
+
+  it('renders actual column headers instead of generic "Log Buckets"', () => {
+    const data = makeChartData(2);
+    renderBucketTable(container, data);
+    const thElements = container.querySelectorAll('thead th');
+    assert.strictEqual(thElements.length, LOG_COLUMN_ORDER.length);
+    // Should not contain old generic header
+    const headerText = container.querySelector('thead').textContent;
+    assert.notInclude(headerText, 'Log Buckets');
+  });
+
+  it('placeholder colspan matches column count', () => {
+    const data = [
+      {
+        t: '2026-01-15 00:00:00.000', cnt_ok: '10', cnt_4xx: '0', cnt_5xx: '0',
+      },
+    ];
+    renderBucketTable(container, data);
+    const td = container.querySelector('.bucket-placeholder');
+    assert.strictEqual(td.getAttribute('colspan'), String(LOG_COLUMN_ORDER.length));
+  });
+
+  it('column headers have data-action for pin toggling', () => {
+    const data = makeChartData(1);
+    renderBucketTable(container, data);
+    const thElements = container.querySelectorAll('thead th');
+    for (const th of thElements) {
+      assert.strictEqual(th.dataset.action, 'toggle-pinned-column');
+      assert.ok(th.dataset.col, 'th should have data-col attribute');
+    }
   });
 });

--- a/js/bucket-table.test.js
+++ b/js/bucket-table.test.js
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { computeBucketHeights, renderBucketTable } from './logs.js';
+
+function makeChartData(count, baseCnt = 10) {
+  return Array.from({ length: count }, (_, i) => ({
+    t: `2026-01-15 ${String(Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00.000`,
+    cnt_ok: String(baseCnt),
+    cnt_4xx: '1',
+    cnt_5xx: '0',
+  }));
+}
+
+describe('computeBucketHeights', () => {
+  it('returns empty for null/empty chart data', () => {
+    assert.deepEqual(computeBucketHeights(null), { buckets: [], totalHeight: 0 });
+    assert.deepEqual(computeBucketHeights([]), { buckets: [], totalHeight: 0 });
+  });
+
+  it('computes height proportional to row count', () => {
+    const data = [
+      {
+        t: '2026-01-15 00:00:00.000', cnt_ok: '10', cnt_4xx: '2', cnt_5xx: '1',
+      },
+      {
+        t: '2026-01-15 00:01:00.000', cnt_ok: '5', cnt_4xx: '0', cnt_5xx: '0',
+      },
+    ];
+    const { buckets } = computeBucketHeights(data);
+    assert.strictEqual(buckets.length, 2);
+    assert.strictEqual(buckets[0].count, 13);
+    assert.strictEqual(buckets[0].height, 13 * 28);
+    assert.strictEqual(buckets[1].count, 5);
+    assert.strictEqual(buckets[1].height, 5 * 28);
+  });
+
+  it('enforces minimum height of 28px for empty buckets', () => {
+    const data = [
+      {
+        t: '2026-01-15 00:00:00.000', cnt_ok: '0', cnt_4xx: '0', cnt_5xx: '0',
+      },
+    ];
+    const { buckets } = computeBucketHeights(data);
+    assert.strictEqual(buckets[0].count, 0);
+    assert.strictEqual(buckets[0].height, 28); // min 1 * ROW_HEIGHT
+  });
+
+  it('scales heights when total exceeds 10M pixels', () => {
+    // Create buckets that would exceed 10M: 100 buckets * 5000 rows * 28px = 14M
+    const data = Array.from({ length: 100 }, (_, i) => ({
+      t: `2026-01-15 ${String(Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00.000`,
+      cnt_ok: '5000',
+      cnt_4xx: '0',
+      cnt_5xx: '0',
+    }));
+    const { buckets, totalHeight } = computeBucketHeights(data);
+    assert.ok(totalHeight <= 10_000_000 + 100 * 28, 'total height should be capped near 10M');
+    // All buckets should still have at least ROW_HEIGHT
+    for (const b of buckets) {
+      assert.ok(b.height >= 28, 'each bucket should have at least 28px height');
+    }
+  });
+});
+
+describe('renderBucketTable', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (container.parentNode) container.parentNode.removeChild(container);
+  });
+
+  it('renders empty message for null chart data', () => {
+    renderBucketTable(container, null);
+    assert.include(container.textContent, 'No chart data');
+  });
+
+  it('renders correct number of bucket rows', () => {
+    const data = makeChartData(5);
+    renderBucketTable(container, data);
+    const rows = container.querySelectorAll('tbody tr.bucket-row');
+    assert.strictEqual(rows.length, 5);
+  });
+
+  it('renders rows in newest-first order', () => {
+    const data = [
+      {
+        t: '2026-01-15 00:00:00.000', cnt_ok: '10', cnt_4xx: '0', cnt_5xx: '0',
+      },
+      {
+        t: '2026-01-15 00:01:00.000', cnt_ok: '20', cnt_4xx: '0', cnt_5xx: '0',
+      },
+      {
+        t: '2026-01-15 00:02:00.000', cnt_ok: '30', cnt_4xx: '0', cnt_5xx: '0',
+      },
+    ];
+    renderBucketTable(container, data);
+    const rows = container.querySelectorAll('tbody tr.bucket-row');
+    // First row should be the newest (last in chart data)
+    assert.strictEqual(rows[0].id, 'bucket-2026-01-15 00:02:00.000');
+    assert.strictEqual(rows[1].id, 'bucket-2026-01-15 00:01:00.000');
+    assert.strictEqual(rows[2].id, 'bucket-2026-01-15 00:00:00.000');
+  });
+
+  it('each row has correct id attribute', () => {
+    const data = [
+      {
+        t: '2026-01-15 12:30:00.000', cnt_ok: '5', cnt_4xx: '0', cnt_5xx: '0',
+      },
+    ];
+    renderBucketTable(container, data);
+    const row = container.querySelector('tbody tr.bucket-row');
+    assert.strictEqual(row.id, 'bucket-2026-01-15 12:30:00.000');
+  });
+
+  it('each row has proportional height', () => {
+    const data = [
+      {
+        t: '2026-01-15 00:00:00.000', cnt_ok: '10', cnt_4xx: '0', cnt_5xx: '0',
+      },
+      {
+        t: '2026-01-15 00:01:00.000', cnt_ok: '20', cnt_4xx: '0', cnt_5xx: '0',
+      },
+    ];
+    renderBucketTable(container, data);
+    const rows = container.querySelectorAll('tbody tr.bucket-row');
+    // Newest first: row 0 = 20 rows, row 1 = 10 rows
+    assert.strictEqual(rows[0].style.height, `${20 * 28}px`);
+    assert.strictEqual(rows[1].style.height, `${10 * 28}px`);
+  });
+
+  it('displays row count in placeholder text', () => {
+    const data = [
+      {
+        t: '2026-01-15 00:00:00.000', cnt_ok: '100', cnt_4xx: '5', cnt_5xx: '2',
+      },
+    ];
+    renderBucketTable(container, data);
+    const td = container.querySelector('.bucket-placeholder');
+    assert.include(td.textContent, '107');
+    assert.include(td.textContent, 'rows');
+  });
+
+  it('uses singular "row" for count of 1', () => {
+    const data = [
+      {
+        t: '2026-01-15 00:00:00.000', cnt_ok: '1', cnt_4xx: '0', cnt_5xx: '0',
+      },
+    ];
+    renderBucketTable(container, data);
+    const td = container.querySelector('.bucket-placeholder');
+    assert.strictEqual(td.textContent, '1 row');
+  });
+
+  it('renders table with sticky header', () => {
+    const data = makeChartData(3);
+    renderBucketTable(container, data);
+    const thead = container.querySelector('thead');
+    assert.ok(thead, 'table should have thead');
+    const th = thead.querySelector('th');
+    assert.ok(th, 'thead should have th');
+  });
+
+  it('renders table with logs-table class', () => {
+    const data = makeChartData(3);
+    renderBucketTable(container, data);
+    const table = container.querySelector('table.logs-table');
+    assert.ok(table, 'table should have logs-table class');
+  });
+});

--- a/js/chart-draw.js
+++ b/js/chart-draw.js
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Canvas drawing helpers for the chart module.
+ * Extracted from chart.js to stay within the max-lines lint limit.
+ */
+
+import { formatNumber } from './format.js';
+import { addAnomalyBounds, parseUTC } from './chart-state.js';
+
+/**
+ * Draw Y axis with grid lines and labels
+ */
+export function drawYAxis(ctx, chartDimensions, cssVar, minValue, maxValue) {
+  const {
+    width, height, padding, chartHeight, labelInset,
+  } = chartDimensions;
+  ctx.fillStyle = cssVar('--text-secondary');
+  ctx.font = '11px -apple-system, sans-serif';
+  ctx.textAlign = 'left';
+
+  for (let i = 1; i <= 4; i += 1) {
+    const val = minValue + (maxValue - minValue) * (i / 4);
+    const y = height - padding.bottom - ((chartHeight * i) / 4);
+
+    ctx.strokeStyle = cssVar('--grid-line');
+    ctx.beginPath();
+    ctx.moveTo(padding.left, y);
+    ctx.lineTo(width - padding.right, y);
+    ctx.stroke();
+
+    ctx.fillStyle = cssVar('--text-secondary');
+    ctx.fillText(formatNumber(val), padding.left + labelInset, y - 4);
+  }
+}
+
+/**
+ * Draw X axis labels
+ */
+// eslint-disable-next-line max-len
+export function drawXAxisLabels(ctx, data, chartDimensions, intendedStartTime, intendedTimeRange, cssVar) {
+  const {
+    width, height, padding, chartWidth, labelInset,
+  } = chartDimensions;
+  ctx.fillStyle = cssVar('--text-secondary');
+  const isMobile = width < 500;
+  const tickIndices = isMobile
+    ? [0, Math.floor((data.length - 1) / 2), data.length - 1]
+    : Array.from({ length: 6 }, (_, idx) => Math.round((idx * (data.length - 1)) / 5));
+
+  const validIndices = tickIndices.filter((i) => i < data.length);
+  for (const i of validIndices) {
+    const time = parseUTC(data[i].t);
+    const elapsed = time.getTime() - intendedStartTime;
+    const x = padding.left + (elapsed / intendedTimeRange) * chartWidth;
+    const timeStr = time.toLocaleTimeString('en-US', {
+      hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'UTC',
+    });
+    const showDate = intendedTimeRange > 24 * 60 * 60 * 1000;
+    const label = showDate
+      ? `${time.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })}, ${timeStr}`
+      : timeStr;
+    const yPos = height - padding.bottom + 20;
+
+    if (i === 0) {
+      ctx.textAlign = 'left';
+      ctx.fillText(label, padding.left + labelInset, yPos);
+    } else if (i === data.length - 1) {
+      ctx.textAlign = 'right';
+      ctx.fillText(`${label} (UTC)`, width - padding.right - labelInset, yPos);
+    } else {
+      ctx.textAlign = 'center';
+      ctx.fillText(label, x, yPos);
+    }
+  }
+}
+
+/**
+ * Draw anomaly highlight for a detected step
+ */
+export function drawAnomalyHighlight(ctx, step, data, chartDimensions, getX, getY, stacks) {
+  const { height, padding, chartWidth } = chartDimensions;
+  const { stackedServer, stackedClient, stackedOk } = stacks;
+
+  const startX = getX(step.startIndex);
+  const endX = getX(step.endIndex);
+  const minBandWidth = Math.max((chartWidth / data.length) * 2, 16);
+  const bandPadding = minBandWidth / 2;
+  const bandLeft = startX - bandPadding;
+  const bandRight = step.startIndex === step.endIndex ? startX + bandPadding : endX + bandPadding;
+
+  const startTime = parseUTC(data[step.startIndex].t);
+  const endTime = parseUTC(data[step.endIndex].t);
+  addAnomalyBounds({
+    left: bandLeft, right: bandRight, startTime, endTime, rank: step.rank,
+  });
+
+  const opacityMultiplier = step.rank === 1 ? 1 : 0.7;
+  const categoryColors = { red: [240, 68, 56], yellow: [247, 144, 9], green: [18, 183, 106] };
+  const [cr, cg, cb] = categoryColors[step.category] || categoryColors.green;
+
+  const seriesBounds = {
+    red: [(i) => getY(stackedServer[i]), () => getY(0)],
+    yellow: [(i) => getY(stackedClient[i]), (i) => getY(stackedServer[i])],
+    green: [(i) => getY(stackedOk[i]), (i) => getY(stackedClient[i])],
+  };
+  const [getSeriesTop, getSeriesBottom] = seriesBounds[step.category] || seriesBounds.green;
+
+  const points = [];
+  for (let i = step.startIndex; i <= step.endIndex; i += 1) {
+    points.push({ x: getX(i), y: getSeriesTop(i) });
+  }
+  for (let i = step.endIndex; i >= step.startIndex; i -= 1) {
+    points.push({ x: getX(i), y: getSeriesBottom(i) });
+  }
+
+  ctx.fillStyle = `rgba(${cr}, ${cg}, ${cb}, ${0.35 * opacityMultiplier})`;
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let i = 1; i < points.length; i += 1) ctx.lineTo(points[i].x, points[i].y);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.strokeStyle = `rgba(${cr}, ${cg}, ${cb}, 0.8)`;
+  ctx.lineWidth = 1.5;
+  ctx.setLineDash([4, 4]);
+  [bandLeft, bandRight].forEach((bx) => {
+    ctx.beginPath();
+    ctx.moveTo(bx, padding.top);
+    ctx.lineTo(bx, height - padding.bottom);
+    ctx.stroke();
+  });
+  ctx.setLineDash([]);
+
+  const mag = step.magnitude;
+  const magnitudeLabel = mag >= 1
+    ? `${mag >= 10 ? Math.round(mag) : mag.toFixed(1).replace(/\.0$/, '')}x`
+    : `${Math.round(mag * 100)}%`;
+  ctx.font = '500 11px -apple-system, sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillStyle = `rgb(${cr}, ${cg}, ${cb})`;
+  const arrow = step.type === 'spike' ? '\u25B2' : '\u25BC';
+  ctx.fillText(`${step.rank} ${arrow} ${magnitudeLabel}`, (bandLeft + bandRight) / 2, padding.top + 12);
+}
+
+/**
+ * Draw a stacked area with line on top
+ */
+export function drawStackedArea(ctx, data, getX, getY, topStack, bottomStack, colors) {
+  if (!topStack.some((v, i) => v > bottomStack[i])) return;
+
+  ctx.beginPath();
+  ctx.moveTo(getX(0), getY(bottomStack[0]));
+  for (let i = 0; i < data.length; i += 1) ctx.lineTo(getX(i), getY(topStack[i]));
+  for (let i = data.length - 1; i >= 0; i -= 1) ctx.lineTo(getX(i), getY(bottomStack[i]));
+  ctx.closePath();
+  ctx.fillStyle = colors.fill;
+  ctx.fill();
+
+  ctx.beginPath();
+  ctx.moveTo(getX(0), getY(topStack[0]));
+  for (let i = 1; i < data.length; i += 1) ctx.lineTo(getX(i), getY(topStack[i]));
+  ctx.strokeStyle = colors.line;
+  ctx.lineWidth = 2;
+  ctx.stroke();
+}

--- a/js/chart.js
+++ b/js/chart.js
@@ -92,10 +92,6 @@ let isDragging = false;
 let dragStartX = null;
 let justCompletedDrag = false;
 
-// Scrubber range state (for table viewport sync)
-let scrubberRangeStart = null; // eslint-disable-line prefer-const
-let scrubberRangeEnd = null; // eslint-disable-line prefer-const
-
 // Callback for chart→scroll sync (set by logs.js)
 let onChartHoverTimestamp = null;
 let onChartClickTimestamp = null;
@@ -141,45 +137,7 @@ export function setScrubberPosition(timestamp) {
   scrubberLine.style.left = `${x}px`;
   scrubberLine.style.top = `${padding.top}px`;
   scrubberLine.style.height = `${height - padding.top - padding.bottom}px`;
-  scrubberLine.style.width = '';
-  scrubberLine.classList.remove('range-mode');
   scrubberLine.classList.add('visible');
-}
-
-/**
- * Show the scrubber as a shaded band between two timestamps (table viewport sync)
- * @param {Date} startTime - Start of visible range
- * @param {Date} endTime - End of visible range
- */
-export function setScrubberRange(startTime, endTime) {
-  if (!scrubberLine) return;
-  const startX = getXAtTime(startTime);
-  const endX = getXAtTime(endTime);
-  const chartLayout = getChartLayout();
-  if (!chartLayout) return;
-
-  const { padding, height } = chartLayout;
-  const { top } = padding;
-  const bandHeight = height - padding.top - padding.bottom;
-
-  scrubberLine.style.left = `${Math.min(startX, endX)}px`;
-  scrubberLine.style.width = `${Math.max(2, Math.abs(endX - startX))}px`;
-  scrubberLine.style.top = `${top}px`;
-  scrubberLine.style.height = `${bandHeight}px`;
-  scrubberLine.classList.add('visible', 'range-mode');
-
-  // Store range so it can be restored after hover
-  scrubberRangeStart = startTime;
-  scrubberRangeEnd = endTime;
-}
-
-/**
- * Restore the scrubber range band if one was set (called on mouseleave)
- */
-function restoreScrubberRange() {
-  if (scrubberRangeStart && scrubberRangeEnd) {
-    setScrubberRange(scrubberRangeStart, scrubberRangeEnd);
-  }
 }
 
 /**
@@ -659,9 +617,6 @@ export function setupChartNavigation(callback) {
 
   // Show/hide scrubber on container hover
   container.addEventListener('mouseenter', () => {
-    // Switch from range band to single-line hover mode
-    scrubberLine.classList.remove('range-mode');
-    scrubberLine.style.width = '';
     scrubberLine.classList.add('visible');
     scrubberStatusBar.classList.add('visible');
   });
@@ -670,12 +625,7 @@ export function setupChartNavigation(callback) {
     scrubberStatusBar.classList.remove('visible');
     hideReleaseTooltip();
     canvas.style.cursor = '';
-    // Restore range band if logs view is active
-    if (state.showLogs && scrubberRangeStart) {
-      restoreScrubberRange();
-    } else {
-      scrubberLine.classList.remove('visible');
-    }
+    scrubberLine.classList.remove('visible');
   });
 
   container.addEventListener('mousemove', (e) => {

--- a/js/chart.js
+++ b/js/chart.js
@@ -92,6 +92,10 @@ let isDragging = false;
 let dragStartX = null;
 let justCompletedDrag = false;
 
+// Scrubber range state (for table viewport sync)
+let scrubberRangeStart = null; // eslint-disable-line prefer-const
+let scrubberRangeEnd = null; // eslint-disable-line prefer-const
+
 // Callback for chart→scroll sync (set by logs.js)
 let onChartHoverTimestamp = null;
 
@@ -117,7 +121,45 @@ export function setScrubberPosition(timestamp) {
   scrubberLine.style.left = `${x}px`;
   scrubberLine.style.top = `${padding.top}px`;
   scrubberLine.style.height = `${height - padding.top - padding.bottom}px`;
+  scrubberLine.style.width = '';
+  scrubberLine.classList.remove('range-mode');
   scrubberLine.classList.add('visible');
+}
+
+/**
+ * Show the scrubber as a shaded band between two timestamps (table viewport sync)
+ * @param {Date} startTime - Start of visible range
+ * @param {Date} endTime - End of visible range
+ */
+export function setScrubberRange(startTime, endTime) {
+  if (!scrubberLine) return;
+  const startX = getXAtTime(startTime);
+  const endX = getXAtTime(endTime);
+  const chartLayout = getChartLayout();
+  if (!chartLayout) return;
+
+  const { padding, height } = chartLayout;
+  const { top } = padding;
+  const bandHeight = height - padding.top - padding.bottom;
+
+  scrubberLine.style.left = `${Math.min(startX, endX)}px`;
+  scrubberLine.style.width = `${Math.max(2, Math.abs(endX - startX))}px`;
+  scrubberLine.style.top = `${top}px`;
+  scrubberLine.style.height = `${bandHeight}px`;
+  scrubberLine.classList.add('visible', 'range-mode');
+
+  // Store range so it can be restored after hover
+  scrubberRangeStart = startTime;
+  scrubberRangeEnd = endTime;
+}
+
+/**
+ * Restore the scrubber range band if one was set (called on mouseleave)
+ */
+function restoreScrubberRange() {
+  if (scrubberRangeStart && scrubberRangeEnd) {
+    setScrubberRange(scrubberRangeStart, scrubberRangeEnd);
+  }
 }
 
 /**
@@ -597,15 +639,23 @@ export function setupChartNavigation(callback) {
 
   // Show/hide scrubber on container hover
   container.addEventListener('mouseenter', () => {
+    // Switch from range band to single-line hover mode
+    scrubberLine.classList.remove('range-mode');
+    scrubberLine.style.width = '';
     scrubberLine.classList.add('visible');
     scrubberStatusBar.classList.add('visible');
   });
 
   container.addEventListener('mouseleave', () => {
-    scrubberLine.classList.remove('visible');
     scrubberStatusBar.classList.remove('visible');
     hideReleaseTooltip();
     canvas.style.cursor = '';
+    // Restore range band if logs view is active
+    if (state.showLogs && scrubberRangeStart) {
+      restoreScrubberRange();
+    } else {
+      scrubberLine.classList.remove('visible');
+    }
   });
 
   container.addEventListener('mousemove', (e) => {

--- a/js/chart.js
+++ b/js/chart.js
@@ -43,6 +43,9 @@ import {
 } from './releases.js';
 import { investigateTimeRange, clearSelectionHighlights } from './anomaly-investigation.js';
 import {
+  drawYAxis, drawXAxisLabels, drawAnomalyHighlight, drawStackedArea,
+} from './chart-draw.js';
+import {
   setNavigationCallback,
   getNavigationCallback,
   navigateTime,
@@ -51,7 +54,6 @@ import {
   setLastChartData,
   getLastChartData,
   getDataAtTime,
-  addAnomalyBounds,
   resetAnomalyBounds,
   setDetectedSteps,
   getDetectedSteps,
@@ -130,162 +132,6 @@ function initChartCanvas() {
   canvas.height = rect.height * dpr;
   ctx.scale(dpr, dpr);
   return { canvas, ctx, rect };
-}
-
-/**
- * Draw Y axis with grid lines and labels
- */
-function drawYAxis(ctx, chartDimensions, cssVar, minValue, maxValue) {
-  const {
-    width, height, padding, chartHeight, labelInset,
-  } = chartDimensions;
-  ctx.fillStyle = cssVar('--text-secondary');
-  ctx.font = '11px -apple-system, sans-serif';
-  ctx.textAlign = 'left';
-
-  for (let i = 1; i <= 4; i += 1) {
-    const val = minValue + (maxValue - minValue) * (i / 4);
-    const y = height - padding.bottom - ((chartHeight * i) / 4);
-
-    ctx.strokeStyle = cssVar('--grid-line');
-    ctx.beginPath();
-    ctx.moveTo(padding.left, y);
-    ctx.lineTo(width - padding.right, y);
-    ctx.stroke();
-
-    ctx.fillStyle = cssVar('--text-secondary');
-    ctx.fillText(formatNumber(val), padding.left + labelInset, y - 4);
-  }
-}
-
-/**
- * Draw X axis labels
- */
-function drawXAxisLabels(ctx, data, chartDimensions, intendedStartTime, intendedTimeRange, cssVar) {
-  const {
-    width, height, padding, chartWidth, labelInset,
-  } = chartDimensions;
-  ctx.fillStyle = cssVar('--text-secondary');
-  const isMobile = width < 500;
-  const tickIndices = isMobile
-    ? [0, Math.floor((data.length - 1) / 2), data.length - 1]
-    : Array.from({ length: 6 }, (_, idx) => Math.round((idx * (data.length - 1)) / 5));
-
-  const validIndices = tickIndices.filter((i) => i < data.length);
-  for (const i of validIndices) {
-    const time = parseUTC(data[i].t);
-    const elapsed = time.getTime() - intendedStartTime;
-    const x = padding.left + (elapsed / intendedTimeRange) * chartWidth;
-    const timeStr = time.toLocaleTimeString('en-US', {
-      hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'UTC',
-    });
-    const showDate = intendedTimeRange > 24 * 60 * 60 * 1000;
-    const label = showDate
-      ? `${time.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })}, ${timeStr}`
-      : timeStr;
-    const yPos = height - padding.bottom + 20;
-
-    if (i === 0) {
-      ctx.textAlign = 'left';
-      ctx.fillText(label, padding.left + labelInset, yPos);
-    } else if (i === data.length - 1) {
-      ctx.textAlign = 'right';
-      ctx.fillText(`${label} (UTC)`, width - padding.right - labelInset, yPos);
-    } else {
-      ctx.textAlign = 'center';
-      ctx.fillText(label, x, yPos);
-    }
-  }
-}
-
-/**
- * Draw anomaly highlight for a detected step
- */
-function drawAnomalyHighlight(ctx, step, data, chartDimensions, getX, getY, stacks) {
-  const { height, padding, chartWidth } = chartDimensions;
-  const { stackedServer, stackedClient, stackedOk } = stacks;
-
-  const startX = getX(step.startIndex);
-  const endX = getX(step.endIndex);
-  const minBandWidth = Math.max((chartWidth / data.length) * 2, 16);
-  const bandPadding = minBandWidth / 2;
-  const bandLeft = startX - bandPadding;
-  const bandRight = step.startIndex === step.endIndex ? startX + bandPadding : endX + bandPadding;
-
-  const startTime = parseUTC(data[step.startIndex].t);
-  const endTime = parseUTC(data[step.endIndex].t);
-  addAnomalyBounds({
-    left: bandLeft, right: bandRight, startTime, endTime, rank: step.rank,
-  });
-
-  const opacityMultiplier = step.rank === 1 ? 1 : 0.7;
-  const categoryColors = { red: [240, 68, 56], yellow: [247, 144, 9], green: [18, 183, 106] };
-  const [cr, cg, cb] = categoryColors[step.category] || categoryColors.green;
-
-  const seriesBounds = {
-    red: [(i) => getY(stackedServer[i]), () => getY(0)],
-    yellow: [(i) => getY(stackedClient[i]), (i) => getY(stackedServer[i])],
-    green: [(i) => getY(stackedOk[i]), (i) => getY(stackedClient[i])],
-  };
-  const [getSeriesTop, getSeriesBottom] = seriesBounds[step.category] || seriesBounds.green;
-
-  const points = [];
-  for (let i = step.startIndex; i <= step.endIndex; i += 1) {
-    points.push({ x: getX(i), y: getSeriesTop(i) });
-  }
-  for (let i = step.endIndex; i >= step.startIndex; i -= 1) {
-    points.push({ x: getX(i), y: getSeriesBottom(i) });
-  }
-
-  ctx.fillStyle = `rgba(${cr}, ${cg}, ${cb}, ${0.35 * opacityMultiplier})`;
-  ctx.beginPath();
-  ctx.moveTo(points[0].x, points[0].y);
-  for (let i = 1; i < points.length; i += 1) ctx.lineTo(points[i].x, points[i].y);
-  ctx.closePath();
-  ctx.fill();
-
-  ctx.strokeStyle = `rgba(${cr}, ${cg}, ${cb}, 0.8)`;
-  ctx.lineWidth = 1.5;
-  ctx.setLineDash([4, 4]);
-  [bandLeft, bandRight].forEach((bx) => {
-    ctx.beginPath();
-    ctx.moveTo(bx, padding.top);
-    ctx.lineTo(bx, height - padding.bottom);
-    ctx.stroke();
-  });
-  ctx.setLineDash([]);
-
-  const mag = step.magnitude;
-  const magnitudeLabel = mag >= 1
-    ? `${mag >= 10 ? Math.round(mag) : mag.toFixed(1).replace(/\.0$/, '')}x`
-    : `${Math.round(mag * 100)}%`;
-  ctx.font = '500 11px -apple-system, sans-serif';
-  ctx.textAlign = 'center';
-  ctx.fillStyle = `rgb(${cr}, ${cg}, ${cb})`;
-  const arrow = step.type === 'spike' ? '\u25B2' : '\u25BC';
-  ctx.fillText(`${step.rank} ${arrow} ${magnitudeLabel}`, (bandLeft + bandRight) / 2, padding.top + 12);
-}
-
-/**
- * Draw a stacked area with line on top
- */
-function drawStackedArea(ctx, data, getX, getY, topStack, bottomStack, colors) {
-  if (!topStack.some((v, i) => v > bottomStack[i])) return;
-
-  ctx.beginPath();
-  ctx.moveTo(getX(0), getY(bottomStack[0]));
-  for (let i = 0; i < data.length; i += 1) ctx.lineTo(getX(i), getY(topStack[i]));
-  for (let i = data.length - 1; i >= 0; i -= 1) ctx.lineTo(getX(i), getY(bottomStack[i]));
-  ctx.closePath();
-  ctx.fillStyle = colors.fill;
-  ctx.fill();
-
-  ctx.beginPath();
-  ctx.moveTo(getX(0), getY(topStack[0]));
-  for (let i = 1; i < data.length; i += 1) ctx.lineTo(getX(i), getY(topStack[i]));
-  ctx.strokeStyle = colors.line;
-  ctx.lineWidth = 2;
-  ctx.stroke();
 }
 
 export function renderChart(data) {

--- a/js/chart.js
+++ b/js/chart.js
@@ -98,6 +98,7 @@ let scrubberRangeEnd = null; // eslint-disable-line prefer-const
 
 // Callback for chart→scroll sync (set by logs.js)
 let onChartHoverTimestamp = null;
+let onChartClickTimestamp = null;
 
 /**
  * Set callback for chart hover → scroll sync
@@ -105,6 +106,14 @@ let onChartHoverTimestamp = null;
  */
 export function setOnChartHoverTimestamp(callback) {
   onChartHoverTimestamp = callback;
+}
+
+/**
+ * Set callback for chart click → load logs at timestamp
+ * @param {Function} callback - Called with Date when clicking chart
+ */
+export function setOnChartClickTimestamp(callback) {
+  onChartClickTimestamp = callback;
 }
 
 /**
@@ -774,9 +783,13 @@ export function setupChartNavigation(callback) {
         hideSelectionOverlay();
         return;
       }
-      const anomalyBounds = getAnomalyAtX(e.clientX - canvas.getBoundingClientRect().left);
+      const clickX = e.clientX - canvas.getBoundingClientRect().left;
+      const anomalyBounds = getAnomalyAtX(clickX);
       if (anomalyBounds) {
         zoomToAnomalyByRank(anomalyBounds.rank);
+      } else if (onChartClickTimestamp) {
+        const clickTime = getTimeAtX(clickX);
+        if (clickTime) onChartClickTimestamp(clickTime);
       }
       return;
     }

--- a/js/chart.js
+++ b/js/chart.js
@@ -100,6 +100,17 @@ let scrubberRangeEnd = null; // eslint-disable-line prefer-const
 let onChartHoverTimestamp = null;
 let onChartClickTimestamp = null;
 
+// Callback invoked when chart data becomes available (set by dashboard-init.js)
+let onChartDataReady = null;
+
+/**
+ * Register a callback to be invoked when chart data is set.
+ * @param {Function} callback
+ */
+export function setOnChartDataReady(callback) {
+  onChartDataReady = callback;
+}
+
 /**
  * Set callback for chart hover → scroll sync
  * @param {Function} callback - Called with timestamp when hovering chart in logs view
@@ -929,6 +940,8 @@ export async function loadTimeSeries(requestContext = getRequestContext('dashboa
     if (!isCurrent()) return;
     state.chartData = result.data;
     renderChart(result.data);
+    // Notify logs view that chart data is available (bucket table may need rendering)
+    if (onChartDataReady) onChartDataReady();
   } catch (err) {
     if (!isCurrent() || isAbortError(err)) return;
     // eslint-disable-next-line no-console

--- a/js/columns.js
+++ b/js/columns.js
@@ -186,7 +186,7 @@ export const LOG_COLUMN_SHORT_LABELS = Object.fromEntries(
  * Columns always included in logs queries (needed for internal use, not display).
  * @type {string[]}
  */
-const ALWAYS_NEEDED_COLUMNS = ['timestamp', 'source', 'sample_hash'];
+const ALWAYS_NEEDED_COLUMNS = ['timestamp', 'source'];
 
 /**
  * Build the backtick-quoted column list for logs SQL queries.

--- a/js/columns.js
+++ b/js/columns.js
@@ -181,3 +181,27 @@ export const LOG_COLUMN_SHORT_LABELS = Object.fromEntries(
     .filter((def) => def.shortLabel)
     .map((def) => [def.logKey, def.shortLabel]),
 );
+
+/**
+ * Columns always included in logs queries (needed for internal use, not display).
+ * @type {string[]}
+ */
+const ALWAYS_NEEDED_COLUMNS = ['timestamp', 'source', 'sample_hash'];
+
+/**
+ * Build the backtick-quoted column list for logs SQL queries.
+ * Includes LOG_COLUMN_ORDER columns plus always-needed columns plus any pinned columns.
+ * @param {string[]} [pinnedColumns] - Additional pinned columns to include.
+ * @returns {string} Comma-separated, backtick-quoted column list for SQL SELECT.
+ */
+export function buildLogColumnsSql(pinnedColumns = []) {
+  const seen = new Set();
+  const cols = [];
+  for (const col of [...ALWAYS_NEEDED_COLUMNS, ...LOG_COLUMN_ORDER, ...pinnedColumns]) {
+    if (!seen.has(col)) {
+      seen.add(col);
+      cols.push(`\`${col}\``);
+    }
+  }
+  return cols.join(', ');
+}

--- a/js/columns.js
+++ b/js/columns.js
@@ -194,10 +194,13 @@ const ALWAYS_NEEDED_COLUMNS = ['timestamp', 'source', 'sample_hash'];
  * @param {string[]} [pinnedColumns] - Additional pinned columns to include.
  * @returns {string} Comma-separated, backtick-quoted column list for SQL SELECT.
  */
+const VALID_COLUMN_RE = /^[a-z][a-z0-9_.]*$/i;
+
 export function buildLogColumnsSql(pinnedColumns = []) {
   const seen = new Set();
   const cols = [];
-  for (const col of [...ALWAYS_NEEDED_COLUMNS, ...LOG_COLUMN_ORDER, ...pinnedColumns]) {
+  const safePinned = pinnedColumns.filter((col) => VALID_COLUMN_RE.test(col));
+  for (const col of [...ALWAYS_NEEDED_COLUMNS, ...LOG_COLUMN_ORDER, ...safePinned]) {
     if (!seen.has(col)) {
       seen.add(col);
       cols.push(`\`${col}\``);

--- a/js/columns.test.js
+++ b/js/columns.test.js
@@ -24,7 +24,7 @@ describe('buildLogColumnsSql', () => {
     const result = buildLogColumnsSql();
     assert.include(result, '`timestamp`');
     assert.include(result, '`source`');
-    assert.include(result, '`sample_hash`');
+    assert.notInclude(result, '`sample_hash`');
   });
 
   it('includes all LOG_COLUMN_ORDER columns', () => {
@@ -66,6 +66,5 @@ describe('buildLogColumnsSql', () => {
     const parts = result.split(', ');
     assert.strictEqual(parts[0], '`timestamp`');
     assert.strictEqual(parts[1], '`source`');
-    assert.strictEqual(parts[2], '`sample_hash`');
   });
 });

--- a/js/columns.test.js
+++ b/js/columns.test.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { buildLogColumnsSql, LOG_COLUMN_ORDER } from './columns.js';
+
+describe('buildLogColumnsSql', () => {
+  it('returns backtick-quoted column list', () => {
+    const result = buildLogColumnsSql();
+    assert.include(result, '`timestamp`');
+    assert.include(result, '`request.host`');
+    assert.include(result, '`response.status`');
+  });
+
+  it('includes always-needed columns', () => {
+    const result = buildLogColumnsSql();
+    assert.include(result, '`timestamp`');
+    assert.include(result, '`source`');
+    assert.include(result, '`sample_hash`');
+  });
+
+  it('includes all LOG_COLUMN_ORDER columns', () => {
+    const result = buildLogColumnsSql();
+    for (const col of LOG_COLUMN_ORDER) {
+      assert.include(result, `\`${col}\``, `missing column: ${col}`);
+    }
+  });
+
+  it('does not duplicate columns', () => {
+    // timestamp is in both ALWAYS_NEEDED and LOG_COLUMN_ORDER
+    const result = buildLogColumnsSql();
+    const matches = result.match(/`timestamp`/g);
+    assert.strictEqual(matches.length, 1, 'timestamp should appear exactly once');
+  });
+
+  it('includes pinned columns', () => {
+    const result = buildLogColumnsSql(['custom.column']);
+    assert.include(result, '`custom.column`');
+  });
+
+  it('does not duplicate pinned columns already in the list', () => {
+    const result = buildLogColumnsSql(['request.host']);
+    const matches = result.match(/`request\.host`/g);
+    assert.strictEqual(matches.length, 1, 'request.host should appear exactly once');
+  });
+
+  it('returns comma-separated values', () => {
+    const result = buildLogColumnsSql();
+    const parts = result.split(', ');
+    assert.ok(parts.length > 5, 'should have many columns');
+    for (const part of parts) {
+      assert.match(part, /^`[^`]+`$/, `each part should be backtick-quoted: ${part}`);
+    }
+  });
+
+  it('starts with always-needed columns', () => {
+    const result = buildLogColumnsSql();
+    const parts = result.split(', ');
+    assert.strictEqual(parts[0], '`timestamp`');
+    assert.strictEqual(parts[1], '`source`');
+    assert.strictEqual(parts[2], '`sample_hash`');
+  });
+});

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -29,7 +29,7 @@ import {
 } from './timer.js';
 import {
   loadTimeSeries, setupChartNavigation, getDetectedAnomalies, getLastChartData,
-  renderChart,
+  renderChart, setOnChartHoverTimestamp,
 } from './chart.js';
 import {
   loadAllBreakdowns, loadBreakdown, getBreakdowns, markSlowestFacet, resetFacetTimings,
@@ -40,7 +40,7 @@ import {
   getFilterForValue,
 } from './filters.js';
 import {
-  loadLogs, toggleLogsView, setLogsElements, setOnShowFiltersView,
+  loadLogs, toggleLogsView, setLogsElements, setOnShowFiltersView, scrollLogsToTimestamp,
 } from './logs.js';
 import { loadHostAutocomplete } from './autocomplete.js';
 import { initModal, closeQuickLinksModal } from './modal.js';
@@ -200,6 +200,15 @@ export function initDashboard(config = {}) {
     if (state.chartData) {
       renderChart(state.chartData);
     }
+  });
+
+  // Chart→Scroll sync: throttled to avoid excessive scrolling
+  let lastHoverScroll = 0;
+  setOnChartHoverTimestamp((timestamp) => {
+    const now = Date.now();
+    if (now - lastHoverScroll < 300) return;
+    lastHoverScroll = now;
+    scrollLogsToTimestamp(timestamp);
   });
 
   setFilterCallbacks(saveStateToURL, loadDashboard);

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -29,7 +29,7 @@ import {
 } from './timer.js';
 import {
   loadTimeSeries, setupChartNavigation, getDetectedAnomalies, getLastChartData,
-  renderChart, setOnChartHoverTimestamp, setOnChartClickTimestamp,
+  renderChart, setOnChartHoverTimestamp, setOnChartClickTimestamp, setOnChartDataReady,
 } from './chart.js';
 import {
   loadAllBreakdowns, loadBreakdown, getBreakdowns, markSlowestFacet, resetFacetTimings,
@@ -41,6 +41,7 @@ import {
 } from './filters.js';
 import {
   loadLogs, toggleLogsView, setLogsElements, setOnShowFiltersView, scrollLogsToTimestamp,
+  tryRenderBucketTable,
 } from './logs.js';
 import { loadHostAutocomplete } from './autocomplete.js';
 import { initModal, closeQuickLinksModal } from './modal.js';
@@ -201,6 +202,10 @@ export function initDashboard(config = {}) {
       renderChart(state.chartData);
     }
   });
+
+  // When chart data arrives, try rendering the bucket table (fixes race condition
+  // where logs view shows "Loading..." because chart data wasn't available yet)
+  setOnChartDataReady(() => tryRenderBucketTable());
 
   // Chart→Scroll sync: throttled to avoid excessive scrolling
   let lastHoverScroll = 0;

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -29,7 +29,7 @@ import {
 } from './timer.js';
 import {
   loadTimeSeries, setupChartNavigation, getDetectedAnomalies, getLastChartData,
-  renderChart, setOnChartHoverTimestamp,
+  renderChart, setOnChartHoverTimestamp, setOnChartClickTimestamp,
 } from './chart.js';
 import {
   loadAllBreakdowns, loadBreakdown, getBreakdowns, markSlowestFacet, resetFacetTimings,
@@ -209,6 +209,15 @@ export function initDashboard(config = {}) {
     if (now - lastHoverScroll < 300) return;
     lastHoverScroll = now;
     scrollLogsToTimestamp(timestamp);
+  });
+
+  // Chart click → open logs at clicked timestamp
+  setOnChartClickTimestamp((timestamp) => {
+    if (!state.showLogs) {
+      toggleLogsView(saveStateToURL, timestamp);
+    } else {
+      scrollLogsToTimestamp(timestamp);
+    }
   });
 
   setFilterCallbacks(saveStateToURL, loadDashboard);

--- a/js/logs.js
+++ b/js/logs.js
@@ -653,6 +653,9 @@ export async function loadLogs(requestContext = getRequestContext('dashboard')) 
     if (virtualTable) {
       virtualTable.setColumns(buildVirtualColumns(currentColumns));
 
+      // Seed VirtualTable cache with pre-fetched page 0 to avoid re-fetch
+      virtualTable.seedCache(0, rows);
+
       // Estimate total rows: use chart data if available, otherwise extrapolate
       const estimated = estimateTotalRows();
       const total = estimated > rows.length ? estimated : rows.length * 10;

--- a/js/logs.js
+++ b/js/logs.js
@@ -724,7 +724,7 @@ export async function loadLogs(requestContext = getRequestContext('dashboard')) 
   }
 }
 
-export function toggleLogsView(saveStateToURL) {
+export function toggleLogsView(saveStateToURL, scrollToTimestamp) {
   state.showLogs = !state.showLogs;
   const dashboardContent = document.getElementById('dashboardContent');
   if (state.showLogs) {
@@ -749,6 +749,9 @@ export function toggleLogsView(saveStateToURL) {
         const estimated = estimateTotalRows();
         const total = estimated > page0.rows.length ? estimated : page0.rows.length * 10;
         virtualTable.setTotalRows(total);
+        if (scrollToTimestamp) {
+          scrollLogsToTimestamp(scrollToTimestamp);
+        }
       }
     } else {
       loadLogs();

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -35,7 +35,7 @@ export class PaginationState {
   }
 
   canLoadMore() {
-    return this.hasMore && !this.loading;
+    return this.hasMore && !this.loading && this.cursor != null;
   }
 
   shouldTriggerLoad(scrollPercent, globalLoading) {

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -11,6 +11,7 @@
  */
 
 export const PAGE_SIZE = 500;
+export const INITIAL_PAGE_SIZE = 100;
 
 export class PaginationState {
   constructor(pageSize = PAGE_SIZE) {

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -14,21 +14,24 @@ export const PAGE_SIZE = 500;
 
 export class PaginationState {
   constructor(pageSize = PAGE_SIZE) {
-    this.offset = 0;
+    this.cursor = null;
     this.hasMore = true;
     this.loading = false;
     this.pageSize = pageSize;
   }
 
   reset() {
-    this.offset = 0;
+    this.cursor = null;
     this.hasMore = true;
     this.loading = false;
   }
 
-  recordPage(resultLength) {
-    this.offset += resultLength;
+  recordPage(rows) {
+    const resultLength = rows.length;
     this.hasMore = resultLength === this.pageSize;
+    if (resultLength > 0) {
+      this.cursor = rows[resultLength - 1].timestamp;
+    }
   }
 
   canLoadMore() {

--- a/js/pagination.test.js
+++ b/js/pagination.test.js
@@ -141,9 +141,15 @@ describe('PaginationState', () => {
   });
 
   describe('canLoadMore', () => {
-    it('returns true when hasMore and not loading', () => {
+    it('returns true when hasMore, not loading, and cursor is set', () => {
       const ps = new PaginationState();
+      ps.cursor = '2025-01-15 10:30:00.000';
       assert.strictEqual(ps.canLoadMore(), true);
+    });
+
+    it('returns false when cursor is null', () => {
+      const ps = new PaginationState();
+      assert.strictEqual(ps.canLoadMore(), false);
     });
 
     it('returns false when loading', () => {
@@ -169,6 +175,7 @@ describe('PaginationState', () => {
   describe('shouldTriggerLoad', () => {
     it('triggers when scrolled past 50% and can load more', () => {
       const ps = new PaginationState();
+      ps.cursor = '2025-01-15 10:30:00.000';
       assert.strictEqual(ps.shouldTriggerLoad(0.6, false), true);
     });
 

--- a/js/request-context.test.js
+++ b/js/request-context.test.js
@@ -53,6 +53,21 @@ describe('request-context', () => {
     }
   });
 
+  it('returns already-aborted signal in fallback when input is pre-aborted', () => {
+    const originalAny = AbortSignal.any;
+    AbortSignal.any = undefined;
+    try {
+      const controllerA = new AbortController();
+      controllerA.abort();
+      const controllerB = new AbortController();
+      const merged = mergeAbortSignals([controllerA.signal, controllerB.signal]);
+
+      assert.isTrue(merged.aborted);
+    } finally {
+      AbortSignal.any = originalAny;
+    }
+  });
+
   it('returns undefined for empty signal list', () => {
     const merged = mergeAbortSignals([]);
     assert.isUndefined(merged);

--- a/js/sql-loader.js
+++ b/js/sql-loader.js
@@ -62,6 +62,7 @@ const ALL_TEMPLATES = [
   'time-series',
   'logs',
   'logs-more',
+  'logs-at',
   'breakdown',
   'breakdown-facet',
   'breakdown-missing',

--- a/js/sql-loader.js
+++ b/js/sql-loader.js
@@ -73,6 +73,7 @@ const ALL_TEMPLATES = [
   'facet-search-pattern',
   'investigate-facet',
   'investigate-selection',
+  'log-detail',
 ];
 
 /**

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -228,6 +228,14 @@ export function syncUIFromState() {
     elements.logsView.classList.add('visible');
     elements.filtersView.classList.remove('visible');
     elements.viewToggleBtn.querySelector('.menu-item-label').textContent = 'View Filters';
+    // Activate flex layout for logs view
+    const dc = document.getElementById('dashboardContent');
+    if (dc) dc.classList.add('logs-active');
+    // Restore chart collapse state from localStorage
+    const chartSection = document.querySelector('.chart-section');
+    if (chartSection && localStorage.getItem('chartCollapsed') === 'true') {
+      chartSection.classList.add('chart-collapsed');
+    }
   } else {
     elements.logsView.classList.remove('visible');
     elements.filtersView.classList.add('visible');

--- a/js/url-state.test.js
+++ b/js/url-state.test.js
@@ -697,6 +697,7 @@ describe('syncUIFromState', () => {
   let mockElements;
   let titleEl;
   let activeFiltersEl;
+  let dashboardContentEl;
 
   beforeEach(() => {
     resetState();
@@ -746,11 +747,17 @@ describe('syncUIFromState', () => {
     activeFiltersEl = document.createElement('div');
     activeFiltersEl.id = 'activeFilters';
     document.body.appendChild(activeFiltersEl);
+
+    // Create dashboardContent element for logs-active class
+    dashboardContentEl = document.createElement('div');
+    dashboardContentEl.id = 'dashboardContent';
+    document.body.appendChild(dashboardContentEl);
   });
 
   afterEach(() => {
     titleEl.remove();
     activeFiltersEl.remove();
+    dashboardContentEl.remove();
     window.history.replaceState({}, '', ORIGINAL_PATH);
   });
 
@@ -804,6 +811,33 @@ describe('syncUIFromState', () => {
       mockElements.viewToggleBtn.querySelector('.menu-item-label').textContent,
       'View Filters',
     );
+  });
+
+  it('adds logs-active class to dashboardContent when showLogs is true', () => {
+    state.showLogs = true;
+    syncUIFromState();
+    assert.isTrue(dashboardContentEl.classList.contains('logs-active'));
+  });
+
+  it('does not add logs-active class when showLogs is false', () => {
+    state.showLogs = false;
+    syncUIFromState();
+    assert.isFalse(dashboardContentEl.classList.contains('logs-active'));
+  });
+
+  it('restores chart collapse state from localStorage when showLogs is true', () => {
+    const chartSection = document.createElement('div');
+    chartSection.classList.add('chart-section');
+    document.body.appendChild(chartSection);
+    localStorage.setItem('chartCollapsed', 'true');
+    try {
+      state.showLogs = true;
+      syncUIFromState();
+      assert.isTrue(chartSection.classList.contains('chart-collapsed'));
+    } finally {
+      chartSection.remove();
+      localStorage.removeItem('chartCollapsed');
+    }
   });
 
   it('shows filters view when showLogs is false', () => {

--- a/js/virtual-table.js
+++ b/js/virtual-table.js
@@ -101,10 +101,18 @@ export class VirtualTable {
   updateHeader() {
     // Build colgroup for deterministic column widths
     this.colgroup.innerHTML = '';
+    let totalWidth = 0;
     for (const col of this.columns) {
       const colEl = document.createElement('col');
-      if (col.width) colEl.style.width = `${col.width}px`;
+      const w = col.width || 120;
+      colEl.style.width = `${w}px`;
+      totalWidth += w;
       this.colgroup.appendChild(colEl);
+    }
+
+    // Set explicit table width so it can exceed container (enables horizontal scroll)
+    if (totalWidth > 0) {
+      this.table.style.width = `${totalWidth}px`;
     }
 
     const tr = document.createElement('tr');

--- a/js/virtual-table.js
+++ b/js/virtual-table.js
@@ -82,6 +82,9 @@ export class VirtualTable {
   initDom() {
     this.container.style.overflowY = 'auto';
 
+    this.spacerTop = document.createElement('div');
+    this.spacerTop.className = 'vt-spacer-top';
+
     this.table = document.createElement('table');
     this.table.className = 'logs-table';
 
@@ -93,7 +96,12 @@ export class VirtualTable {
     this.table.appendChild(this.thead);
     this.table.appendChild(this.tbody);
 
+    this.spacerBottom = document.createElement('div');
+    this.spacerBottom.className = 'vt-spacer-bottom';
+
+    this.container.appendChild(this.spacerTop);
     this.container.appendChild(this.table);
+    this.container.appendChild(this.spacerBottom);
 
     this.updateHeader();
   }
@@ -176,8 +184,8 @@ export class VirtualTable {
 
   renderRows() {
     if (this.totalRows === 0) {
-      this.tbody.style.paddingTop = '0px';
-      this.tbody.style.paddingBottom = '0px';
+      this.spacerTop.style.height = '0px';
+      this.spacerBottom.style.height = '0px';
       this.tbody.innerHTML = '';
       this.lastRange = null;
       return;
@@ -216,9 +224,8 @@ export class VirtualTable {
       }
     }
 
-    // Padding-based virtual scroll: push visible rows into correct position
-    this.tbody.style.paddingTop = `${start * this.rowHeight}px`;
-    this.tbody.style.paddingBottom = `${Math.max(0, (this.totalRows - end) * this.rowHeight)}px`;
+    this.spacerTop.style.height = `${start * this.rowHeight}px`;
+    this.spacerBottom.style.height = `${Math.max(0, (this.totalRows - end) * this.rowHeight)}px`;
     this.tbody.innerHTML = html;
 
     if (fetchStart !== -1) {
@@ -318,6 +325,8 @@ export class VirtualTable {
   clearCache() {
     this.cache.clear();
     this.pending.clear();
+    this.spacerTop.style.height = '0px';
+    this.spacerBottom.style.height = '0px';
   }
 
   destroy() {

--- a/js/virtual-table.js
+++ b/js/virtual-table.js
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const DEFAULT_ROW_HEIGHT = 28;
+const DEFAULT_OVERSCAN = 10;
+const MAX_CACHED_PAGES = 20;
+
+function getPinnedOffsets(columns) {
+  const offsets = new Map();
+  let left = 0;
+  for (const col of columns) {
+    if (col.pinned) {
+      offsets.set(col.key, left);
+      left += col.width || 120;
+    }
+  }
+  return offsets;
+}
+
+function makeCellStyle(col, offsets) {
+  if (!col.pinned) return '';
+  const left = offsets.get(col.key);
+  return ` style="position:sticky;left:${left}px;z-index:1"`;
+}
+
+function findInCache(cache, idx) {
+  for (const page of cache.values()) {
+    const offset = idx - page.startIdx;
+    if (offset >= 0 && offset < page.rows.length) {
+      return page.rows[offset];
+    }
+  }
+  return null;
+}
+
+/**
+ * Minimal virtual-scrolling table. Renders only visible rows into a
+ * standard HTML <table>, backed by an async getData callback.
+ */
+export class VirtualTable {
+  /**
+   * @param {Object} opts
+   * @param {HTMLElement} opts.container
+   * @param {number} [opts.rowHeight=28]
+   * @param {Array<{key:string, label:string, pinned?:boolean, width?:number}>} opts.columns
+   * @param {(start:number, count:number) => Promise<Object[]>} opts.getData
+   * @param {(col:Object, value:unknown, row:Object) => string} opts.renderCell
+   * @param {(first:number, last:number) => void} [opts.onVisibleRangeChange]
+   * @param {(idx:number, row:Object) => void} [opts.onRowClick]
+   */
+  constructor({
+    container, rowHeight, columns, getData, renderCell,
+    onVisibleRangeChange, onRowClick,
+  }) {
+    this.container = container;
+    this.rowHeight = rowHeight || DEFAULT_ROW_HEIGHT;
+    this.columns = columns;
+    this.getDataFn = getData;
+    this.renderCellFn = renderCell;
+    this.onRangeChange = onVisibleRangeChange || null;
+    this.onRowClickFn = onRowClick || null;
+
+    this.totalRows = 0;
+    this.cache = new Map();
+    this.pending = new Set();
+    this.rafId = null;
+    this.lastRange = null;
+
+    this.initDom();
+    this.initEvents();
+  }
+
+  initDom() {
+    this.container.style.overflowY = 'auto';
+    this.container.style.position = 'relative';
+
+    this.spacer = document.createElement('div');
+    this.spacer.style.width = '1px';
+    this.spacer.style.height = '0px';
+    this.spacer.style.pointerEvents = 'none';
+
+    this.table = document.createElement('table');
+    this.table.className = 'logs-table';
+    this.table.style.position = 'sticky';
+    this.table.style.top = '0';
+
+    this.thead = document.createElement('thead');
+    this.tbody = document.createElement('tbody');
+    this.table.appendChild(this.thead);
+    this.table.appendChild(this.tbody);
+
+    this.container.appendChild(this.table);
+    this.container.appendChild(this.spacer);
+
+    this.updateHeader();
+  }
+
+  updateHeader() {
+    const tr = document.createElement('tr');
+    let pinnedLeft = 0;
+    for (const col of this.columns) {
+      const th = document.createElement('th');
+      th.textContent = col.label || col.key;
+      th.title = col.key;
+      if (col.width) th.style.width = `${col.width}px`;
+      if (col.pinned) {
+        th.style.position = 'sticky';
+        th.style.left = `${pinnedLeft}px`;
+        th.style.zIndex = '2';
+        pinnedLeft += col.width || 120;
+      }
+      tr.appendChild(th);
+    }
+    this.thead.innerHTML = '';
+    this.thead.appendChild(tr);
+  }
+
+  initEvents() {
+    this.scrollHandler = () => {
+      if (this.rafId) return;
+      this.rafId = requestAnimationFrame(() => {
+        this.rafId = null;
+        this.renderRows();
+      });
+    };
+    this.container.addEventListener(
+      'scroll',
+      this.scrollHandler,
+      { passive: true },
+    );
+
+    if (this.onRowClickFn) {
+      this.clickHandler = (e) => {
+        const tr = e.target.closest('tr[data-row-idx]');
+        if (!tr) return;
+        const idx = parseInt(tr.dataset.rowIdx, 10);
+        const row = findInCache(this.cache, idx);
+        if (row) this.onRowClickFn(idx, row);
+      };
+      this.tbody.addEventListener('click', this.clickHandler);
+    }
+  }
+
+  computeRange() {
+    const { scrollTop } = this.container;
+    const viewHeight = this.container.clientHeight;
+    const start = Math.max(
+      0,
+      Math.floor(scrollTop / this.rowHeight) - DEFAULT_OVERSCAN,
+    );
+    const visible = Math.ceil(viewHeight / this.rowHeight);
+    const end = Math.min(
+      this.totalRows,
+      start + visible + DEFAULT_OVERSCAN * 2,
+    );
+    return { start, end };
+  }
+
+  renderRows() {
+    if (this.totalRows === 0) {
+      this.tbody.innerHTML = '';
+      this.lastRange = null;
+      return;
+    }
+
+    const { start, end } = this.computeRange();
+
+    if (
+      this.lastRange
+      && this.lastRange.start === start
+      && this.lastRange.end === end
+    ) return;
+    this.lastRange = { start, end };
+
+    const offsets = getPinnedOffsets(this.columns);
+    let html = '';
+    let fetchStart = -1;
+
+    for (let i = start; i < end; i += 1) {
+      const row = findInCache(this.cache, i);
+      const top = i * this.rowHeight;
+
+      if (row) {
+        html += `<tr data-row-idx="${i}" style="height:${
+          this.rowHeight}px;position:absolute;top:${
+          top}px;width:100%">`;
+        for (const col of this.columns) {
+          const sty = makeCellStyle(col, offsets);
+          html += `<td${sty}>${this.renderCellFn(col, row[col.key], row)}</td>`;
+        }
+        html += '</tr>';
+      } else {
+        html += `<tr data-row-idx="${i
+        }" class="loading-row" style="height:${
+          this.rowHeight}px;position:absolute;top:${
+          top}px;width:100%">`;
+        for (const col of this.columns) {
+          html += `<td${makeCellStyle(col, offsets)}>&nbsp;</td>`;
+        }
+        html += '</tr>';
+        if (fetchStart === -1) fetchStart = i;
+      }
+    }
+
+    this.tbody.style.position = 'relative';
+    this.tbody.style.height = `${this.totalRows * this.rowHeight}px`;
+    this.tbody.innerHTML = html;
+
+    if (fetchStart !== -1) {
+      this.fetchRange(fetchStart, end);
+    }
+
+    if (this.onRangeChange) {
+      const visStart = Math.max(start + DEFAULT_OVERSCAN, 0);
+      const visEnd = Math.min(end - DEFAULT_OVERSCAN, this.totalRows);
+      this.onRangeChange(visStart, visEnd);
+    }
+  }
+
+  async fetchRange(startIdx, endIdx) {
+    const count = endIdx - startIdx;
+    if (this.pending.has(startIdx)) return;
+    this.pending.add(startIdx);
+
+    try {
+      const rows = await this.getDataFn(startIdx, count);
+      this.cache.set(startIdx, { startIdx, rows });
+      this.evictDistantPages();
+      this.lastRange = null;
+      this.renderRows();
+    } finally {
+      this.pending.delete(startIdx);
+    }
+  }
+
+  evictDistantPages() {
+    if (this.cache.size <= MAX_CACHED_PAGES) return;
+    const center = this.container.scrollTop / this.rowHeight;
+    const sorted = [...this.cache.entries()]
+      .map(([key, page]) => ({
+        key,
+        dist: Math.abs(page.startIdx - center),
+      }))
+      .sort((a, b) => b.dist - a.dist);
+
+    while (this.cache.size > MAX_CACHED_PAGES) {
+      this.cache.delete(sorted.shift().key);
+    }
+  }
+
+  /* ---- Public API ---- */
+
+  setTotalRows(n) {
+    this.totalRows = n;
+    this.spacer.style.height = `${n * this.rowHeight}px`;
+    this.lastRange = null;
+    this.renderRows();
+  }
+
+  setColumns(cols) {
+    this.columns = cols;
+    this.updateHeader();
+    this.lastRange = null;
+    this.renderRows();
+  }
+
+  scrollToRow(index) {
+    this.container.scrollTop = Math.max(0, index * this.rowHeight);
+  }
+
+  scrollToTimestamp(ts, getTimestamp) {
+    if (this.totalRows === 0) return;
+    const target = typeof ts === 'number' ? ts : ts.getTime();
+    let lo = 0;
+    let hi = this.totalRows - 1;
+    let best = 0;
+    let bestDiff = Infinity;
+
+    while (lo <= hi) {
+      const mid = Math.floor((lo + hi) / 2);
+      const row = findInCache(this.cache, mid);
+      if (!row) break;
+      const rowTs = getTimestamp(row);
+      const diff = Math.abs(rowTs - target);
+      if (diff < bestDiff) {
+        bestDiff = diff;
+        best = mid;
+      }
+      if (rowTs > target) lo = mid + 1;
+      else hi = mid - 1;
+    }
+    this.scrollToRow(best);
+  }
+
+  invalidate() {
+    this.lastRange = null;
+    this.renderRows();
+  }
+
+  clearCache() {
+    this.cache.clear();
+    this.pending.clear();
+  }
+
+  destroy() {
+    this.container.removeEventListener('scroll', this.scrollHandler);
+    if (this.clickHandler) {
+      this.tbody.removeEventListener('click', this.clickHandler);
+    }
+    if (this.rafId) cancelAnimationFrame(this.rafId);
+    this.cache.clear();
+  }
+}

--- a/js/virtual-table.js
+++ b/js/virtual-table.js
@@ -157,6 +157,8 @@ export class VirtualTable {
 
     if (this.onRowClickFn) {
       this.clickHandler = (e) => {
+        // Let data-action clicks (e.g. add-filter) bubble to global handler
+        if (e.target.closest('[data-action]')) return;
         const tr = e.target.closest('tr[data-row-idx]');
         if (!tr) return;
         const idx = parseInt(tr.dataset.rowIdx, 10);

--- a/js/virtual-table.test.js
+++ b/js/virtual-table.test.js
@@ -83,18 +83,17 @@ describe('VirtualTable', () => {
   });
 
   describe('setTotalRows', () => {
-    it('sets tbody padding to create virtual scroll space', () => {
+    it('sets spacer heights to create virtual scroll space', () => {
       container = makeContainer();
       vt = new VirtualTable({
         container, columns: makeColumns(), getData: makeGetData([]), renderCell,
       });
       vt.setTotalRows(1000);
-      const { tbody } = vt;
-      const topPad = parseInt(tbody.style.paddingTop, 10);
-      const bottomPad = parseInt(tbody.style.paddingBottom, 10);
-      const renderedRows = tbody.querySelectorAll('tr').length;
-      // Total virtual height = topPad + renderedRows*rowHeight + bottomPad
-      assert.strictEqual(topPad + renderedRows * 28 + bottomPad, 1000 * 28);
+      const topH = parseInt(vt.spacerTop.style.height, 10);
+      const bottomH = parseInt(vt.spacerBottom.style.height, 10);
+      const renderedRows = vt.tbody.querySelectorAll('tr').length;
+      // Total virtual height = topH + renderedRows*rowHeight + bottomH
+      assert.strictEqual(topH + renderedRows * 28 + bottomH, 1000 * 28);
     });
 
     it('uses custom row height', () => {
@@ -103,11 +102,10 @@ describe('VirtualTable', () => {
         container, columns: makeColumns(), getData: makeGetData([]), renderCell, rowHeight: 40,
       });
       vt.setTotalRows(500);
-      const { tbody } = vt;
-      const topPad = parseInt(tbody.style.paddingTop, 10);
-      const bottomPad = parseInt(tbody.style.paddingBottom, 10);
-      const renderedRows = tbody.querySelectorAll('tr').length;
-      assert.strictEqual(topPad + renderedRows * 40 + bottomPad, 500 * 40);
+      const topH = parseInt(vt.spacerTop.style.height, 10);
+      const bottomH = parseInt(vt.spacerBottom.style.height, 10);
+      const renderedRows = vt.tbody.querySelectorAll('tr').length;
+      assert.strictEqual(topH + renderedRows * 40 + bottomH, 500 * 40);
     });
   });
 
@@ -304,7 +302,7 @@ describe('VirtualTable', () => {
       assert.strictEqual(vt.table.style.width, '300px');
     });
 
-    it('sets tbody paddingTop and paddingBottom for virtual scroll area', () => {
+    it('sets spacer heights for virtual scroll area', () => {
       container = makeContainer(280);
       const allRows = Array.from({ length: 100 }, (_, i) => ({
         timestamp: `row-${i}`, status: 200,
@@ -314,12 +312,11 @@ describe('VirtualTable', () => {
       });
       vt.setTotalRows(100);
 
-      const { tbody } = vt;
-      const topPad = parseInt(tbody.style.paddingTop, 10);
-      const bottomPad = parseInt(tbody.style.paddingBottom, 10);
-      // With scrollTop=0, paddingTop should be 0 (start=0)
-      assert.strictEqual(topPad, 0, 'paddingTop should be 0 at scroll position 0');
-      assert.ok(bottomPad > 0, 'paddingBottom should be positive');
+      const topH = parseInt(vt.spacerTop.style.height, 10);
+      const bottomH = parseInt(vt.spacerBottom.style.height, 10);
+      // With scrollTop=0, spacerTop should be 0 (start=0)
+      assert.strictEqual(topH, 0, 'spacerTop height should be 0 at scroll position 0');
+      assert.ok(bottomH > 0, 'spacerBottom height should be positive');
     });
   });
 

--- a/js/virtual-table.test.js
+++ b/js/virtual-table.test.js
@@ -277,6 +277,33 @@ describe('VirtualTable', () => {
       assert.strictEqual(colEls[1].style.width, '60px');
     });
 
+    it('sets table width to sum of column widths for horizontal scrolling', () => {
+      container = makeContainer();
+      const cols = [
+        { key: 'timestamp', label: 'Time', width: 180 },
+        { key: 'status', label: 'Status', width: 60 },
+        { key: 'host', label: 'Host', width: 200 },
+      ];
+      vt = new VirtualTable({
+        container, columns: cols, getData: makeGetData([]), renderCell,
+      });
+      assert.strictEqual(vt.table.style.width, '440px');
+    });
+
+    it('defaults column width to 120 when not specified', () => {
+      container = makeContainer();
+      const cols = [
+        { key: 'timestamp', label: 'Time', width: 180 },
+        { key: 'other', label: 'Other' },
+      ];
+      vt = new VirtualTable({
+        container, columns: cols, getData: makeGetData([]), renderCell,
+      });
+      const colEls = container.querySelectorAll('colgroup col');
+      assert.strictEqual(colEls[1].style.width, '120px');
+      assert.strictEqual(vt.table.style.width, '300px');
+    });
+
     it('sets tbody paddingTop and paddingBottom for virtual scroll area', () => {
       container = makeContainer(280);
       const allRows = Array.from({ length: 100 }, (_, i) => ({

--- a/scripts/benchmark-bucket-fetch.mjs
+++ b/scripts/benchmark-bucket-fetch.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Benchmark ClickHouse query response times for different row counts.
+ * Measures fetch latency for the same columns used by the dashboard logs view.
+ *
+ * Usage: node scripts/benchmark-bucket-fetch.mjs <username> <password>
+ */
+
+const CLICKHOUSE_HOST = 's2p5b8wmt5.eastus2.azure.clickhouse.cloud';
+const CLICKHOUSE_PORT = 8443;
+const DATABASE = 'helix_logs_production';
+const RUNS_PER_TEST = 3;
+const DELAY_BETWEEN_RUNS_MS = 500;
+
+const COLUMNS = [
+  '`timestamp`',
+  '`source`',
+  '`response.status`',
+  '`request.method`',
+  '`request.host`',
+  '`request.url`',
+  '`cdn.cache_status`',
+  '`response.headers.content_type`',
+  '`helix.request_type`',
+  '`helix.backend_type`',
+  '`request.headers.x_forwarded_host`',
+  '`request.headers.referer`',
+  '`request.headers.user_agent`',
+  '`client.ip`',
+  '`request.headers.x_forwarded_for`',
+  '`response.headers.x_error`',
+  '`request.headers.accept`',
+  '`request.headers.accept_encoding`',
+  '`request.headers.cache_control`',
+  '`request.headers.x_byo_cdn_type`',
+  '`response.headers.location`',
+].join(', ');
+
+const TABLE = `${DATABASE}.cdn_requests_v2`;
+
+const TEST_CASES = [
+  {
+    name: 'LIMIT 100 (initial viewport)',
+    limit: 100,
+    timeWindow: '15 min',
+    sql: `SELECT ${COLUMNS} FROM ${TABLE}
+WHERE timestamp >= now() - INTERVAL 15 MINUTE
+ORDER BY timestamp DESC LIMIT 100`,
+  },
+  {
+    name: 'LIMIT 500 (one page)',
+    limit: 500,
+    timeWindow: '15 min',
+    sql: `SELECT ${COLUMNS} FROM ${TABLE}
+WHERE timestamp >= now() - INTERVAL 15 MINUTE
+ORDER BY timestamp DESC LIMIT 500`,
+  },
+  {
+    name: 'LIMIT 2000 (medium bucket)',
+    limit: 2000,
+    timeWindow: '15 min',
+    sql: `SELECT ${COLUMNS} FROM ${TABLE}
+WHERE timestamp >= now() - INTERVAL 15 MINUTE
+ORDER BY timestamp DESC LIMIT 2000`,
+  },
+  {
+    name: 'LIMIT 6000 (full large bucket)',
+    limit: 6000,
+    timeWindow: '15 min',
+    sql: `SELECT ${COLUMNS} FROM ${TABLE}
+WHERE timestamp >= now() - INTERVAL 15 MINUTE
+ORDER BY timestamp DESC LIMIT 6000`,
+  },
+  {
+    name: '5-second bucket, all rows',
+    limit: 10000,
+    timeWindow: '5 sec',
+    sql: `SELECT ${COLUMNS} FROM ${TABLE}
+WHERE timestamp >= now() - INTERVAL 5 SECOND
+ORDER BY timestamp DESC LIMIT 10000`,
+  },
+  {
+    name: '5-min bucket, LIMIT 500',
+    limit: 500,
+    timeWindow: '5 min',
+    sql: `SELECT ${COLUMNS} FROM ${TABLE}
+WHERE timestamp >= now() - INTERVAL 5 MINUTE
+ORDER BY timestamp DESC LIMIT 500`,
+  },
+  {
+    name: '5-min bucket, LIMIT 5000',
+    limit: 5000,
+    timeWindow: '5 min',
+    sql: `SELECT ${COLUMNS} FROM ${TABLE}
+WHERE timestamp >= now() - INTERVAL 5 MINUTE
+ORDER BY timestamp DESC LIMIT 5000`,
+  },
+  {
+    name: '5-min bucket, LIMIT 50000',
+    limit: 50000,
+    timeWindow: '5 min',
+    sql: `SELECT ${COLUMNS} FROM ${TABLE}
+WHERE timestamp >= now() - INTERVAL 5 MINUTE
+ORDER BY timestamp DESC LIMIT 50000`,
+  },
+];
+
+function printUsage() {
+  console.log('Usage: node scripts/benchmark-bucket-fetch.mjs <username> <password>');
+  console.log('');
+  console.log('Benchmarks ClickHouse query response times for different row counts');
+  console.log('using the same columns as the dashboard logs view.');
+  console.log('');
+  console.log('Arguments:');
+  console.log('  username   ClickHouse username');
+  console.log('  password   ClickHouse password');
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+}
+
+function sleep(ms) {
+  // eslint-disable-next-line no-promise-executor-return
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function runQuery(sql, auth, runIndex) {
+  const taggedSql = `/* run=${runIndex} t=${Date.now()} */ ${sql}`;
+  const url = `https://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?database=${DATABASE}&use_query_cache=0`;
+
+  const start = performance.now();
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(auth).toString('base64')}`,
+      'Content-Type': 'text/plain',
+    },
+    body: `${taggedSql} FORMAT JSON`,
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`ClickHouse HTTP ${resp.status}: ${body.slice(0, 200)}`);
+  }
+
+  const json = await resp.json();
+  const elapsed = performance.now() - start;
+
+  return {
+    elapsed,
+    rows: json.rows,
+    transferBytes: JSON.stringify(json.data).length,
+    serverElapsed: json.statistics?.elapsed ?? null,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    process.exit(0);
+  }
+
+  if (args.length < 2) {
+    console.error('Error: username and password are required.\n');
+    printUsage();
+    process.exit(1);
+  }
+
+  const [username, password] = args;
+  const auth = `${username}:${password}`;
+
+  console.log(`Running benchmark against ${CLICKHOUSE_HOST} as ${username}`);
+  console.log(`${RUNS_PER_TEST} runs per test, reporting median\n`);
+
+  const results = [];
+
+  for (const testCase of TEST_CASES) {
+    const timings = [];
+    let lastResult = null;
+
+    process.stdout.write(`  ${testCase.name} ...`);
+
+    // eslint-disable-next-line no-await-in-loop -- sequential runs required for stable timings
+    for (let i = 0; i < RUNS_PER_TEST; i += 1) {
+      if (i > 0) {
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(DELAY_BETWEEN_RUNS_MS);
+      }
+      // eslint-disable-next-line no-await-in-loop
+      const result = await runQuery(testCase.sql, auth, i);
+      timings.push(result.elapsed);
+      lastResult = result;
+    }
+
+    const medianTime = median(timings);
+    const transferKb = (lastResult.transferBytes / 1024).toFixed(1);
+
+    process.stdout.write(` ${medianTime.toFixed(0)} ms (${lastResult.rows} rows, ${transferKb} KB)\n`);
+
+    results.push({
+      name: testCase.name,
+      limit: testCase.limit,
+      timeWindow: testCase.timeWindow,
+      rows: lastResult.rows,
+      medianMs: medianTime,
+      transferKb: parseFloat(transferKb),
+      serverElapsedMs: lastResult.serverElapsed !== null
+        ? (lastResult.serverElapsed * 1000).toFixed(0)
+        : 'n/a',
+    });
+  }
+
+  console.log('\n## Results\n');
+  console.log('| # | Test | Limit | Time Window | Rows Returned | Median Time (ms) | Server Time (ms) | Transfer Size (KB) |');
+  console.log('|---|------|-------|-------------|---------------|-------------------|-------------------|--------------------|');
+
+  results.forEach((r, i) => {
+    console.log(
+      `| ${i + 1} | ${r.name} | ${r.limit} | ${r.timeWindow} | ${r.rows} | ${r.medianMs.toFixed(0)} | ${r.serverElapsedMs} | ${r.transferKb} |`,
+    );
+  });
+}
+
+main().catch((err) => {
+  console.error('Benchmark failed:', err.message);
+  process.exit(1);
+});

--- a/sql/queries/log-detail.sql
+++ b/sql/queries/log-detail.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM {{database}}.{{table}}
+WHERE timestamp = toDateTime64('{{timestamp}}', 3) AND `request.host` = '{{host}}'
+LIMIT 1

--- a/sql/queries/logs-at.sql
+++ b/sql/queries/logs-at.sql
@@ -1,0 +1,5 @@
+SELECT {{columns}}
+FROM {{database}}.{{table}}
+WHERE {{timeFilter}} AND timestamp <= toDateTime64('{{cursor}}', 3) {{hostFilter}} {{facetFilters}} {{additionalWhereClause}}
+ORDER BY timestamp DESC
+LIMIT {{pageSize}}

--- a/sql/queries/logs-more.sql
+++ b/sql/queries/logs-more.sql
@@ -1,6 +1,5 @@
-SELECT *
+SELECT {{columns}}
 FROM {{database}}.{{table}}
-WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{additionalWhereClause}}
+WHERE {{timeFilter}} AND timestamp < toDateTime64('{{cursor}}', 3) {{hostFilter}} {{facetFilters}} {{additionalWhereClause}}
 ORDER BY timestamp DESC
 LIMIT {{pageSize}}
-OFFSET {{offset}}

--- a/sql/queries/logs.sql
+++ b/sql/queries/logs.sql
@@ -1,4 +1,4 @@
-SELECT *
+SELECT {{columns}}
 FROM {{database}}.{{table}}
 WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{additionalWhereClause}}
 ORDER BY timestamp DESC


### PR DESCRIPTION
## Summary

Replace the logs table rendering with a custom virtual scrolling component that keeps DOM elements limited, loads data on demand, and provides chart scrubber synchronization.

This is the third iteration on improving the logs view, building on lessons from two prior PRs:
- **#122** — Added keyset pagination, column selection, and sticky chart, then grew a gap-row/island system for lazy loading that became complex
- **#128** — Alternative approach that didn't land

This PR takes a clean approach: a minimal ~300-line virtual table component that eliminates gap rows, progressive retry loops, and full innerHTML re-renders entirely. The virtual scroll *is* the loading mechanism — rows are fetched on demand as they scroll into view.

**Key changes:**
- **New `VirtualTable` component** (`js/virtual-table.js`, 322 lines) — zero-dependency virtual scrolling table with fixed row height, sparse page cache, async data loading, and placeholder rows
- **Rewritten logs view** (`js/logs.js`) — uses VirtualTable with a `getData` callback that maps row indices to ClickHouse keyset pagination queries
- **Chart scrubber sync** — `onVisibleRangeChange` callback updates the chart crosshair as the user scrolls through logs
- **Jump to timestamp** — chart hover/click loads data at any point in the time range via `logs-at.sql`
- **Keyset pagination** (#84) — cursor-based pagination for consistent ordering
- **Column selection** (#87) — pin/unpin columns in the logs table
- **Sticky chart** (#66) — chart stays visible while scrolling logs
- **Chart drawing extraction** — `js/chart-draw.js` extracted from `chart.js` to stay under max-lines lint rule

**What this eliminates vs #122:**
- Gap rows / island management / progressive retry loops
- Full innerHTML re-rendering on each data load
- Complex scroll threshold detection

Supersedes #122 and #128. Closes #66, #84, #87.

## Testing Done

- 777 automated tests pass
- 95.32% code coverage (above 95% threshold)
- Lint passes with zero errors
- VirtualTable has 16 dedicated unit tests covering row calculation, caching, scroll-to-row, visible range callbacks, and placeholder rendering

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)