### PR TITLE
fix(mobile): restore hamburger menu on mobile

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -84,6 +84,13 @@
             <line x1="15" y1="9" x2="7" y2="9"/>
           </svg>
         </button>
+        <button id="moreBtn" class="menu-btn" title="More actions">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <circle cx="10" cy="4" r="1.5"/>
+            <circle cx="10" cy="10" r="1.5"/>
+            <circle cx="10" cy="16" r="1.5"/>
+          </svg>
+        </button>
       </div>
     </header>
 
@@ -226,6 +233,22 @@
       <button class="modal-close" data-action="close-quick-links">&times;</button>
     </div>
     <iframe id="quickLinksFrame" src="index.html"></iframe>
+  </dialog>
+
+  <!-- More Actions Menu -->
+  <dialog id="moreMenu" class="dropdown-menu">
+    <button class="menu-item" id="moreViewToggleItem">
+      <span class="menu-item-label">View Logs</span>
+      <kbd class="menu-item-kbd">t</kbd>
+    </button>
+    <button class="menu-item" id="moreRefreshItem">
+      <span class="menu-item-label">Refresh</span>
+      <kbd class="menu-item-kbd">r</kbd>
+    </button>
+    <div class="menu-divider"></div>
+    <button class="menu-item" id="moreLogoutItem">
+      <span class="menu-item-label">Logout</span>
+    </button>
   </dialog>
 
   <!-- Keyboard Help Dialog -->

--- a/backend.html
+++ b/backend.html
@@ -84,6 +84,13 @@
             <line x1="15" y1="9" x2="7" y2="9"/>
           </svg>
         </button>
+        <button id="moreBtn" class="menu-btn" title="More actions">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <circle cx="10" cy="4" r="1.5"/>
+            <circle cx="10" cy="10" r="1.5"/>
+            <circle cx="10" cy="16" r="1.5"/>
+          </svg>
+        </button>
       </div>
     </header>
 
@@ -211,6 +218,22 @@
       <button class="modal-close" data-action="close-quick-links">&times;</button>
     </div>
     <iframe id="quickLinksFrame" src="index.html"></iframe>
+  </dialog>
+
+  <!-- More Actions Menu -->
+  <dialog id="moreMenu" class="dropdown-menu">
+    <button class="menu-item" id="moreViewToggleItem">
+      <span class="menu-item-label">View Logs</span>
+      <kbd class="menu-item-kbd">t</kbd>
+    </button>
+    <button class="menu-item" id="moreRefreshItem">
+      <span class="menu-item-label">Refresh</span>
+      <kbd class="menu-item-kbd">r</kbd>
+    </button>
+    <div class="menu-divider"></div>
+    <button class="menu-item" id="moreLogoutItem">
+      <span class="menu-item-label">Logout</span>
+    </button>
   </dialog>
 
   <!-- Keyboard Help Dialog -->

--- a/css/layout.css
+++ b/css/layout.css
@@ -74,6 +74,10 @@ header h1 {
   display: none;
 }
 
