### PR TITLE
ci: invalidate CDN cache after main GCS deploys

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,7 +29,17 @@ jobs:
           gsutil -m rsync -r -d \
             -x 'node_modules/|\.git/|\.github/|debug/|hars/|scripts/|\.claude/|\.yolo/|cx/.*|.*\.local\.md|\.env.*|package-lock\.json|screenshot\.png|.*\.test\.js|eslint\.config\.js|knip\.json|\.jscpd\.json|\.releaserc\.json|renovate\.json|\.gitignore|AGENTS\.md|VIEW_MIGRATION\.md|CLAUDE\.md|README\.md' \
             . gs://klickhaus-static
-          rm /tmp/gcp-key.json
+
+      - name: Invalidate CDN cache
+        run: |
+          gcloud compute url-maps invalidate-cdn-cache klickhaus-lb \
+            --path "/*" \
+            --project helix-225321 \
+            --async
+
+      - name: Clean up credentials
+        if: always()
+        run: rm -f /tmp/gcp-key.json
 
   # Deploy to Azure Static Web Apps (backup)
   deploy-azure:


### PR DESCRIPTION
## Summary
- The main static-deploy workflow pushed to GCS but never invalidated the Cloud CDN in front of it, so every push took ~1 hour (the `max-age=3600` on objects in `klickhaus-static`) to propagate to `klickhaus.aemstatus.net`.
- Adds an `Invalidate CDN cache` step mirroring the one already used in `preview-deploy.yml`, invalidating `/*` on the `klickhaus-lb` URL map after the GCS rsync.
- Moves the credential cleanup into a dedicated `if: always()` step so it still runs if the deploy or invalidation fails.

Note: the `cx-source` branch maintains its own copy of `static.yml` (it has the `main`/`cx-source` branching to deploy into `/cx/`). That copy needs a follow-up edit so pushes to `cx-source` also invalidate `/cx/*`; not in this PR.

## Testing Done
- Verified manually: `gcloud compute url-maps invalidate-cdn-cache klickhaus-lb --path "/cx/*" --project helix-225321` succeeded and `klickhaus.aemstatus.net/cx/dashboard.html` immediately returned the freshly deployed HTML (`content-length: 12920`, `last-modified` matching the latest deploy commit). The deploy service account (used by `GCP_SA_KEY_B64`) already has `compute.urlMaps.invalidateCache` — `preview-deploy.yml` has been using it for months.

## Checklist
- [ ] Tests pass (`npm test`) — n/a, CI-only change
- [ ] Lint passes (`npm run lint`) — n/a, CI-only change
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)