### PR TITLE
Cancel stale ClickHouse queries server-side on navigation

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -13,6 +13,41 @@ import { CLICKHOUSE_URL } from './config.js';
 import { TIME_RANGES } from './constants.js';
 import { state } from './state.js';
 
+// Maps AbortSignals to query group prefixes for server-side cancellation
+const signalQueryGroups = new WeakMap();
+const queryState = { counter: 0 };
+
+/**
+ * Associate an AbortSignal with a query group prefix.
+ * All queries using this signal will get a query_id with this prefix.
+ */
+export function setSignalQueryGroup(signal, groupPrefix) {
+  signalQueryGroups.set(signal, groupPrefix);
+}
+
+/**
+ * Get the query group prefix associated with a signal, if any.
+ */
+export function getSignalQueryGroup(signal) {
+  return signalQueryGroups.get(signal);
+}
+
+/**
+ * Cancel running queries on the ClickHouse server matching a group prefix.
+ * Fire-and-forget — errors are silently ignored.
+ */
+export function killQueryGroup(prefix) {
+  if (!prefix || !state.credentials?.user) return;
+  const safePfx = prefix.replace(/'/g, "\\'");
+  fetch(CLICKHOUSE_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${btoa(`${state.credentials.user}:${state.credentials.password}`)}`,
+    },
+    body: `KILL QUERY WHERE query_id LIKE '${safePfx}-%' ASYNC`,
+  }).catch(() => { /* ignore */ });
+}
+
 // Force refresh state - set by dashboard when refresh button is clicked
 const refreshState = { force: false };
 
@@ -212,6 +247,15 @@ export async function query(
     params.set('use_query_cache', '1');
     params.set('query_cache_ttl', cacheTtl.toString());
     params.set('query_cache_nondeterministic_function_handling', 'save');
+  }
+
+  // Tag query with a server-side query_id for cancellation support
+  if (signal) {
+    const groupPrefix = signalQueryGroups.get(signal);
+    if (groupPrefix) {
+      queryState.counter += 1;
+      params.set('query_id', `${groupPrefix}-${queryState.counter}`);
+    }
   }
 
   // Normalize SQL whitespace for consistent cache keys

--- a/js/breakdowns/approx-top.test.js
+++ b/js/breakdowns/approx-top.test.js
@@ -16,6 +16,11 @@ import { DEFAULT_TOP_N } from '../constants.js';
 import { startRequestContext } from '../request-context.js';
 import { setQueryTimestamp } from '../time.js';
 
+// Filter helper: extract only ClickHouse query POSTs (exclude KILL QUERY and other control calls)
+function queryPosts(calls) {
+  return calls.filter((c) => c.options?.method === 'POST' && c.options?.body?.includes('FORMAT JSON'));
+}
+
 // SQL templates used by loadBreakdown
 const BREAKDOWN_SQL_TEMPLATE = 'SELECT\n  {{col}} as dim,\n  {{aggTotal}} as cnt,\n  {{aggOk}} as cnt_ok,\n  {{agg4xx}} as cnt_4xx,\n  {{agg5xx}} as cnt_5xx{{summaryCol}}\nFROM {{database}}.{{table}}\n{{sampleClause}}\nWHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{extra}} {{additionalWhereClause}}\nGROUP BY dim WITH TOTALS\nORDER BY {{orderBy}}\nLIMIT {{topN}}\n';
 
@@ -112,7 +117,7 @@ describe('approx_top_count refinement for high-cardinality breakdowns', () => {
     const ctx = startRequestContext('facets');
     await loadBreakdown(b, '1=1', '', ctx, { sampleClause: '', multiplier: 1 });
 
-    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    const queryCalls = queryPosts(calls);
     assert.isAbove(queryCalls.length, 0, 'should send query');
     const queryBody = queryCalls[0].options.body;
     assert.include(queryBody, 'approx_top_count', 'should use approx_top_count');
@@ -154,7 +159,7 @@ describe('approx_top_count refinement for high-cardinality breakdowns', () => {
     const ctx = startRequestContext('facets');
     await loadBreakdown(b, '1=1', '', ctx, { sampleClause: '', multiplier: 1 });
 
-    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    const queryCalls = queryPosts(calls);
     assert.isAbove(queryCalls.length, 0, 'should send query');
     const queryBody = queryCalls[0].options.body;
     assert.notInclude(queryBody, 'approx_top_count', 'should not use approx_top_count');
@@ -169,7 +174,7 @@ describe('approx_top_count refinement for high-cardinality breakdowns', () => {
     const ctx = startRequestContext('facets');
     await loadBreakdown(b, '1=1', '', ctx, { sampleClause: 'SAMPLE 0.01', multiplier: 100 });
 
-    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    const queryCalls = queryPosts(calls);
     assert.isAbove(queryCalls.length, 0, 'should send query');
     const queryBody = queryCalls[0].options.body;
     assert.notInclude(queryBody, 'approx_top_count', 'should not use approx_top_count');
@@ -193,7 +198,7 @@ describe('approx_top_count refinement for high-cardinality breakdowns', () => {
 
     await loadAllBreakdownsRefined(startRequestContext('facets'));
 
-    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    const queryCalls = queryPosts(calls);
     assert.isAbove(queryCalls.length, 0, 'should send query');
     const queryBody = queryCalls[0].options.body;
     assert.include(queryBody, 'approx_top_count', 'should use approx_top_count');

--- a/js/breakdowns/index.js
+++ b/js/breakdowns/index.js
@@ -11,7 +11,9 @@
  */
 import { DATABASE } from '../config.js';
 import { state } from '../state.js';
-import { query, getQueryErrorDetails, isAbortError } from '../api.js';
+import {
+  query, getQueryErrorDetails, isAbortError, setSignalQueryGroup, getSignalQueryGroup,
+} from '../api.js';
 import {
   startRequestContext, getRequestContext, isRequestCurrent, mergeAbortSignals,
 } from '../request-context.js';
@@ -233,6 +235,13 @@ function createRequestStatus(requestContext) {
   const globalContext = getRequestContext('facets');
   const activeContext = requestContext || globalContext;
   const combinedSignal = mergeAbortSignals([activeContext.signal, globalContext.signal]);
+  // AbortSignal.any() returns a new native signal that loses WeakMap associations,
+  // so explicitly propagate the query group to the merged signal
+  const group = getSignalQueryGroup(activeContext.signal)
+    || getSignalQueryGroup(globalContext.signal);
+  if (group && combinedSignal) {
+    setSignalQueryGroup(combinedSignal, group);
+  }
   const isCurrent = () => isRequestCurrent(activeContext.requestId, activeContext.scope)
     && isRequestCurrent(globalContext.requestId, globalContext.scope);
   return { isCurrent, signal: combinedSignal };

--- a/js/breakdowns/index.test.js
+++ b/js/breakdowns/index.test.js
@@ -41,6 +41,10 @@ const BUCKETED_SQL_TEMPLATE = 'SELECT\n  {{bucketExpr}} as dim,\n  sum(agg_total
 
 // Approx-top template: like BREAKDOWN_SQL_TEMPLATE but without {{orderBy}} (hardcodes cnt DESC)
 const APPROX_TOP_SQL_TEMPLATE = BREAKDOWN_SQL_TEMPLATE.replace('{{orderBy}}', 'cnt DESC');
+
+// Filter helper: extract only ClickHouse data query POSTs (exclude KILL QUERY calls)
+const queryPosts = (calls) => calls.filter((c) => c.options?.method === 'POST' && c.options?.body?.includes('FORMAT JSON'));
+
 // Create a mock fetch that returns SQL templates and ClickHouse query results.
 function createMockFetch(queryResponse = {
   data: [{
@@ -53,7 +57,6 @@ function createMockFetch(queryResponse = {
   const calls = [];
   const mockFetch = async (url, options) => {
     calls.push({ url, options });
-    // SQL template requests (GET)
     if (typeof url === 'string' && url.endsWith('.sql')) {
       let template = BREAKDOWN_SQL_TEMPLATE;
       if (url.includes('breakdown-facet.sql')) template = FACET_SQL_TEMPLATE;
@@ -61,12 +64,8 @@ function createMockFetch(queryResponse = {
       else if (url.includes('breakdown-approx-top.sql')) template = APPROX_TOP_SQL_TEMPLATE;
       return { ok: true, text: async () => template };
     }
-    // ClickHouse API POST requests
     if (options && options.method === 'POST') {
-      return {
-        ok: true,
-        json: async () => ({ ...queryResponse, networkTime: 42 }),
-      };
+      return { ok: true, json: async () => ({ ...queryResponse, networkTime: 42 }) };
     }
     return { ok: false, status: 404 };
   };
@@ -371,7 +370,7 @@ describe('loadBreakdown (facet table path)', () => {
     assert.ok(sqlCalls.some((c) => c.url.includes('breakdown-facet.sql')), 'should use facet template');
 
     // Should have posted a query
-    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    const queryCalls = queryPosts(calls);
     assert.isAbove(queryCalls.length, 0, 'should execute query');
 
     // Card should contain rendered table content
@@ -476,7 +475,7 @@ describe('loadBreakdown (raw table path)', () => {
     await loadBreakdown(b, '1=1', '', ctx);
 
     // Verify query uses raw table (cdn_requests_v2, not cdn_facet_minutes)
-    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    const queryCalls = queryPosts(calls);
     assert.isAbove(queryCalls.length, 0, 'should send query');
     const queryBody = queryCalls[0].options.body;
     assert.include(queryBody, 'cdn_requests_v2', 'should query raw table');
@@ -493,7 +492,7 @@ describe('loadBreakdown (raw table path)', () => {
     const ctx = startRequestContext('facets');
     await loadBreakdown(b, '1=1', '', ctx);
 
-    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    const queryCalls = queryPosts(calls);
     assert.isAbove(queryCalls.length, 0, 'should send query');
     const queryBody = queryCalls[0].options.body;
     assert.include(queryBody, 'cdn_requests_v2', 'should query raw table for high-cardinality');
@@ -511,7 +510,7 @@ describe('loadBreakdown (raw table path)', () => {
     const ctx = startRequestContext('facets');
     await loadBreakdown(b, '1=1', '', ctx);
 
-    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    const queryCalls = queryPosts(calls);
     assert.isAbove(queryCalls.length, 0, 'should send query');
     const queryBody = queryCalls[0].options.body;
     assert.include(queryBody, 'cdn_requests_v2', 'should query raw table');
@@ -530,7 +529,7 @@ describe('loadBreakdown (raw table path)', () => {
     await loadBreakdown(b, '1=1', '', ctx);
 
     // Verify it used raw table (bytes mode disables facet table)
-    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    const queryCalls = queryPosts(calls);
     assert.isAbove(queryCalls.length, 0);
     const queryBody = queryCalls[0].options.body;
     assert.include(queryBody, 'cdn_requests_v2', 'should query raw table in bytes mode');
@@ -781,7 +780,7 @@ describe('loadBreakdown (custom aggregations)', () => {
     const ctx = startRequestContext('facets');
     await loadBreakdown(b, '1=1', '', ctx);
 
-    const queryCalls = calls.filter((c) => c.options?.method === 'POST');
+    const queryCalls = queryPosts(calls);
     assert.isAbove(queryCalls.length, 0);
     const queryBody = queryCalls[0].options.body;
     assert.include(queryBody, "countIf(`level` = 'INFO')", 'should use custom aggOk');
@@ -957,7 +956,7 @@ describe('gradual refinement', () => {
     window.fetch = mockFetch;
     const ctx = startRequestContext('facets');
     await loadBreakdown({ id: refId, col: '`source`' }, '1=1', '', ctx, { sampleClause: '', multiplier: 1 });
-    const { body } = calls.filter((c) => c.options?.method === 'POST')[0].options;
+    const { body } = queryPosts(calls)[0].options;
     assert.notInclude(body, 'SAMPLE');
     assert.include(body, 'sample_hash >= 0');
   });
@@ -967,7 +966,7 @@ describe('gradual refinement', () => {
     window.fetch = mockFetch;
     const ctx = startRequestContext('facets');
     await loadBreakdown({ id: refId, col: '`source`' }, '1=1', '', ctx, { sampleClause: 'SAMPLE 0.5', multiplier: 2 });
-    const { body } = calls.filter((c) => c.options?.method === 'POST')[0].options;
+    const { body } = queryPosts(calls)[0].options;
     assert.include(body, 'SAMPLE 0.5');
     assert.notInclude(body, 'sample_hash');
   });
@@ -977,7 +976,7 @@ describe('gradual refinement', () => {
     const { fetch: mockFetch, calls } = createMockFetch();
     window.fetch = mockFetch;
     await loadAllBreakdownsRefined(startRequestContext('facets'));
-    const { body } = calls.filter((c) => c.options?.method === 'POST')[0].options;
+    const { body } = queryPosts(calls)[0].options;
     assert.include(body, 'sample_hash >= 0');
   });
 
@@ -986,7 +985,7 @@ describe('gradual refinement', () => {
     const { fetch: mockFetch, calls } = createMockFetch();
     window.fetch = mockFetch;
     await loadAllBreakdownsRefined(startRequestContext('facets'));
-    assert.strictEqual(calls.filter((c) => c.options?.method === 'POST').length, 0);
+    assert.strictEqual(queryPosts(calls).length, 0);
   });
 
   it('includes facet filters in approx-top SQL', async () => {
@@ -995,6 +994,6 @@ describe('gradual refinement', () => {
     window.fetch = mockFetch;
     await loadBreakdown({ id: refId, col: '`request.host`', highCardinality: true }, '1=1', '', startRequestContext('facets'), { sampleClause: '', multiplier: 1 });
     assert.ok(calls.some((c) => c.url?.includes('breakdown-approx-top.sql')), 'should use approx-top template');
-    assert.include(calls.filter((c) => c.options?.method === 'POST')[0].options.body, "`request.method` = 'GET'", 'approx-top SQL should include facet filter');
+    assert.include(queryPosts(calls)[0].options.body, "`request.method` = 'GET'", 'approx-top SQL should include facet filter');
   });
 });

--- a/js/request-context.js
+++ b/js/request-context.js
@@ -10,12 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
+import {
+  setSignalQueryGroup, getSignalQueryGroup, killQueryGroup,
+} from './api.js';
+
 const contexts = new Map();
 
 function getContext(scope) {
   const key = scope || 'dashboard';
   if (!contexts.has(key)) {
-    contexts.set(key, { requestId: 0, controller: null });
+    contexts.set(key, { requestId: 0, controller: null, queryGroupPrefix: null });
   }
   return contexts.get(key);
 }
@@ -25,8 +29,14 @@ export function startRequestContext(scope) {
   if (ctx.controller) {
     ctx.controller.abort();
   }
+  // Cancel any still-running server-side queries from the previous context
+  if (ctx.queryGroupPrefix) {
+    killQueryGroup(ctx.queryGroupPrefix);
+  }
   ctx.controller = new AbortController();
   ctx.requestId += 1;
+  ctx.queryGroupPrefix = `klick-${scope || 'dashboard'}-${ctx.requestId}`;
+  setSignalQueryGroup(ctx.controller.signal, ctx.queryGroupPrefix);
   return {
     requestId: ctx.requestId,
     signal: ctx.controller.signal,
@@ -53,20 +63,31 @@ export function mergeAbortSignals(signals) {
   if (activeSignals.length === 0) return undefined;
   if (activeSignals.length === 1) return activeSignals[0];
 
+  let merged;
   if (typeof AbortSignal.any === 'function') {
-    return AbortSignal.any(activeSignals);
-  }
+    merged = AbortSignal.any(activeSignals);
+  } else {
+    const controller = new AbortController();
+    const onAbort = () => controller.abort();
 
-  const controller = new AbortController();
-  const onAbort = () => controller.abort();
-
-  for (const signal of activeSignals) {
-    if (signal.aborted) {
-      controller.abort();
-      return controller.signal;
+    for (const signal of activeSignals) {
+      if (signal.aborted) {
+        controller.abort();
+        return controller.signal;
+      }
+      signal.addEventListener('abort', onAbort, { once: true });
     }
-    signal.addEventListener('abort', onAbort, { once: true });
+    merged = controller.signal;
   }
 
-  return controller.signal;
+  // Propagate query group from the first signal that has one
+  for (const signal of activeSignals) {
+    const group = getSignalQueryGroup(signal);
+    if (group) {
+      setSignalQueryGroup(merged, group);
+      break;
+    }
+  }
+
+  return merged;
 }

--- a/scripts/add-user.mjs
+++ b/scripts/add-user.mjs
@@ -108,6 +108,12 @@ async function main() {
       console.log(`Granted dictGet on ${DATABASE}.${dict}`);
     }
 
+    // Grant system.processes access so users can cancel their own queries (KILL QUERY)
+    const processGrantSql = `GRANT SELECT(query_id, user, query) ON system.processes TO ${newUsername}`;
+    await query(processGrantSql, adminUser, adminPassword);
+    // eslint-disable-next-line no-console
+    console.log('Granted SELECT on system.processes for query cancellation');
+
     // Apply parallel replicas and memory limit settings
     const settingsSql = [
       `ALTER USER ${newUsername} SETTINGS`,


### PR DESCRIPTION
## Summary
- When users switch time ranges (e.g., from 7-day to 15-minute view), refinement pass queries (full table scans without sampling) continued running on the ClickHouse server even after the browser aborted the fetch
- These stale queries consumed server resources and starved new queries — David observed 37s dashboard loads on a 15-minute time range because 7-day refinement queries were still running
- Each request context now tags its queries with a unique `query_id` prefix, and when a new context replaces the old one, it sends `KILL QUERY` to cancel still-running server queries

## Testing Done
- Verified `KILL QUERY` works for read-only users (tested against production ClickHouse Cloud instance)
- All 774 tests pass (`npm test`)
- Zero lint errors (`npm run lint`)
- Updated test helpers in `index.test.js` and `approx-top.test.js` to filter out `KILL QUERY` POST calls from assertions

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)