### PR TITLE
refactor: remove RUM host exclusion from delivery dashboard

### DIFF
--- a/js/delivery-main.js
+++ b/js/delivery-main.js
@@ -11,12 +11,6 @@
  */
 import { initDashboard } from './dashboard-init.js';
 
-// Hosts excluded from delivery dashboard (backend/admin/RUM/docs services)
-const EXCLUDED_DELIVERY_HOSTS = [
-  'rum.aem.page',
-  'rum.hlx.page',
-];
-
 const DEFAULT_HIDDEN_FACETS = [
   'breakdown-accept-encoding',
   'breakdown-cdn-version',
@@ -32,13 +26,10 @@ const DEFAULT_HIDDEN_FACETS = [
   'breakdown-time-elapsed',
 ];
 
-const excludedList = EXCLUDED_DELIVERY_HOSTS.map((host) => `'${host}'`).join(', ');
-
 initDashboard({
   title: 'Delivery',
   tableName: 'delivery',
   weightColumn: 'weight',
   timeSeriesTemplate: 'time-series-delivery',
-  additionalWhereClause: `AND \`request.host\` NOT IN (${excludedList})`,
   defaultHiddenFacets: DEFAULT_HIDDEN_FACETS,
 });


### PR DESCRIPTION
## Summary
- Remove `EXCLUDED_DELIVERY_HOSTS` (`rum.aem.page`, `rum.hlx.page`) and the generated `additionalWhereClause` from the delivery dashboard init.
- RUM hosts will no longer be filtered out of the delivery dashboard.

## Testing Done
- `npm run lint`

## Checklist
- [ ] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)