### PR TITLE
Delivery dashboard facet URL prefs and default hidden facets

### DIFF
--- a/css/facets.css
+++ b/css/facets.css
@@ -61,6 +61,13 @@
   .breakdown-table .count {
     font-size: 11px;
   }
+
+  /* Restore selection tint on mobile (base cards are borderless) */
+  .breakdown-card.preview {
+    background: rgba(59, 130, 246, 0.2);
+    border-radius: 8px;
+    padding: 12px;
+  }
 }
 
 @media (min-width: 1800px) {
@@ -86,33 +93,16 @@
   opacity: 0.7;
 }
 
-/* Preview state - show "Preview" badge when facets display selection data */
+/* Preview state — same fill/stroke as .chart-selection-overlay (time-range selection) */
 .breakdown-card.preview {
-  border-color: rgba(59, 130, 246, 0.3);
-}
-
-.breakdown-card.preview::after {
-  content: 'Preview';
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  font-size: 10px;
-  font-weight: 600;
-  color: #3b82f6;
-  background: rgba(59, 130, 246, 0.1);
-  padding: 1px 5px;
-  border-radius: 3px;
-  line-height: 1.4;
-  pointer-events: none;
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.8);
 }
 
 @media (prefers-color-scheme: dark) {
   .breakdown-card.preview {
-    border-color: rgba(59, 130, 246, 0.4);
-  }
-
-  .breakdown-card.preview::after {
-    background: rgba(59, 130, 246, 0.2);
+    background: rgba(96, 165, 250, 0.25);
+    border-color: rgba(96, 165, 250, 0.9);
   }
 }
 

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -238,9 +238,30 @@ export function initDashboard(config = {}) {
     loadLogs(dashboardContext);
   });
 
+  function applyDefaultHiddenFacets() {
+    if (!config.defaultHiddenFacets) {
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('hf')) {
+      return;
+    }
+    if (!window.location.search) {
+      state.hiddenFacets = [...config.defaultHiddenFacets];
+      return;
+    }
+    const hasCustomPrefs = localStorage.getItem(`facetPrefs_${state.title || ''}`);
+    if (!hasCustomPrefs) {
+      state.hiddenFacets = [...config.defaultHiddenFacets];
+    }
+  }
+
   setFilterCallbacks(saveStateToURL, loadDashboard);
   setOnBeforeRestore(() => invalidateInvestigationCache());
-  setOnStateRestored(loadDashboard);
+  setOnStateRestored(() => {
+    applyDefaultHiddenFacets();
+    loadDashboard();
+  });
 
   // Move facets between pinned/normal/hidden sections based on state
   function reorderFacets(toggledFacetId = null) {
@@ -301,18 +322,15 @@ export function initDashboard(config = {}) {
     }
   }
 
-  function applyDefaultHiddenFacets() {
-    if (!config.defaultHiddenFacets) {
-      return;
-    }
-    const hasCustomPrefs = localStorage.getItem(`facetPrefs_${state.title || ''}`);
-    if (!hasCustomPrefs) {
-      state.hiddenFacets = [...config.defaultHiddenFacets];
-    }
-  }
-
   // Initialize
   async function init() {
+    // Set title before loadStateFromURL → loadFacetPrefs() so the storage key matches
+    // this dashboard (e.g. facetPrefs_Delivery), not the generic facetPrefs key.
+    const initialParams = new URLSearchParams(window.location.search);
+    if (config.title && !initialParams.has('title')) {
+      state.title = config.title;
+    }
+
     loadStateFromURL();
 
     // Apply dashboard-specific configuration

--- a/js/delivery-main.js
+++ b/js/delivery-main.js
@@ -19,12 +19,17 @@ const EXCLUDED_DELIVERY_HOSTS = [
 
 const DEFAULT_HIDDEN_FACETS = [
   'breakdown-accept-encoding',
-  'breakdown-content-encoding',
-  'breakdown-content-types',
   'breakdown-cdn-version',
+  'breakdown-content-encoding',
+  'breakdown-content-length',
+  'breakdown-content-types',
   'breakdown-delivery-ratelimit-rate',
+  'breakdown-ips',
   'breakdown-location',
+  'breakdown-paths',
+  'breakdown-referers',
   'breakdown-surrogate-key',
+  'breakdown-time-elapsed',
 ];
 
 const excludedList = EXCLUDED_DELIVERY_HOSTS.map((host) => `'${host}'`).join(', ');


### PR DESCRIPTION
## Summary

This pull request fixes delivery dashboard facet visibility when opening `/delivery.html` without query parameters: the dashboard title is set before loading URL state so facet preferences use the correct per-dashboard localStorage key (`facetPrefs_Delivery` instead of generic `facetPrefs`). Bare URLs apply the configured default hidden facets; URLs with an `hf` parameter are left unchanged. History navigation runs the same default logic before reloading data.

The delivery default hidden facet list is expanded to hide paths, referrers, originating IPs, content length, and response time by default, in addition to the existing defaults.

## Testing Done

- Verified `eslint` on changed files via pre-commit hook.
- Full `npm test` / `npm run lint` not run in this environment (Playwright browser install may be required locally).

## Checklist

- [ ] Tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

Made with [Cursor](https://cursor.com)