### PR TITLE
Lambda: split Function Name into name (no version) and Function Versi…

### DIFF
--- a/js/breakdowns/definitions-lambda.js
+++ b/js/breakdowns/definitions-lambda.js
@@ -28,7 +28,12 @@ export const lambdaBreakdowns = [
   },
   {
     id: 'breakdown-function-name',
-    col: '`function_name`',
+    col: "replaceRegexpOne(`function_name`, '/[^/]+$', '')",
+    highCardinality: true,
+  },
+  {
+    id: 'breakdown-function-version',
+    col: "arrayElement(splitByChar('/', `function_name`), -1)",
     highCardinality: true,
   },
   {

--- a/js/breakdowns/definitions-lambda.test.js
+++ b/js/breakdowns/definitions-lambda.test.js
@@ -13,14 +13,15 @@ import { assert } from 'chai';
 import { lambdaBreakdowns } from './definitions-lambda.js';
 
 describe('lambdaBreakdowns', () => {
-  it('has nine facets', () => {
-    assert.strictEqual(lambdaBreakdowns.length, 9);
+  it('has ten facets', () => {
+    assert.strictEqual(lambdaBreakdowns.length, 10);
   });
 
   it('each facet has id and col (string or function)', () => {
     const ids = [
       'breakdown-level',
       'breakdown-function-name',
+      'breakdown-function-version',
       'breakdown-app-name',
       'breakdown-subsystem',
       'breakdown-log-group',
@@ -42,10 +43,20 @@ describe('lambdaBreakdowns', () => {
     assert.strictEqual(levelFacet.summaryLabel, 'error rate');
   });
 
-  it('function_name and log_group are high cardinality', () => {
+  it('function_name strips version and function_version is last segment', () => {
     const fn = lambdaBreakdowns.find((b) => b.id === 'breakdown-function-name');
-    const lg = lambdaBreakdowns.find((b) => b.id === 'breakdown-log-group');
+    const fv = lambdaBreakdowns.find((b) => b.id === 'breakdown-function-version');
+    assert.ok(fn);
+    assert.ok(fv);
+    assert.include(fn.col, 'replaceRegexpOne');
+    assert.include(fn.col, "'/[^/]+$'");
+    assert.include(fv.col, "arrayElement(splitByChar('/', `function_name`), -1)");
     assert.strictEqual(fn.highCardinality, true);
+    assert.strictEqual(fv.highCardinality, true);
+  });
+
+  it('log_group is high cardinality', () => {
+    const lg = lambdaBreakdowns.find((b) => b.id === 'breakdown-log-group');
     assert.strictEqual(lg.highCardinality, true);
   });
 

--- a/js/breakdowns/index.test.js
+++ b/js/breakdowns/index.test.js
@@ -122,7 +122,7 @@ describe('getBreakdowns', () => {
     state.breakdowns = lambdaBreakdowns;
     const result = getBreakdowns();
     assert.strictEqual(result, lambdaBreakdowns);
-    assert.strictEqual(result.length, 9);
+    assert.strictEqual(result.length, 10);
   });
 });
 

--- a/lambda.html
+++ b/lambda.html
@@ -95,6 +95,10 @@
           <h3>Function Name</h3>
           <div class="loading"><div class="spinner"></div>Loading...</div>
         </div>
+        <div class="breakdown-card" id="breakdown-function-version">
+          <h3>Function Version</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
         <div class="breakdown-card" id="breakdown-app-name">
           <h3>App Name</h3>
           <div class="loading"><div class="spinner"></div>Loading...</div>


### PR DESCRIPTION
…on facet

As mentioned in #111

- Function Name: strip version suffix with replaceRegexpOne(..., '/[^/]+$', '') e.g. /helix3/admin/v12 -> /helix3/admin
- Function Version: new facet with arrayElement(splitByChar(...), -1) -> v12
- Add breakdown-function-version card in lambda.html
- Tests: 10 facets, replaceRegexpOne for name strip, arrayElement for version

## Summary
<img width="830" height="257" alt="Screenshot 2026-02-13 at 3 16 23 PM" src="https://github.com/user-attachments/assets/42910ed8-116f-4e3e-8c93-09a735cfd84a" />

## Testing Done
<!-- How did you verify this works? -->

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)
