### PR TITLE
feat: auto-detect exact hostname filter for faster queries

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -110,7 +110,8 @@ header h1 {
 
   /* Hide these on mobile */
   #topN,
-  #hostSuggestions {
+  #hostSuggestions,
+  #hostFilterMode {
     display: none;
   }
 
@@ -182,6 +183,30 @@ header input[type="text"] {
 header select option {
   background: var(--card-bg);
   color: var(--text);
+}
+
+/* Host Filter Mode Badge */
+.filter-mode-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 3px;
+  white-space: nowrap;
+  margin-left: -4px;
+}
+
+.filter-mode-badge:empty {
+  display: none;
+}
+
+.filter-mode-exact {
+  background: color-mix(in srgb, var(--success) 15%, transparent);
+  color: var(--success);
+}
+
+.filter-mode-partial {
+  background: color-mix(in srgb, var(--text-secondary) 15%, transparent);
+  color: var(--text-secondary);
 }
 
 /* Active Filters */

--- a/dashboard.html
+++ b/dashboard.html
@@ -61,7 +61,7 @@
       <div class="header-right">
         <span class="kbd-control"><kbd class="kbd-hint" id="timeRangeHint">2</kbd><select id="timeRange"></select></span>
         <select id="topN"></select>
-        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by host..." list="hostSuggestions" autocomplete="off"></span>
+        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by host..." list="hostSuggestions" autocomplete="off"><span id="hostFilterMode" class="filter-mode-badge"></span></span>
         <datalist id="hostSuggestions"></datalist>
         <button id="moreBtn" class="menu-btn" title="More actions">
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">

--- a/delivery.html
+++ b/delivery.html
@@ -61,7 +61,7 @@
       <div class="header-right">
         <span class="kbd-control"><kbd class="kbd-hint" id="timeRangeHint">2</kbd><select id="timeRange"></select></span>
         <select id="topN"></select>
