### PR TITLE
fix: apply column filters to high-cardinality breakdown refinement queries

### DIFF
--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -277,6 +277,7 @@ async function buildApproxTopSql(b, params, aggs, dedupClause, timeFilter, hostF
     sampleClause: params.sampleClause || '',
     timeFilter,
     hostFilter,
+    facetFilters: params.facetFilters,
     extra: params.extra,
     additionalWhereClause: dedupClause,
     topN: String(state.topN),

--- a/sql/queries/breakdown-approx-top.sql
+++ b/sql/queries/breakdown-approx-top.sql
@@ -4,13 +4,13 @@ WITH top_dims AS (
     SELECT arrayJoin(approx_top_count({{topN}})({{col}})) AS pair
     FROM {{database}}.{{table}}
     {{sampleClause}}
-    WHERE {{timeFilter}} {{hostFilter}} {{extra}} {{additionalWhereClause}}
+    WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{extra}} {{additionalWhereClause}}
   )
 )
 SELECT {{col}} AS dim, {{aggTotal}} AS cnt, {{aggOk}} AS cnt_ok,
   {{agg4xx}} AS cnt_4xx, {{agg5xx}} AS cnt_5xx{{summaryCol}}
 FROM {{database}}.{{table}}
-WHERE {{timeFilter}} {{hostFilter}} {{extra}} {{additionalWhereClause}}
+WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{extra}} {{additionalWhereClause}}
   AND {{col}} IN (SELECT dim FROM top_dims)
 GROUP BY dim
 ORDER BY cnt DESC
@@ -19,4 +19,4 @@ UNION ALL
 SELECT '' AS dim, {{aggTotal}} AS cnt, {{aggOk}} AS cnt_ok,
   {{agg4xx}} AS cnt_4xx, {{agg5xx}} AS cnt_5xx{{summaryCol}}
 FROM {{database}}.{{table}}
-WHERE {{timeFilter}} {{hostFilter}} {{extra}} {{additionalWhereClause}}
+WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{extra}} {{additionalWhereClause}}


### PR DESCRIPTION
## Summary
- `buildApproxTopSql()` was not passing `facetFilters` to the SQL template, and `breakdown-approx-top.sql` had no `{{facetFilters}}` placeholder
- Column filters (e.g. `status=429`) were dropped during the refinement pass for high-cardinality breakdowns (hosts, user-agents, URLs, IPs, referers, redirect locations), causing unfiltered counts to overwrite the initially correct sampled numbers
- Added `facetFilters: params.facetFilters` to the template params and `{{facetFilters}}` to all three WHERE clauses in the SQL template

## Testing Done
- Added test verifying facet filters appear in approx-top SQL output
- `npm run lint` passes
- `npm test` passes (772/772 tests, 95.82% coverage)
- Verified via direct ClickHouse queries that dashboard was showing unfiltered host counts (~17.3M for admin.hlx.page) instead of 429-filtered counts (~10.3M)

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)