+#moreBtn {
+  display: none;
+}
+
 @media (max-width: 600px) {
   header h1 {
     display: none;
@@ -88,7 +92,9 @@ header h1 {
     font-size: 16px;
   }
 
-  #refreshBtn {
+  #viewToggleBtn,
+  #refreshBtn,
+  #logoutBtn {
     display: none;
   }
 
@@ -106,7 +112,7 @@ header h1 {
   #menuBtn { order: 1; }
   #hostFilter { order: 2; flex: 1; min-width: 0; width: auto; }
   #timeRange { order: 3; flex: 1; min-width: 0; width: auto; }
-  #moreBtn { order: 4; }
+  #moreBtn { order: 4; display: flex; }
 
   /* Hide these on mobile */
   #topN,

--- a/css/modals.css
+++ b/css/modals.css
@@ -365,6 +365,63 @@
   margin-bottom: 12px;
 }
 
+/* More Actions Dropdown Menu */
+#moreMenu {
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card-bg);
+  color: var(--text);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  min-width: 200px;
+  margin: 0;
+  position: fixed;
+}
+
+#moreMenu::backdrop {
+  background: transparent;
+}
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.15s;
+  text-align: left;
+}
+
+.menu-item:hover {
+  background: var(--bg);
+}
+
+.menu-item-label {
+  flex: 1;
+}
+
+.menu-item-kbd {
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.menu-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
 @media (max-width: 600px) {
   #logDetailModal {
     width: 100vw;

--- a/dashboard.html
+++ b/dashboard.html
@@ -84,6 +84,13 @@
             <line x1="15" y1="9" x2="7" y2="9"/>
           </svg>
         </button>
+        <button id="moreBtn" class="menu-btn" title="More actions">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <circle cx="10" cy="4" r="1.5"/>
+            <circle cx="10" cy="10" r="1.5"/>
+            <circle cx="10" cy="16" r="1.5"/>
+          </svg>
+        </button>
       </div>
     </header>
 
@@ -219,6 +226,22 @@
       <button class="modal-close" data-action="close-quick-links">&times;</button>
     </div>
     <iframe id="quickLinksFrame" src="index.html"></iframe>
+  </dialog>
+
+  <!-- More Actions Menu -->
+  <dialog id="moreMenu" class="dropdown-menu">
+    <button class="menu-item" id="moreViewToggleItem">
+      <span class="menu-item-label">View Logs</span>
+      <kbd class="menu-item-kbd">t</kbd>
+    </button>
+    <button class="menu-item" id="moreRefreshItem">
+      <span class="menu-item-label">Refresh</span>
+      <kbd class="menu-item-kbd">r</kbd>
+    </button>
+    <div class="menu-divider"></div>
+    <button class="menu-item" id="moreLogoutItem">
+      <span class="menu-item-label">Logout</span>
+    </button>
   </dialog>
 
   <!-- Keyboard Help Dialog -->

--- a/delivery.html
+++ b/delivery.html
@@ -84,6 +84,13 @@
             <line x1="15" y1="9" x2="7" y2="9"/>
           </svg>
         </button>
+        <button id="moreBtn" class="menu-btn" title="More actions">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <circle cx="10" cy="4" r="1.5"/>
+            <circle cx="10" cy="10" r="1.5"/>
+            <circle cx="10" cy="16" r="1.5"/>
+          </svg>
+        </button>
       </div>
     </header>
 
@@ -230,6 +237,22 @@
   </dialog>
 
   <!-- More Actions Menu -->
+  <!-- More Actions Menu -->
+  <dialog id="moreMenu" class="dropdown-menu">
+    <button class="menu-item" id="moreViewToggleItem">
+      <span class="menu-item-label">View Logs</span>
+      <kbd class="menu-item-kbd">t</kbd>
+    </button>
+    <button class="menu-item" id="moreRefreshItem">
+      <span class="menu-item-label">Refresh</span>
+      <kbd class="menu-item-kbd">r</kbd>
+    </button>
+    <div class="menu-divider"></div>
+    <button class="menu-item" id="moreLogoutItem">
+      <span class="menu-item-label">Logout</span>
+    </button>
+  </dialog>
+
   <!-- Keyboard Help Dialog -->
   <dialog id="keyboardHelp" role="dialog" aria-labelledby="keyboardHelpTitle">
     <div class="keyboard-help-content">

--- a/js/modal.js
+++ b/js/modal.js
@@ -10,7 +10,9 @@
  * governing permissions and limitations under the License.
  */
 let quickLinksModal = null;
+let moreMenu = null;
 let menuBtn = null;
+let moreBtn = null;
 
 export function openQuickLinksModal() {
   quickLinksModal.showModal();
@@ -20,9 +22,30 @@ export function closeQuickLinksModal() {
   quickLinksModal.close();
 }
 
+export function openMoreMenu() {
+  if (!moreBtn || !moreMenu) {
+    return;
+  }
+
+  // Position the menu below the button
+  const rect = moreBtn.getBoundingClientRect();
+  moreMenu.style.top = `${rect.bottom + 4}px`;
+  moreMenu.style.left = `${rect.right - 200}px`; // Align right edge with button
+
+  moreMenu.showModal();
+}
+
+export function closeMoreMenu() {
+  if (moreMenu) {
+    moreMenu.close();
+  }
+}
+
 export function initModal() {
   quickLinksModal = document.getElementById('quickLinksModal');
+  moreMenu = document.getElementById('moreMenu');
   menuBtn = document.getElementById('menuBtn');
+  moreBtn = document.getElementById('moreBtn');
 
   // Handle messages from the iframe
   window.addEventListener('message', (e) => {
@@ -53,4 +76,51 @@ export function initModal() {
   });
 
   menuBtn.addEventListener('click', openQuickLinksModal);
+
+  // More menu handling
+  if (moreBtn && moreMenu) {
+    moreBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      openMoreMenu();
+    });
+
+    // Close more menu when clicking backdrop or outside
+    moreMenu.addEventListener('click', (e) => {
+      if (e.target === moreMenu) {
+        closeMoreMenu();
+      }
+    });
+
+    // Close menu when clicking any menu item
+    moreMenu.querySelectorAll('.menu-item').forEach((item) => {
+      item.addEventListener('click', () => {
+        closeMoreMenu();
+      });
+    });
+
+    // Close more menu on Escape
+    moreMenu.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        closeMoreMenu();
+      }
+    });
+
+    // Close more menu when clicking outside
+    document.addEventListener('click', (e) => {
+      if (moreMenu.open && !moreMenu.contains(e.target) && e.target !== moreBtn) {
+        closeMoreMenu();
+      }
+    });
+
+    // Delegate menu item clicks to real header buttons
+    document.getElementById('moreViewToggleItem')?.addEventListener('click', () => {
+      document.getElementById('viewToggleBtn').click();
+    });
+    document.getElementById('moreRefreshItem')?.addEventListener('click', () => {
+      document.getElementById('refreshBtn').click();
+    });
+    document.getElementById('moreLogoutItem')?.addEventListener('click', () => {
+      document.getElementById('logoutBtn').click();
+    });
+  }
 }