-        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by host..." list="hostSuggestions" autocomplete="off"></span>
+        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by host..." list="hostSuggestions" autocomplete="off"><span id="hostFilterMode" class="filter-mode-badge"></span></span>
         <datalist id="hostSuggestions"></datalist>
         <button id="moreBtn" class="menu-btn" title="More actions">
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -22,7 +22,7 @@ import {
 } from './url-state.js';
 import {
   queryTimestamp, setQueryTimestamp, clearCustomTimeRange, isCustomTimeRange,
-  getTimeFilter, getHostFilter, getSamplingConfig,
+  getTimeFilter, getHostFilter, getSamplingConfig, isExactHostname,
 } from './time.js';
 import {
   startQueryTimer, stopQueryTimer, hasVisibleUpdatingFacets, initFacetObservers,
@@ -84,6 +84,7 @@ export function initDashboard(config = {}) {
     timeRangeSelect: document.getElementById('timeRange'),
     topNSelect: document.getElementById('topN'),
     hostFilterInput: document.getElementById('hostFilter'),
+    hostFilterMode: document.getElementById('hostFilterMode'),
     refreshBtn: document.getElementById('refreshBtn'),
     logoutBtn: document.getElementById('logoutBtn'),
     viewToggleBtn: document.getElementById('viewToggleBtn'),
@@ -91,6 +92,21 @@ export function initDashboard(config = {}) {
     filtersView: document.getElementById('filtersView'),
     dashboardContent: document.getElementById('dashboardContent'),
   };
+
+  function updateHostFilterIndicator(value) {
+    const badge = elements.hostFilterMode;
+    if (!badge) return;
+    if (!value) {
+      badge.textContent = '';
+      badge.className = 'filter-mode-badge';
+      return;
+    }
+    const exact = isExactHostname(value);
+    badge.textContent = exact ? 'exact' : 'partial';
+    badge.className = exact
+      ? 'filter-mode-badge filter-mode-exact'
+      : 'filter-mode-badge filter-mode-partial';
+  }
 
   // Pass elements to modules that need them
   setElements(elements);
@@ -219,7 +235,10 @@ export function initDashboard(config = {}) {
 
   setFilterCallbacks(saveStateToURL, loadDashboard);
   setOnBeforeRestore(() => invalidateInvestigationCache());
-  setOnStateRestored(loadDashboard);
+  setOnStateRestored(() => {
+    updateHostFilterIndicator(state.hostFilter);
+    loadDashboard();
+  });
 
   // Move facets between pinned/normal/hidden sections based on state
   function reorderFacets(toggledFacetId = null) {
@@ -348,6 +367,7 @@ export function initDashboard(config = {}) {
       state.credentials = storedCredentials;
       preloadAllTemplates();
       syncUIFromState();
+      updateHostFilterIndicator(state.hostFilter);
       reorderFacets();
       showDashboard();
       updateTimeRangeHint();
@@ -381,9 +401,11 @@ export function initDashboard(config = {}) {
 
     let filterTimeout;
     elements.hostFilterInput.addEventListener('input', (e) => {
+      updateHostFilterIndicator(e.target.value);
       clearTimeout(filterTimeout);
       filterTimeout = setTimeout(() => {
         state.hostFilter = e.target.value;
+        state.hostFilterExact = isExactHostname(state.hostFilter);
         saveStateToURL();
         loadDashboard();
       }, 500);
@@ -399,6 +421,7 @@ export function initDashboard(config = {}) {
         e.preventDefault();
         clearTimeout(filterTimeout);
         state.hostFilter = e.target.value;
+        state.hostFilterExact = isExactHostname(state.hostFilter);
         saveStateToURL();
         loadDashboard();
         e.target.blur();
@@ -407,6 +430,8 @@ export function initDashboard(config = {}) {
         clearTimeout(filterTimeout);
         e.target.value = hostFilterOriginalValue;
         state.hostFilter = hostFilterOriginalValue;
+        state.hostFilterExact = isExactHostname(state.hostFilter);
+        updateHostFilterIndicator(hostFilterOriginalValue);
         e.target.blur();
       }
     });
@@ -417,6 +442,7 @@ export function initDashboard(config = {}) {
       try {
         preloadAllTemplates();
         syncUIFromState();
+        updateHostFilterIndicator(state.hostFilter);
         reorderFacets();
         showDashboard();
         updateTimeRangeHint();

--- a/js/state.js
+++ b/js/state.js
@@ -40,6 +40,7 @@ export const state = {
   tableName: 'cdn_requests_v2', // Table to query (e.g. lambda_logs for Lambda dashboard)
   timeSeriesTemplate: 'time-series', // SQL template name for chart (e.g. time-series-lambda)
   aggregations: null, // Optional { aggTotal, aggOk, agg4xx, agg5xx } for non-CDN tables
+  hostFilterExact: false, // Whether hostFilter is an exact hostname (auto-detected)
   hostFilterColumn: null, // Optional column for header filter (e.g. function_name for lambda)
   breakdowns: null, // Optional override breakdown list (e.g. lambda facets)
 };

--- a/js/time.js
+++ b/js/time.js
@@ -205,11 +205,24 @@ export function getTimeFilter() {
   return `toStartOfMinute(timestamp) BETWEEN toStartOfMinute(toDateTime('${startIso}')) AND toStartOfMinute(toDateTime('${endIso}'))`;
 }
 
+export function isExactHostname(value) {
+  if (!value) return false;
+  if (!value.includes('.')) return false;
+  if (value.endsWith('.')) return false;
+  return /^[a-z0-9.-]+$/i.test(value);
+}
+
 export function getHostFilter() {
   if (!state.hostFilter) return '';
   const escaped = state.hostFilter.replace(/'/g, "\\'");
   if (state.hostFilterColumn) {
+    if (state.hostFilterExact) {
+      return `AND \`${state.hostFilterColumn}\` = '${escaped}'`;
+    }
     return `AND \`${state.hostFilterColumn}\` LIKE '%${escaped}%'`;
+  }
+  if (state.hostFilterExact) {
+    return `AND (\`request.host\` = '${escaped}' OR \`request.headers.x_forwarded_host\` LIKE '%${escaped}%')`;
   }
   return `AND (\`request.host\` LIKE '%${escaped}%' OR \`request.headers.x_forwarded_host\` LIKE '%${escaped}%')`;
 }

--- a/js/time.test.js
+++ b/js/time.test.js
@@ -16,7 +16,7 @@ import {
   isCustomTimeRange, getCustomTimeRange, customTimeRange,
   getTimeFilter, getTimeBucket, getTimeBucketStep, getPeriodMs,
   getInterval, getTimeRangeBounds, getTimeRangeStart, getTimeRangeEnd,
-  getTable, getHostFilter,
+  getTable, getHostFilter, isExactHostname,
   getSamplingConfig, getFacetTimeFilter, zoomOut,
 } from './time.js';
 
@@ -24,6 +24,7 @@ beforeEach(() => {
   clearCustomTimeRange();
   state.timeRange = '1h';
   state.hostFilter = '';
+  state.hostFilterExact = false;
   state.hostFilterColumn = null;
   state.tableName = null;
   setQueryTimestamp(new Date('2026-01-20T12:34:56Z'));
@@ -90,27 +91,80 @@ describe('getTable', () => {
   });
 });
 
+describe('isExactHostname', () => {
+  it('returns true for valid hostnames', () => {
+    assert.isTrue(isExactHostname('example.com'));
+    assert.isTrue(isExactHostname('www.adobe.com'));
+    assert.isTrue(isExactHostname('main--site--org.aem.live'));
+    assert.isTrue(isExactHostname('sub.domain.example.co.uk'));
+  });
+
+  it('returns false for partial patterns', () => {
+    assert.isFalse(isExactHostname('adobe'));
+    assert.isFalse(isExactHostname(''));
+    assert.isFalse(isExactHostname(null));
+    assert.isFalse(isExactHostname(undefined));
+  });
+
+  it('returns false for wildcards', () => {
+    assert.isFalse(isExactHostname('*.adobe.com'));
+  });
+
+  it('returns false for trailing dot', () => {
+    assert.isFalse(isExactHostname('blog.'));
+  });
+
+  it('returns false for values with spaces', () => {
+    assert.isFalse(isExactHostname('my site.com'));
+  });
+
+  it('returns false for values with special characters', () => {
+    assert.isFalse(isExactHostname('site.com/path'));
+    assert.isFalse(isExactHostname('site.com?q=1'));
+  });
+});
+
 describe('getHostFilter', () => {
   it('returns empty string when no hostFilter', () => {
     state.hostFilter = '';
     assert.strictEqual(getHostFilter(), '');
   });
 
-  it('returns CDN host filter when hostFilterColumn not set', () => {
+  it('returns LIKE filter for partial hostnames (no dot)', () => {
     state.hostFilter = 'example';
+    state.hostFilterExact = false;
     state.hostFilterColumn = null;
     const result = getHostFilter();
+    assert.include(result, "LIKE '%example%'");
     assert.include(result, 'request.host');
     assert.include(result, 'x_forwarded_host');
-    assert.include(result, 'example');
   });
 
-  it('returns column filter when hostFilterColumn is set', () => {
+  it('returns exact = on request.host and LIKE on x_forwarded_host for exact hostnames', () => {
+    state.hostFilter = 'example.com';
+    state.hostFilterExact = true;
+    state.hostFilterColumn = null;
+    const result = getHostFilter();
+    assert.include(result, "`request.host` = 'example.com'");
+    assert.include(result, "`request.headers.x_forwarded_host` LIKE '%example.com%'");
+  });
+
+  it('returns LIKE column filter when hostFilterColumn is set and partial', () => {
     state.hostFilter = 'myFunc';
+    state.hostFilterExact = false;
     state.hostFilterColumn = 'function_name';
     const result = getHostFilter();
     assert.include(result, '`function_name`');
-    assert.include(result, 'myFunc');
+    assert.include(result, "LIKE '%myFunc%'");
+  });
+
+  it('returns exact = column filter when hostFilterColumn is set and exact', () => {
+    state.hostFilter = 'my.function';
+    state.hostFilterExact = true;
+    state.hostFilterColumn = 'function_name';
+    const result = getHostFilter();
+    assert.include(result, "`function_name` = 'my.function'");
+    assert.notInclude(result, 'LIKE');
   });
 
   it('escapes single quotes in hostFilter', () => {

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -12,6 +12,7 @@
 import { state, loadFacetPrefs } from './state.js';
 import {
   queryTimestamp, setQueryTimestamp, customTimeRange, setCustomTimeRange, clearCustomTimeRange,
+  isExactHostname,
 } from './time.js';
 import { renderActiveFilters } from './filters.js';
 import {
@@ -49,6 +50,7 @@ export function setUrlStateElements(els) {
 function addBasicParams(params) {
   if (state.timeRange !== DEFAULT_TIME_RANGE) params.set('t', state.timeRange);
   if (state.hostFilter) params.set('host', state.hostFilter);
+  if (state.hostFilterExact) params.set('domainExact', '1');
   if (state.topN !== DEFAULT_TOP_N) params.set('n', state.topN);
   if (state.showLogs) params.set('view', 'logs');
   if (state.title) params.set('title', state.title);
@@ -117,7 +119,11 @@ function loadBasicState(params) {
   if (params.has('t') && TIME_RANGES[params.get('t')]) {
     state.timeRange = params.get('t');
   }
-  if (params.has('host')) state.hostFilter = params.get('host');
+  if (params.has('host')) {
+    state.hostFilter = params.get('host');
+    state.hostFilterExact = params.get('domainExact') === '1'
+      || isExactHostname(state.hostFilter);
+  }
   if (params.has('n')) {
     const n = parseInt(params.get('n'), 10);
     if (TOP_N_OPTIONS.includes(n)) state.topN = n;

--- a/js/url-state.test.js
+++ b/js/url-state.test.js
@@ -25,6 +25,7 @@ const ORIGINAL_PATH = window.location.pathname;
 function resetState() {
   state.timeRange = DEFAULT_TIME_RANGE;
   state.hostFilter = '';
+  state.hostFilterExact = false;
   state.topN = DEFAULT_TOP_N;
   state.filters = [];
   state.showLogs = false;
@@ -88,22 +89,32 @@ describe('loadStateFromURL', () => {
   });
 
   describe('host filter', () => {
-    it('loads host filter', () => {
+    it('loads host filter and detects exact hostname', () => {
       setURL({ host: 'example.com' });
       loadStateFromURL();
       assert.strictEqual(state.hostFilter, 'example.com');
+      assert.isTrue(state.hostFilterExact);
     });
 
-    it('loads AEM domain', () => {
+    it('loads AEM domain as exact', () => {
       setURL({ host: 'main--site--org.aem.live' });
       loadStateFromURL();
       assert.strictEqual(state.hostFilter, 'main--site--org.aem.live');
+      assert.isTrue(state.hostFilterExact);
+    });
+
+    it('loads partial filter as non-exact', () => {
+      setURL({ host: 'adobe' });
+      loadStateFromURL();
+      assert.strictEqual(state.hostFilter, 'adobe');
+      assert.isFalse(state.hostFilterExact);
     });
 
     it('keeps empty when host is absent', () => {
       setURL({});
       loadStateFromURL();
       assert.strictEqual(state.hostFilter, '');
+      assert.isFalse(state.hostFilterExact);
     });
   });
 
@@ -427,6 +438,22 @@ describe('saveStateToURL', () => {
     saveStateToURL();
     const params = new URLSearchParams(window.location.search);
     assert.strictEqual(params.get('host'), 'example.com');
+  });
+
+  it('encodes domainExact when hostFilterExact is true', () => {
+    state.hostFilter = 'example.com';
+    state.hostFilterExact = true;
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.strictEqual(params.get('domainExact'), '1');
+  });
+
+  it('omits domainExact when hostFilterExact is false', () => {
+    state.hostFilter = 'example';
+    state.hostFilterExact = false;
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.isFalse(params.has('domainExact'));
   });
 
   it('encodes non-default topN', () => {

--- a/lambda.html
+++ b/lambda.html
@@ -61,7 +61,7 @@
       <div class="header-right">
         <span class="kbd-control"><kbd class="kbd-hint" id="timeRangeHint">2</kbd><select id="timeRange"></select></span>
         <select id="topN"></select>
-        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by function..." list="hostSuggestions" autocomplete="off"></span>
+        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by function..." list="hostSuggestions" autocomplete="off"><span id="hostFilterMode" class="filter-mode-badge"></span></span>
         <datalist id="hostSuggestions"></datalist>
         <button id="moreBtn" class="menu-btn" title="More actions">
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">


### PR DESCRIPTION
## Summary
Auto-detect whether the hostname filter input is a complete hostname (e.g. `www.adobe.com`) or a partial pattern (e.g. `adobe`), and use exact `=` match on `request.host` instead of `LIKE '%…%'` when appropriate.

**Changes:**
- Added `isExactHostname()` heuristic in `js/time.js` — detects valid hostnames (has dot, valid chars, no wildcards)
- Updated `getHostFilter()` to use `=` on `request.host` for exact matches (primary key benefit), keeping `LIKE` on `x_forwarded_host` (comma-separated values)
- Added `hostFilterExact` to state and URL serialization (`domainExact=1` param)
- Added visual "exact"/"partial" indicator badge next to the filter input in all 3 dashboards
- Benchmarked: 0-45% speedup on exact match queries (best on longer time ranges)

## Testing Done
- `npm run lint` — passes (0 errors)
- `npm test` — 785/785 tests pass, 95.82% coverage
- New tests for `isExactHostname()` covering edge cases (dots, wildcards, trailing dots, etc.)
- New tests for exact-mode `getHostFilter()` SQL generation
- New tests for `domainExact` URL param round-trip
- Benchmarked against live ClickHouse: LIKE vs exact match across 4 query patterns (1h, 1h breakdown, 6h sampled, 24h sampled)

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)