### PR TITLE
ci: protect /cx/ subpath from main branch deploys

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,7 +27,7 @@ jobs:
           echo "${{ secrets.GCP_SA_KEY_B64 }}" | base64 -d > /tmp/gcp-key.json
           gcloud auth activate-service-account --key-file=/tmp/gcp-key.json
           gsutil -m rsync -r -d \
-            -x 'node_modules/|\.git/|\.github/|debug/|hars/|scripts/|\.claude/|\.yolo/|.*\.local\.md|\.env.*|package-lock\.json|screenshot\.png|.*\.test\.js|eslint\.config\.js|knip\.json|\.jscpd\.json|\.releaserc\.json|renovate\.json|\.gitignore|AGENTS\.md|VIEW_MIGRATION\.md|CLAUDE\.md|README\.md' \
+            -x 'node_modules/|\.git/|\.github/|debug/|hars/|scripts/|\.claude/|\.yolo/|cx/.*|.*\.local\.md|\.env.*|package-lock\.json|screenshot\.png|.*\.test\.js|eslint\.config\.js|knip\.json|\.jscpd\.json|\.releaserc\.json|renovate\.json|\.gitignore|AGENTS\.md|VIEW_MIGRATION\.md|CLAUDE\.md|README\.md' \
             . gs://klickhaus-static
           rm /tmp/gcp-key.json
 


### PR DESCRIPTION
## Summary
The main branch deploy runs `gsutil rsync -r -d . gs://klickhaus-static`, which recursively deletes anything in the bucket not present in the source. `cx-source` deploys to `gs://klickhaus-static/cx/`, so every push to `main` wipes it out — this is why `klickhaus.aemstatus.net/cx/` has been returning 404s.

- Add `cx/.*` to the rsync `-x` exclusion pattern. `gsutil rsync -x` protects matching paths from both copy and delete, so main's deploys will now leave the `/cx/` subpath untouched.
- `cx-source` still needs to be re-deployed once (via `workflow_dispatch` on the `static.yml` workflow from the `cx-source` branch) to restore the missing content; this PR only prevents future deletions.

## Testing Done
- Verified via `gsutil ls gs://klickhaus-static/cx/` that the directory is currently empty, matching the 404 symptom.
- Confirmed the last successful `cx-source` deploy ran on 2026-03-17 (workflow run `23196917823`), and multiple `main` deploys have run since — each one executing `rsync -r -d` against the bucket root.

## Checklist
- [ ] Tests pass (`npm test`) — n/a, CI-only change
- [ ] Lint passes (`npm run lint`) — n/a, CI-only change
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)