--- a/lambda.html
+++ b/lambda.html
@@ -84,6 +84,13 @@
             <line x1="15" y1="9" x2="7" y2="9"/>
           </svg>
         </button>
+        <button id="moreBtn" class="menu-btn" title="More actions">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <circle cx="10" cy="4" r="1.5"/>
+            <circle cx="10" cy="10" r="1.5"/>
+            <circle cx="10" cy="16" r="1.5"/>
+          </svg>
+        </button>
       </div>
     </header>
 
@@ -177,6 +184,22 @@
       <button class="modal-close" data-action="close-quick-links">&times;</button>
     </div>
     <iframe id="quickLinksFrame" src="index.html"></iframe>
+  </dialog>
+
+  <!-- More Actions Menu -->
+  <dialog id="moreMenu" class="dropdown-menu">
+    <button class="menu-item" id="moreViewToggleItem">
+      <span class="menu-item-label">View Logs</span>
+      <kbd class="menu-item-kbd">t</kbd>
+    </button>
+    <button class="menu-item" id="moreRefreshItem">
+      <span class="menu-item-label">Refresh</span>
+      <kbd class="menu-item-kbd">r</kbd>
+    </button>
+    <div class="menu-divider"></div>
+    <button class="menu-item" id="moreLogoutItem">
+      <span class="menu-item-label">Logout</span>
+    </button>
   </dialog>
 
   <!-- Keyboard Help Dialog -->


### PR DESCRIPTION
## Summary
- On mobile (≤600px), hides the individual `viewToggleBtn`, `refreshBtn`, and `logoutBtn` icon buttons and shows a three-dot `moreBtn` hamburger instead
- Clicking `moreBtn` opens a `moreMenu` dropdown with View Logs, Refresh, and Logout items that delegate to the real hidden buttons
- On desktop (>600px), the individual icon buttons remain visible as before — no change
- Applies to all dashboard pages: dashboard, delivery, backend, admin, lambda

## Testing Done
- Verify on desktop: three icon buttons (list view, refresh, logout) visible in header, no hamburger
- Verify on mobile (≤600px): three-dot hamburger visible, clicking opens dropdown with all three actions
- Lint passes (`npm run lint` — no new errors introduced)

## Checklist
- [ ] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)