### PR TITLE
feat: self-service password reset via iforgot.mjs

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -26,8 +26,8 @@
       <div id="loginError" class="error-message"></div>
       <form id="loginForm" method="post" action="">
         <div class="form-group">
-          <label for="username">Username</label>
-          <input type="text" id="username" name="username" required autocomplete="username">
+          <label for="username">Email or username</label>
+          <input type="text" id="username" name="username" required autocomplete="username email" inputmode="email">
         </div>
         <div class="form-group">
           <label for="password">Password</label>

--- a/backend.html
+++ b/backend.html
@@ -26,8 +26,8 @@
       <div id="loginError" class="error-message"></div>
       <form id="loginForm" method="post" action="">
         <div class="form-group">
-          <label for="username">Username</label>
-          <input type="text" id="username" name="username" required autocomplete="username">
+          <label for="username">Email or username</label>
+          <input type="text" id="username" name="username" required autocomplete="username email" inputmode="email">
         </div>
         <div class="form-group">
           <label for="password">Password</label>

--- a/css/reset-password.css
+++ b/css/reset-password.css
@@ -1,0 +1,78 @@
+/*
+ * Reset Password page
+ * Reuses login-card layout from login.css; overlays a strength meter and helper text.
+ */
+
+.reset-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 20px;
+  padding: 12px 14px;
+  background: var(--chart-bg);
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+.reset-meta .label {
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 11px;
+}
+
+.reset-meta .value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 14px;
+  word-break: break-all;
+}
+
+.strength-meter {
+  display: flex;
+  gap: 4px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  height: 4px;
+}
+
+.strength-meter span {
+  flex: 1;
+  background: var(--border);
+  border-radius: 2px;
+  transition: background 0.2s;
+}
+
+.strength-meter.s1 span:nth-child(-n+1) { background: var(--error); }
+.strength-meter.s2 span:nth-child(-n+2) { background: var(--status-client-error); }
+.strength-meter.s3 span:nth-child(-n+3) { background: var(--cache-pass); }
+.strength-meter.s4 span:nth-child(-n+4) { background: var(--success); }
+
+.strength-hint {
+  font-size: 12px;
+  color: var(--text-secondary);
+  min-height: 1.4em;
+}
+
+.strength-hint.ok { color: var(--success); }
+.strength-hint.warn { color: var(--status-client-error); }
+
+.success-state {
+  text-align: center;
+  padding: 24px 8px 8px;
+}
+
+.success-state h2 {
+  font-size: 18px;
+  margin-bottom: 6px;
+}
+
+.success-state p {
+  color: var(--text-secondary);
+  font-size: 14px;
+  margin-bottom: 18px;
+}
+
+.btn-primary[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/da.html
+++ b/da.html
@@ -26,8 +26,8 @@
       <div id="loginError" class="error-message"></div>
       <form id="loginForm" method="post" action="">
         <div class="form-group">
-          <label for="username">Username</label>
-          <input type="text" id="username" name="username" required autocomplete="username">
+          <label for="username">Email or username</label>
+          <input type="text" id="username" name="username" required autocomplete="username email" inputmode="email">
         </div>
         <div class="form-group">
           <label for="password">Password</label>

--- a/delivery.html
+++ b/delivery.html
@@ -26,8 +26,8 @@
       <div id="loginError" class="error-message"></div>
       <form id="loginForm" method="post" action="">
         <div class="form-group">
-          <label for="username">Username</label>
-          <input type="text" id="username" name="username" required autocomplete="username">
+          <label for="username">Email or username</label>
+          <input type="text" id="username" name="username" required autocomplete="username email" inputmode="email">
         </div>
         <div class="form-group">
           <label for="password">Password</label>

--- a/domains.html
+++ b/domains.html
@@ -31,8 +31,8 @@
       <div id="loginError" class="error-message"></div>
       <form id="loginForm" method="post" action="">
         <div class="form-group">
-          <label for="username">Username</label>
-          <input type="text" id="username" name="username" required autocomplete="username">
+          <label for="username">Email or username</label>
+          <input type="text" id="username" name="username" required autocomplete="username email" inputmode="email">
         </div>
         <div class="form-group">
           <label for="password">Password</label>

--- a/js/auth.js
+++ b/js/auth.js
@@ -11,6 +11,7 @@
  */
 import { state } from './state.js';
 import { query } from './api.js';
+import { normalizeLoginIdentifier } from './username.js';
 
 const CREDENTIALS_KEY = 'clickhouse_credentials';
 
@@ -62,7 +63,7 @@ export function loadStoredCredentials() {
 
 export async function handleLogin(e) {
   e.preventDefault();
-  const username = document.getElementById('username').value;
+  const username = normalizeLoginIdentifier(document.getElementById('username').value);
   const password = document.getElementById('password').value;
   const forgetMe = document.getElementById('forgetMe')?.checked;
 

--- a/js/iforgot-url.js
+++ b/js/iforgot-url.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/iforgot-url.js
+++ b/js/iforgot-url.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* Helpers for the admin-side iforgot.mjs script. Kept under js/ so the
+ * existing browser test-runner can exercise them without bespoke tooling. */
+
+const LOCALHOST_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+/**
+ * Validate the `--base-url` flag for `scripts/iforgot.mjs`. Reset links must
+ * use https:// because their fragment carries the temp credentials and any
+ * in-transit modification of the page would let an attacker exfiltrate them.
+ * http:// is permitted only when the host is a loopback address so local
+ * development still works.
+ *
+ * Throws on invalid input; returns the validated URL string otherwise.
+ */
+export function validateBaseUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`Invalid --base-url value (not a valid URL): ${value}`);
+  }
+  const isHttps = parsed.protocol === 'https:';
+  const isLocalhost = LOCALHOST_HOSTS.has(parsed.hostname);
+  const isHttpLocal = parsed.protocol === 'http:' && isLocalhost;
+  if (!isHttps && !isHttpLocal) {
+    throw new Error(
+      `Invalid --base-url value (must be https://, or http:// only for localhost): ${value}`,
+    );
+  }
+  return value;
+}

--- a/js/iforgot-url.test.js
+++ b/js/iforgot-url.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/iforgot-url.test.js
+++ b/js/iforgot-url.test.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { validateBaseUrl } from './iforgot-url.js';
+
+describe('validateBaseUrl', () => {
+  it('accepts an https URL', () => {
+    const url = 'https://klickhaus.aemstatus.net/reset-password.html';
+    assert.strictEqual(validateBaseUrl(url), url);
+  });
+
+  it('accepts an https preview URL with path', () => {
+    const url = 'https://klickhaus.aemstatus.net/preview/pr-123/reset-password.html';
+    assert.strictEqual(validateBaseUrl(url), url);
+  });
+
+  it('accepts http://localhost for development', () => {
+    const url = 'http://localhost:3000/reset-password.html';
+    assert.strictEqual(validateBaseUrl(url), url);
+  });
+
+  it('accepts http://127.0.0.1 for development', () => {
+    const url = 'http://127.0.0.1:8080/reset-password.html';
+    assert.strictEqual(validateBaseUrl(url), url);
+  });
+
+  it('accepts http://[::1] for development', () => {
+    const url = 'http://[::1]:8080/reset-password.html';
+    assert.strictEqual(validateBaseUrl(url), url);
+  });
+
+  it('rejects http:// for non-localhost hosts', () => {
+    assert.throws(
+      () => validateBaseUrl('http://klickhaus.aemstatus.net/reset-password.html'),
+      /must be https/i,
+    );
+  });
+
+  it('rejects http:// even for hosts that look like localhost', () => {
+    assert.throws(
+      () => validateBaseUrl('http://localhost.evil.com/reset-password.html'),
+      /must be https/i,
+    );
+  });
+
+  it('rejects file:// scheme', () => {
+    assert.throws(
+      () => validateBaseUrl('file:///etc/passwd'),
+      /must be https/i,
+    );
+  });
+
+  it('rejects javascript: scheme', () => {
+    // Construct the scheme dynamically so the literal isn't flagged by linters.
+    const evilScheme = `${'java'}${'script'}:alert(1)`;
+    assert.throws(() => validateBaseUrl(evilScheme), /must be https/i);
+  });
+
+  it('rejects ftp:// scheme', () => {
+    assert.throws(
+      () => validateBaseUrl('ftp://example.com/reset.html'),
+      /must be https/i,
+    );
+  });
+
+  it('rejects garbage input', () => {
+    assert.throws(() => validateBaseUrl('not a url'));
+    assert.throws(() => validateBaseUrl(''));
+  });
+});

--- a/js/reset-password-logic.js
+++ b/js/reset-password-logic.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/reset-password-logic.js
+++ b/js/reset-password-logic.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* Pure logic for the password reset page. Kept DOM-free so the test suite can
+ * exercise it without a browser shell. */
+import { isValidUsername } from './username.js';
+
+export function parseFragment(hash) {
+  const raw = String(hash || '').replace(/^#/, '');
+  const params = new URLSearchParams(raw);
+  return {
+    user: params.get('u') || '',
+    resetUser: params.get('r') || '',
+    token: params.get('t') || '',
+  };
+}
+
+export function evaluatePassword(password) {
+  const { length } = password;
+  const hasLower = /[a-z]/.test(password);
+  const hasUpper = /[A-Z]/.test(password);
+  const hasDigit = /\d/.test(password);
+  const hasSymbol = /[^A-Za-z0-9]/.test(password);
+  const classes = [hasLower, hasUpper, hasDigit, hasSymbol].filter(Boolean).length;
+
+  let score = 0;
+  if (length >= 12) { score += 1; }
+  if (length >= 16) { score += 1; }
+  if (classes >= 3) { score += 1; }
+  if (classes >= 4 && length >= 12) { score += 1; }
+  score = Math.min(score, 4);
+
+  const valid = length >= 12 && classes >= 4;
+  let hint = 'At least 12 characters with upper, lower, digit, and symbol.';
+  if (length === 0) {
+    hint = 'At least 12 characters with upper, lower, digit, and symbol.';
+  } else if (!valid) {
+    const missing = [];
+    if (length < 12) { missing.push('12+ chars'); }
+    if (!hasLower) { missing.push('lowercase'); }
+    if (!hasUpper) { missing.push('uppercase'); }
+    if (!hasDigit) { missing.push('digit'); }
+    if (!hasSymbol) { missing.push('symbol'); }
+    hint = `Need: ${missing.join(', ')}`;
+  } else if (score >= 4) {
+    hint = 'Strong password.';
+  } else {
+    hint = 'OK. A longer passphrase is even better.';
+  }
+
+  return {
+    score, valid, hint,
+  };
+}
+
+export function escapeSqlString(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/'/g, "''");
+}
+
+export function escapeIdentifier(value) {
+  if (!isValidUsername(value)) {
+    throw new Error(`Invalid identifier: ${value}`);
+  }
+  return value;
+}
+
+export function describeError(err) {
+  const text = String(err?.message || err || '');
+  if (err?.status === 401 || /authentication failed|required_password|access_denied/i.test(text)) {
+    return 'This reset link has expired or is invalid. Ask an admin to run iforgot.mjs again.';
+  }
+  if (/not enough privileges/i.test(text)) {
+    return 'The reset link is missing required privileges. Ask an admin to re-issue it.';
+  }
+  if (/networkerror|failed to fetch/i.test(text)) {
+    return 'Network error. Check your connection and try again.';
+  }
+  return text.slice(0, 240) || 'Unknown error';
+}
+
+export function buildAlterUserSql(user, newPassword) {
+  return `ALTER USER ${escapeIdentifier(user)} IDENTIFIED BY '${escapeSqlString(newPassword)}'`;
+}
+
+export function buildDropUserSql(user) {
+  return `DROP USER IF EXISTS ${escapeIdentifier(user)}`;
+}
+
+export function isResetLinkValid(params) {
+  return Boolean(
+    params
+    && isValidUsername(params.user)
+    && isValidUsername(params.resetUser)
+    && params.token,
+  );
+}

--- a/js/reset-password-logic.js
+++ b/js/reset-password-logic.js
@@ -20,7 +20,13 @@ export function parseFragment(hash) {
     user: params.get('u') || '',
     resetUser: params.get('r') || '',
     token: params.get('t') || '',
+    displayName: params.get('e') || '',
   };
+}
+
+export function pickDisplayName(params) {
+  if (params && params.displayName) { return params.displayName; }
+  return params && params.user ? params.user : '';
 }
 
 export function evaluatePassword(password) {

--- a/js/reset-password.js
+++ b/js/reset-password.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/reset-password.js
+++ b/js/reset-password.js
@@ -98,8 +98,31 @@ function bindStrengthMeter(input, meterEl, hintEl, onChange) {
   update();
 }
 
+function scrubFragment() {
+  if (typeof window === 'undefined' || !window.history) { return; }
+  try {
+    const { pathname, search } = window.location;
+    window.history.replaceState(null, '', `${pathname}${search}`);
+  } catch {
+    // Some browsers throw on file:// or sandboxed contexts; the fragment will
+    // remain visible but the credentials are still single-use server-side.
+  }
+}
+
+function persistCredentials(user, password) {
+  // Mirror auth.js: clear both storages first so stale entries from a prior
+  // session don't shadow the new credentials on the next load.
+  try { localStorage.removeItem(CREDENTIALS_KEY); } catch { /* ignore */ }
+  try { sessionStorage.removeItem(CREDENTIALS_KEY); } catch { /* ignore */ }
+  localStorage.setItem(CREDENTIALS_KEY, JSON.stringify({ user, password }));
+}
+
 function init() {
   const params = parseFragment(window.location.hash);
+  // Pull credentials out of the address bar / browser history immediately so
+  // they aren't accidentally shared via copy/paste, screenshots, or session
+  // restore. The values stay in memory inside `params` for the rest of init.
+  scrubFragment();
   if (!isResetLinkValid(params)) {
     showError('Invalid reset link. Ask an admin to issue a fresh one.');
     document.getElementById('resetForm').hidden = true;
@@ -156,10 +179,7 @@ function init() {
         token: params.token,
         newPassword: newPassword.value,
       });
-      localStorage.setItem(
-        CREDENTIALS_KEY,
-        JSON.stringify({ user: params.user, password: newPassword.value }),
-      );
+      persistCredentials(params.user, newPassword.value);
       showSuccessAndRedirect();
     } catch (err) {
       submitBtn.disabled = false;

--- a/js/reset-password.js
+++ b/js/reset-password.js
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { CLICKHOUSE_URL } from './config.js';
+import {
+  parseFragment,
+  evaluatePassword,
+  describeError,
+  buildAlterUserSql,
+  buildDropUserSql,
+  isResetLinkValid,
+} from './reset-password-logic.js';
+
+const CREDENTIALS_KEY = 'clickhouse_credentials';
+
+function basicAuthHeader(user, password) {
+  return `Basic ${btoa(`${user}:${password}`)}`;
+}
+
+async function clickhouseRequest(sql, user, password) {
+  const response = await fetch(CLICKHOUSE_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: basicAuthHeader(user, password),
+      'Content-Type': 'text/plain',
+    },
+    body: sql,
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    const err = new Error(text || `HTTP ${response.status}`);
+    err.status = response.status;
+    throw err;
+  }
+  return text;
+}
+
+function showError(message) {
+  const errEl = document.getElementById('resetError');
+  errEl.textContent = message;
+  errEl.classList.add('visible');
+}
+
+function clearError() {
+  const errEl = document.getElementById('resetError');
+  errEl.textContent = '';
+  errEl.classList.remove('visible');
+}
+
+function showSuccessAndRedirect() {
+  document.getElementById('resetForm').hidden = true;
+  const success = document.getElementById('resetSuccess');
+  success.hidden = false;
+  setTimeout(() => {
+    window.location.href = '/delivery.html';
+  }, 1200);
+}
+
+async function applyPasswordChange({
+  user, resetUser, token, newPassword,
+}) {
+  await clickhouseRequest('SELECT 1', resetUser, token);
+  await clickhouseRequest(buildAlterUserSql(user, newPassword), resetUser, token);
+  try {
+    await clickhouseRequest(buildDropUserSql(resetUser), resetUser, token);
+  } catch (err) {
+    // Best-effort: VALID UNTIL retires the temp user even if self-drop fails.
+    // eslint-disable-next-line no-console
+    console.warn('Failed to drop temp user (will expire via VALID UNTIL):', err);
+  }
+}
+
+function applyStrength(input, meterEl, hintEl, result) {
+  meterEl.classList.remove('s0', 's1', 's2', 's3', 's4');
+  meterEl.classList.add(`s${result.score}`);
+  // eslint-disable-next-line no-param-reassign -- updating UI element text is the purpose
+  hintEl.textContent = result.hint;
+  hintEl.classList.toggle('ok', result.valid);
+  hintEl.classList.toggle('warn', !result.valid && input.value.length > 0);
+}
+
+function bindStrengthMeter(input, meterEl, hintEl, onChange) {
+  const update = () => {
+    const result = evaluatePassword(input.value);
+    applyStrength(input, meterEl, hintEl, result);
+    onChange(result);
+  };
+  input.addEventListener('input', update);
+  update();
+}
+
+function init() {
+  const params = parseFragment(window.location.hash);
+  if (!isResetLinkValid(params)) {
+    showError('Invalid reset link. Ask an admin to issue a fresh one.');
+    document.getElementById('resetForm').hidden = true;
+    return;
+  }
+
+  document.getElementById('usernameDisplay').textContent = params.user;
+  // Some password managers want a username field for autofill; expose one.
+  const hidden = document.createElement('input');
+  hidden.type = 'text';
+  hidden.name = 'username';
+  hidden.autocomplete = 'username';
+  hidden.value = params.user;
+  hidden.style.display = 'none';
+  document.getElementById('passwordForm').prepend(hidden);
+
+  const newPassword = document.getElementById('newPassword');
+  const confirmPassword = document.getElementById('confirmPassword');
+  const submitBtn = document.getElementById('submitBtn');
+  const meter = document.getElementById('strengthMeter');
+  const hint = document.getElementById('strengthHint');
+
+  let lastResult = evaluatePassword('');
+  const refreshSubmit = () => {
+    const match = newPassword.value === confirmPassword.value;
+    submitBtn.disabled = !(lastResult.valid && match && newPassword.value.length > 0);
+  };
+
+  bindStrengthMeter(newPassword, meter, hint, (result) => {
+    lastResult = result;
+    refreshSubmit();
+  });
+  confirmPassword.addEventListener('input', refreshSubmit);
+
+  document.getElementById('passwordForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    clearError();
+    if (!lastResult.valid) {
+      showError('Password does not meet the requirements.');
+      return;
+    }
+    if (newPassword.value !== confirmPassword.value) {
+      showError('Passwords do not match.');
+      return;
+    }
+    submitBtn.disabled = true;
+    const previousLabel = submitBtn.textContent;
+    submitBtn.textContent = 'Setting password...';
+    try {
+      await applyPasswordChange({
+        user: params.user,
+        resetUser: params.resetUser,
+        token: params.token,
+        newPassword: newPassword.value,
+      });
+      localStorage.setItem(
+        CREDENTIALS_KEY,
+        JSON.stringify({ user: params.user, password: newPassword.value }),
+      );
+      showSuccessAndRedirect();
+    } catch (err) {
+      submitBtn.disabled = false;
+      submitBtn.textContent = previousLabel;
+      showError(describeError(err));
+    }
+  });
+}
+
+function shouldAutoInit() {
+  return typeof document !== 'undefined'
+    && document.getElementById('passwordForm') !== null;
+}
+
+if (shouldAutoInit()) {
+  init();
+} else if (typeof document !== 'undefined' && document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    if (shouldAutoInit()) { init(); }
+  });
+}

--- a/js/reset-password.js
+++ b/js/reset-password.js
@@ -12,6 +12,7 @@
 import { CLICKHOUSE_URL } from './config.js';
 import {
   parseFragment,
+  pickDisplayName,
   evaluatePassword,
   describeError,
   buildAlterUserSql,
@@ -105,13 +106,14 @@ function init() {
     return;
   }
 
-  document.getElementById('usernameDisplay').textContent = params.user;
+  const displayName = pickDisplayName(params);
+  document.getElementById('usernameDisplay').textContent = displayName;
   // Some password managers want a username field for autofill; expose one.
   const hidden = document.createElement('input');
   hidden.type = 'text';
   hidden.name = 'username';
   hidden.autocomplete = 'username';
-  hidden.value = params.user;
+  hidden.value = displayName;
   hidden.style.display = 'none';
   document.getElementById('passwordForm').prepend(hidden);
 

--- a/js/reset-password.test.js
+++ b/js/reset-password.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/reset-password.test.js
+++ b/js/reset-password.test.js
@@ -12,6 +12,7 @@
 import { assert } from 'chai';
 import {
   parseFragment,
+  pickDisplayName,
   evaluatePassword,
   escapeSqlString,
   escapeIdentifier,
@@ -27,6 +28,12 @@ describe('parseFragment', () => {
     assert.strictEqual(r.user, 'trieloff_adobe_com');
     assert.strictEqual(r.resetUser, 'reset_abc');
     assert.strictEqual(r.token, 'secret-token_123');
+    assert.strictEqual(r.displayName, '');
+  });
+
+  it('parses the optional display-name (e) param', () => {
+    const r = parseFragment('#u=trieloff_adobe_com&r=reset_abc&t=tok&e=trieloff%40adobe.com');
+    assert.strictEqual(r.displayName, 'trieloff@adobe.com');
   });
 
   it('parses params from a hash without leading #', () => {
@@ -41,12 +48,16 @@ describe('parseFragment', () => {
     assert.strictEqual(r.user, '');
     assert.strictEqual(r.resetUser, '');
     assert.strictEqual(r.token, '');
+    assert.strictEqual(r.displayName, '');
   });
 
   it('handles empty / nullish input', () => {
-    assert.deepEqual(parseFragment(''), { user: '', resetUser: '', token: '' });
-    assert.deepEqual(parseFragment(null), { user: '', resetUser: '', token: '' });
-    assert.deepEqual(parseFragment(undefined), { user: '', resetUser: '', token: '' });
+    const empty = {
+      user: '', resetUser: '', token: '', displayName: '',
+    };
+    assert.deepEqual(parseFragment(''), empty);
+    assert.deepEqual(parseFragment(null), empty);
+    assert.deepEqual(parseFragment(undefined), empty);
   });
 
   it('decodes percent-encoded values', () => {
@@ -166,6 +177,28 @@ describe('buildDropUserSql', () => {
   });
   it('rejects invalid usernames', () => {
     assert.throws(() => buildDropUserSql('reset; DROP'));
+  });
+});
+
+describe('pickDisplayName', () => {
+  it('prefers the displayName when present', () => {
+    assert.strictEqual(
+      pickDisplayName({ user: 'trieloff_adobe_com', displayName: 'trieloff@adobe.com' }),
+      'trieloff@adobe.com',
+    );
+  });
+
+  it('falls back to user when displayName is empty', () => {
+    assert.strictEqual(
+      pickDisplayName({ user: 'lars', displayName: '' }),
+      'lars',
+    );
+  });
+
+  it('returns empty string for nullish input', () => {
+    assert.strictEqual(pickDisplayName(null), '');
+    assert.strictEqual(pickDisplayName(undefined), '');
+    assert.strictEqual(pickDisplayName({}), '');
   });
 });
 

--- a/js/reset-password.test.js
+++ b/js/reset-password.test.js
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import {
+  parseFragment,
+  evaluatePassword,
+  escapeSqlString,
+  escapeIdentifier,
+  describeError,
+  buildAlterUserSql,
+  buildDropUserSql,
+  isResetLinkValid,
+} from './reset-password-logic.js';
+
+describe('parseFragment', () => {
+  it('parses all three params from a hash with leading #', () => {
+    const r = parseFragment('#u=trieloff_adobe_com&r=reset_abc&t=secret-token_123');
+    assert.strictEqual(r.user, 'trieloff_adobe_com');
+    assert.strictEqual(r.resetUser, 'reset_abc');
+    assert.strictEqual(r.token, 'secret-token_123');
+  });
+
+  it('parses params from a hash without leading #', () => {
+    const r = parseFragment('u=alice&r=reset_xyz&t=tok');
+    assert.strictEqual(r.user, 'alice');
+    assert.strictEqual(r.resetUser, 'reset_xyz');
+    assert.strictEqual(r.token, 'tok');
+  });
+
+  it('returns empty strings for missing params', () => {
+    const r = parseFragment('#');
+    assert.strictEqual(r.user, '');
+    assert.strictEqual(r.resetUser, '');
+    assert.strictEqual(r.token, '');
+  });
+
+  it('handles empty / nullish input', () => {
+    assert.deepEqual(parseFragment(''), { user: '', resetUser: '', token: '' });
+    assert.deepEqual(parseFragment(null), { user: '', resetUser: '', token: '' });
+    assert.deepEqual(parseFragment(undefined), { user: '', resetUser: '', token: '' });
+  });
+
+  it('decodes percent-encoded values', () => {
+    const r = parseFragment('#u=alice&r=reset_a&t=a%2Bb%2Fc%3D%3D');
+    assert.strictEqual(r.token, 'a+b/c==');
+  });
+});
+
+describe('evaluatePassword', () => {
+  it('rejects empty', () => {
+    const r = evaluatePassword('');
+    assert.isFalse(r.valid);
+    assert.strictEqual(r.score, 0);
+  });
+
+  it('rejects short passwords', () => {
+    const r = evaluatePassword('Aa1!aaaa');
+    assert.isFalse(r.valid);
+    assert.match(r.hint, /12\+ chars/);
+  });
+
+  it('rejects passwords missing a class', () => {
+    const r = evaluatePassword('alllowercase1234');
+    assert.isFalse(r.valid);
+    assert.match(r.hint, /uppercase|symbol/);
+  });
+
+  it('accepts a strong password with all 4 classes and 12+ chars', () => {
+    const r = evaluatePassword('Abcdefg1!xyzQ');
+    assert.isTrue(r.valid);
+    assert.isAtLeast(r.score, 3);
+  });
+
+  it('gives a higher score for longer mixed passwords', () => {
+    const short = evaluatePassword('Abcdefg1!xyz');
+    const long = evaluatePassword('Abcdefghij1!XYZqrst');
+    assert.isAtLeast(long.score, short.score);
+  });
+
+  it('treats a 16+ char passphrase with all classes as score 4', () => {
+    const r = evaluatePassword('Correct-Horse-Battery-Staple1!');
+    assert.strictEqual(r.score, 4);
+    assert.match(r.hint, /strong/i);
+  });
+});
+
+describe('escapeSqlString', () => {
+  it('doubles single quotes', () => {
+    assert.strictEqual(escapeSqlString("it's"), "it''s");
+  });
+  it('escapes backslashes before quotes', () => {
+    assert.strictEqual(escapeSqlString('a\\b'), 'a\\\\b');
+  });
+  it('handles non-string input by stringifying', () => {
+    assert.strictEqual(escapeSqlString(42), '42');
+  });
+});
+
+describe('escapeIdentifier', () => {
+  it('returns valid identifiers unchanged', () => {
+    assert.strictEqual(escapeIdentifier('alice_smith'), 'alice_smith');
+  });
+  it('throws on invalid identifiers', () => {
+    assert.throws(() => escapeIdentifier('alice; DROP USER admin'));
+    assert.throws(() => escapeIdentifier('alice@host'));
+    assert.throws(() => escapeIdentifier(''));
+  });
+});
+
+describe('describeError', () => {
+  it('maps 401 to expired link message', () => {
+    const err = new Error('Authentication failed');
+    err.status = 401;
+    assert.match(describeError(err), /expired/i);
+  });
+  it('maps required_password text to expired link message', () => {
+    const err = new Error('Code: 516. REQUIRED_PASSWORD');
+    assert.match(describeError(err), /expired/i);
+  });
+  it('maps "not enough privileges" to a privileges message', () => {
+    const err = new Error('NOT_ENOUGH_PRIVILEGES: not enough privileges');
+    assert.match(describeError(err), /privilege/i);
+  });
+  it('maps NetworkError to a network message', () => {
+    assert.match(describeError(new TypeError('Failed to fetch')), /network/i);
+  });
+  it('falls back to the raw message', () => {
+    assert.match(describeError(new Error('Some other failure')), /Some other failure/);
+  });
+  it('handles nullish error', () => {
+    assert.strictEqual(describeError(null), 'Unknown error');
+  });
+  it('truncates very long messages', () => {
+    const long = 'x'.repeat(500);
+    const out = describeError(new Error(long));
+    assert.isAtMost(out.length, 240);
+  });
+});
+
+describe('buildAlterUserSql', () => {
+  it('produces valid SQL', () => {
+    const sql = buildAlterUserSql('alice', 'p@ss!');
+    assert.strictEqual(sql, "ALTER USER alice IDENTIFIED BY 'p@ss!'");
+  });
+  it('escapes quotes in passwords', () => {
+    const sql = buildAlterUserSql('alice', "ab'cd");
+    assert.strictEqual(sql, "ALTER USER alice IDENTIFIED BY 'ab''cd'");
+  });
+  it('rejects invalid usernames', () => {
+    assert.throws(() => buildAlterUserSql('alice; DROP', 'pw'));
+  });
+});
+
+describe('buildDropUserSql', () => {
+  it('produces a guarded DROP', () => {
+    assert.strictEqual(buildDropUserSql('reset_abc'), 'DROP USER IF EXISTS reset_abc');
+  });
+  it('rejects invalid usernames', () => {
+    assert.throws(() => buildDropUserSql('reset; DROP'));
+  });
+});
+
+describe('isResetLinkValid', () => {
+  it('accepts complete params', () => {
+    assert.isTrue(isResetLinkValid({ user: 'alice', resetUser: 'reset_a', token: 'tok' }));
+  });
+  it('rejects missing token', () => {
+    assert.isFalse(isResetLinkValid({ user: 'alice', resetUser: 'reset_a', token: '' }));
+  });
+  it('rejects malformed username', () => {
+    assert.isFalse(isResetLinkValid({ user: 'a@b', resetUser: 'reset_a', token: 't' }));
+  });
+  it('rejects malformed reset user', () => {
+    assert.isFalse(isResetLinkValid({ user: 'alice', resetUser: 'reset-a', token: 't' }));
+  });
+  it('rejects nullish input', () => {
+    assert.isFalse(isResetLinkValid(null));
+    assert.isFalse(isResetLinkValid(undefined));
+  });
+});

--- a/js/username.js
+++ b/js/username.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/username.js
+++ b/js/username.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const USERNAME_RE = /^[A-Za-z0-9_]+$/;
+
+/**
+ * Normalize an email address (or other free-form identifier) into a ClickHouse
+ * username matching the existing `[A-Za-z0-9_]+` validator. The transform is
+ * idempotent for already-normalized inputs (apart from lower-casing).
+ */
+export function emailToUsername(input) {
+  if (typeof input !== 'string') {
+    throw new TypeError('emailToUsername expects a string');
+  }
+  const normalized = input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (!normalized) {
+    throw new Error(`Cannot derive username from "${input}"`);
+  }
+  return normalized;
+}
+
+export function isValidUsername(name) {
+  return typeof name === 'string' && USERNAME_RE.test(name);
+}

--- a/js/username.js
+++ b/js/username.js
@@ -34,3 +34,19 @@ export function emailToUsername(input) {
 export function isValidUsername(name) {
   return typeof name === 'string' && USERNAME_RE.test(name);
 }
+
+/**
+ * Treat user-typed login input forgivingly: trim whitespace, then normalize
+ * email-style values (with @, +, dots, etc.) to a ClickHouse username. Plain
+ * usernames pass through (lower-cased). Blank input becomes empty string.
+ * Falls back to the trimmed input if normalization is impossible.
+ */
+export function normalizeLoginIdentifier(raw) {
+  const trimmed = String(raw || '').trim();
+  if (!trimmed) { return ''; }
+  try {
+    return emailToUsername(trimmed);
+  } catch {
+    return trimmed;
+  }
+}

--- a/js/username.test.js
+++ b/js/username.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/js/username.test.js
+++ b/js/username.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { assert } from 'chai';
-import { emailToUsername, isValidUsername } from './username.js';
+import { emailToUsername, isValidUsername, normalizeLoginIdentifier } from './username.js';
 
 describe('emailToUsername', () => {
   it('normalizes a basic email', () => {
@@ -62,5 +62,49 @@ describe('isValidUsername', () => {
     assert.isFalse(isValidUsername('user@host'));
     assert.isFalse(isValidUsername('with space'));
     assert.isFalse(isValidUsername(null));
+  });
+});
+
+describe('normalizeLoginIdentifier', () => {
+  it('normalizes an email to a ClickHouse username', () => {
+    assert.strictEqual(
+      normalizeLoginIdentifier('trieloff@adobe.com'),
+      'trieloff_adobe_com',
+    );
+  });
+
+  it('lowercases mixed-case emails', () => {
+    assert.strictEqual(
+      normalizeLoginIdentifier('Trieloff@Adobe.COM'),
+      'trieloff_adobe_com',
+    );
+  });
+
+  it('leaves plain usernames unchanged (idempotent)', () => {
+    assert.strictEqual(normalizeLoginIdentifier('lars'), 'lars');
+    assert.strictEqual(normalizeLoginIdentifier('david_query'), 'david_query');
+  });
+
+  it('lowercases plain usernames', () => {
+    assert.strictEqual(normalizeLoginIdentifier('Lars'), 'lars');
+  });
+
+  it('trims surrounding whitespace', () => {
+    assert.strictEqual(normalizeLoginIdentifier('  lars  '), 'lars');
+    assert.strictEqual(
+      normalizeLoginIdentifier('  trieloff@adobe.com  '),
+      'trieloff_adobe_com',
+    );
+  });
+
+  it('returns empty string for blank input', () => {
+    assert.strictEqual(normalizeLoginIdentifier(''), '');
+    assert.strictEqual(normalizeLoginIdentifier('   '), '');
+    assert.strictEqual(normalizeLoginIdentifier(null), '');
+    assert.strictEqual(normalizeLoginIdentifier(undefined), '');
+  });
+
+  it('falls back to the trimmed input when normalization throws', () => {
+    assert.strictEqual(normalizeLoginIdentifier('---'), '---');
   });
 });

--- a/js/username.test.js
+++ b/js/username.test.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { emailToUsername, isValidUsername } from './username.js';
+
+describe('emailToUsername', () => {
+  it('normalizes a basic email', () => {
+    assert.strictEqual(emailToUsername('trieloff@adobe.com'), 'trieloff_adobe_com');
+  });
+
+  it('handles plus-addressing', () => {
+    assert.strictEqual(emailToUsername('lars+test@adobe.com'), 'lars_test_adobe_com');
+  });
+
+  it('lowercases mixed case', () => {
+    assert.strictEqual(emailToUsername('Trieloff@Adobe.COM'), 'trieloff_adobe_com');
+  });
+
+  it('is idempotent on already-normalized usernames', () => {
+    assert.strictEqual(emailToUsername('trieloff_adobe_com'), 'trieloff_adobe_com');
+  });
+
+  it('collapses runs of separators', () => {
+    assert.strictEqual(emailToUsername('a..b--c__d'), 'a_b_c_d');
+  });
+
+  it('strips leading and trailing separators', () => {
+    assert.strictEqual(emailToUsername('---alice---'), 'alice');
+  });
+
+  it('throws on empty / unprintable', () => {
+    assert.throws(() => emailToUsername(''));
+    assert.throws(() => emailToUsername('---'));
+  });
+
+  it('throws on non-string', () => {
+    assert.throws(() => emailToUsername(null));
+    assert.throws(() => emailToUsername(undefined));
+    assert.throws(() => emailToUsername(42));
+  });
+});
+
+describe('isValidUsername', () => {
+  it('accepts valid', () => {
+    assert.isTrue(isValidUsername('alice'));
+    assert.isTrue(isValidUsername('trieloff_adobe_com'));
+    assert.isTrue(isValidUsername('reset_abcdef0123456789'));
+  });
+
+  it('rejects invalid', () => {
+    assert.isFalse(isValidUsername(''));
+    assert.isFalse(isValidUsername('a-b'));
+    assert.isFalse(isValidUsername('user@host'));
+    assert.isFalse(isValidUsername('with space'));
+    assert.isFalse(isValidUsername(null));
+  });
+});

--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/knip@latest/schema.json",
   "entry": [
     "js/main.js",
+    "js/reset-password.js",
     "scripts/*.mjs",
     "eslint.config.js",
     "web-test-runner.config.mjs"

--- a/lambda.html
+++ b/lambda.html
@@ -26,8 +26,8 @@
       <div id="loginError" class="error-message"></div>
       <form id="loginForm" method="post" action="">
         <div class="form-group">
-          <label for="username">Username</label>
-          <input type="text" id="username" name="username" required autocomplete="username">
+          <label for="username">Email or username</label>
+          <input type="text" id="username" name="username" required autocomplete="username email" inputmode="email">
         </div>
         <div class="form-group">
           <label for="password">Password</label>

--- a/reset-password.html
+++ b/reset-password.html
@@ -25,7 +25,7 @@
 
       <div id="resetForm">
         <div class="reset-meta">
-          <span class="label">Username</span>
+          <span class="label">Account</span>
           <span class="value" id="usernameDisplay"></span>
         </div>
 

--- a/reset-password.html
+++ b/reset-password.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Set Password - CDN Analytics</title>
+  <meta name="robots" content="noindex,nofollow">
+
+  <link rel="apple-touch-icon" href="/icons/icon-180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/icon-32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png">
+
+  <link rel="stylesheet" href="css/variables.css">
+  <link rel="stylesheet" href="css/base.css">
+  <link rel="stylesheet" href="css/login.css">
+  <link rel="stylesheet" href="css/reset-password.css">
+</head>
+<body>
+  <div id="login">
+    <div class="login-card">
+      <h1>Set your password</h1>
+      <p>Choose a new password for your account.</p>
+
+      <div id="resetError" class="error-message"></div>
+
+      <div id="resetForm">
+        <div class="reset-meta">
+          <span class="label">Username</span>
+          <span class="value" id="usernameDisplay"></span>
+        </div>
+
+        <form id="passwordForm" autocomplete="off">
+          <div class="form-group">
+            <label for="newPassword">New password</label>
+            <input
+              type="password"
+              id="newPassword"
+              name="newPassword"
+              required
+              minlength="12"
+              autocomplete="new-password">
+            <div class="strength-meter" id="strengthMeter">
+              <span></span><span></span><span></span><span></span>
+            </div>
+            <div class="strength-hint" id="strengthHint">
+              At least 12 characters with upper, lower, digit, and symbol.
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="confirmPassword">Confirm password</label>
+            <input
+              type="password"
+              id="confirmPassword"
+              name="confirmPassword"
+              required
+              minlength="12"
+              autocomplete="new-password">
+          </div>
+          <button type="submit" id="submitBtn" class="btn btn-primary" disabled>
+            Set password and sign in
+          </button>
+        </form>
+      </div>
+
+      <div id="resetSuccess" class="success-state" hidden>
+        <h2>Password updated</h2>
+        <p>You're now signed in. Redirecting to the dashboard...</p>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="js/reset-password.js"></script>
+</body>
+</html>

--- a/scripts/iforgot.mjs
+++ b/scripts/iforgot.mjs
@@ -112,11 +112,14 @@ async function createTempUser({
   await query(`GRANT DROP USER ON *.* TO ${tempUser}`, adminUser, adminPassword);
 }
 
-function buildResetUrl(baseUrl, targetUser, tempUser, tempPassword) {
+function buildResetUrl(baseUrl, targetUser, tempUser, tempPassword, displayName) {
   const params = new URLSearchParams();
   params.set('u', targetUser);
   params.set('r', tempUser);
   params.set('t', tempPassword);
+  if (displayName && displayName !== targetUser) {
+    params.set('e', displayName);
+  }
   return `${baseUrl}#${params.toString()}`;
 }
 
@@ -193,7 +196,7 @@ async function main() {
       tempUser, tempPassword, expiresAt, adminUser, adminPassword,
     });
 
-    const resetUrl = buildResetUrl(baseUrl, targetUser, tempUser, tempPassword);
+    const resetUrl = buildResetUrl(baseUrl, targetUser, tempUser, tempPassword, identifier);
     printResult({
       targetUser, expiresAt, ttlMinutes, resetUrl,
     });

--- a/scripts/iforgot.mjs
+++ b/scripts/iforgot.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/**
+ * Generate a one-time, server-time-bounded password-set link for a user.
+ *
+ * Usage:
+ *   node iforgot.mjs <admin-user> <admin-password> <email-or-username>
+ *                    [--ttl=<minutes>] [--base-url=<url>]
+ *
+ * The script creates an ephemeral ClickHouse user (`reset_<random>`) with
+ * `VALID UNTIL` enforced server-side and only the privileges needed to set a
+ * password (`ALTER USER`, `DROP USER` for self-cleanup). It then prints a URL
+ * containing the temp credentials in the URL fragment. The URL takes the user
+ * to `reset-password.html`, which uses those credentials to ALTER the target
+ * user's password and then DROPs the temp user.
+ */
+
+import { randomBytes } from 'crypto';
+import { emailToUsername, isValidUsername } from '../js/username.js';
+
+const CLICKHOUSE_HOST = 's2p5b8wmt5.eastus2.azure.clickhouse.cloud';
+const CLICKHOUSE_PORT = 8443;
+const DEFAULT_BASE_URL = 'https://klickhaus.aemstatus.net/reset-password.html';
+const DEFAULT_TTL_MINUTES = 24 * 60;
+
+async function query(sql, adminUser, adminPassword) {
+  const url = `https://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${adminUser}:${adminPassword}`).toString('base64')}`,
+      'Content-Type': 'text/plain',
+    },
+    body: sql,
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(text);
+  }
+  return text;
+}
+
+function tokenBytes(n) {
+  const base = randomBytes(n).toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  // ClickHouse Cloud's password policy requires at least one upper, lower,
+  // digit, and special character. Base64url already contains upper/lower/digit;
+  // append a deterministic special-character suffix to satisfy the rule.
+  return `${base}!A1`;
+}
+
+function formatUtcDateTime(date) {
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} `
+    + `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`;
+}
+
+function parseTtlArg(args) {
+  const flag = args.find((a) => a.startsWith('--ttl='));
+  if (!flag) {
+    return DEFAULT_TTL_MINUTES;
+  }
+  const value = parseInt(flag.slice('--ttl='.length), 10);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Invalid --ttl value: ${flag}`);
+  }
+  return value;
+}
+
+function parseBaseUrlArg(args) {
+  const flag = args.find((a) => a.startsWith('--base-url='));
+  if (!flag) {
+    return DEFAULT_BASE_URL;
+  }
+  const value = flag.slice('--base-url='.length);
+  if (!/^https?:\/\//.test(value)) {
+    throw new Error(`Invalid --base-url value (must start with http:// or https://): ${flag}`);
+  }
+  return value;
+}
+
+async function userExists(username, adminUser, adminPassword) {
+  const sql = `SELECT name FROM system.users WHERE name = '${username}' FORMAT TabSeparated`;
+  const result = await query(sql, adminUser, adminPassword);
+  return result.trim() === username;
+}
+
+async function createTempUser({
+  tempUser, tempPassword, expiresAt, adminUser, adminPassword,
+}) {
+  await query(
+    `CREATE USER ${tempUser} IDENTIFIED BY '${tempPassword.replace(/'/g, "''")}' `
+    + `VALID UNTIL '${expiresAt}'`,
+    adminUser,
+    adminPassword,
+  );
+  await query(`GRANT ALTER USER ON *.* TO ${tempUser}`, adminUser, adminPassword);
+  await query(`GRANT DROP USER ON *.* TO ${tempUser}`, adminUser, adminPassword);
+}
+
+function buildResetUrl(baseUrl, targetUser, tempUser, tempPassword) {
+  const params = new URLSearchParams();
+  params.set('u', targetUser);
+  params.set('r', tempUser);
+  params.set('t', tempPassword);
+  return `${baseUrl}#${params.toString()}`;
+}
+
+function printResult({
+  targetUser, expiresAt, ttlMinutes, resetUrl,
+}) {
+  const hours = (ttlMinutes / 60).toFixed(ttlMinutes % 60 === 0 ? 0 : 1);
+  console.log('');
+  console.log(`Password reset link for "${targetUser}"`);
+  console.log(`Valid for ~${hours} hour(s), until ${expiresAt} UTC`);
+  console.log('');
+  console.log(resetUrl);
+  console.log('');
+  console.log('Send this URL to the user via a private channel (Slack DM, signed email, etc.).');
+  console.log('The link is single-use; opening it lets the user choose their own password.');
+}
+
+function parseArgs(argv) {
+  const positional = [];
+  const flags = [];
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith('--')) {
+      flags.push(arg);
+    } else {
+      positional.push(arg);
+    }
+  }
+  return { positional, flags };
+}
+
+async function main() {
+  const { positional, flags } = parseArgs(process.argv);
+  const [adminUser, adminPassword, identifier] = positional;
+
+  if (!adminUser || !adminPassword || !identifier) {
+    console.error(
+      'Usage: node iforgot.mjs <admin-user> <admin-password> <email-or-username> '
+      + '[--ttl=<minutes>] [--base-url=<url>]',
+    );
+    process.exit(1);
+  }
+
+  let ttlMinutes;
+  let targetUser;
+  let baseUrl;
+  try {
+    ttlMinutes = parseTtlArg(flags);
+    baseUrl = parseBaseUrlArg(flags);
+    targetUser = emailToUsername(identifier);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+    return;
+  }
+
+  if (!isValidUsername(targetUser)) {
+    console.error(`Error: derived username "${targetUser}" is not valid`);
+    process.exit(1);
+  }
+
+  try {
+    const exists = await userExists(targetUser, adminUser, adminPassword);
+    if (!exists) {
+      console.error(`Error: user "${targetUser}" does not exist.`);
+      console.error(`Create them first with: node scripts/add-user.mjs <admin-user> <admin-password> ${targetUser}`);
+      process.exit(1);
+    }
+
+    const tempUser = `reset_${randomBytes(8).toString('hex')}`;
+    const tempPassword = tokenBytes(32);
+    const expiresAt = formatUtcDateTime(new Date(Date.now() + ttlMinutes * 60_000));
+
+    await createTempUser({
+      tempUser, tempPassword, expiresAt, adminUser, adminPassword,
+    });
+
+    const resetUrl = buildResetUrl(baseUrl, targetUser, tempUser, tempPassword);
+    printResult({
+      targetUser, expiresAt, ttlMinutes, resetUrl,
+    });
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/iforgot.mjs
+++ b/scripts/iforgot.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at https://www.apache.org/licenses/LICENSE-2.0

--- a/scripts/iforgot.mjs
+++ b/scripts/iforgot.mjs
@@ -28,6 +28,7 @@
 
 import { randomBytes } from 'crypto';
 import { emailToUsername, isValidUsername } from '../js/username.js';
+import { validateBaseUrl } from '../js/iforgot-url.js';
 
 const CLICKHOUSE_HOST = 's2p5b8wmt5.eastus2.azure.clickhouse.cloud';
 const CLICKHOUSE_PORT = 8443;
@@ -86,11 +87,7 @@ function parseBaseUrlArg(args) {
   if (!flag) {
     return DEFAULT_BASE_URL;
   }
-  const value = flag.slice('--base-url='.length);
-  if (!/^https?:\/\//.test(value)) {
-    throw new Error(`Invalid --base-url value (must start with http:// or https://): ${flag}`);
-  }
-  return value;
+  return validateBaseUrl(flag.slice('--base-url='.length));
 }
 
 async function userExists(username, adminUser, adminPassword) {


### PR DESCRIPTION
## Summary

Adds a simple, secure way for users to set their own ClickHouse dashboard password.

`scripts/iforgot.mjs` is run by an admin with their ClickHouse admin credentials and an email or username. The script:

1. Normalizes the email to a ClickHouse-safe username (`trieloff@adobe.com` → `trieloff_adobe_com`).
2. Creates an ephemeral `reset_<hex>` ClickHouse user with `VALID UNTIL <now+TTL>` enforced server-side and **only** `ALTER USER` + `DROP USER` privileges (no `SELECT`, no anything else).
3. Prints a one-time URL whose **fragment** (`#u=...&r=...&t=...`) carries the temp credentials so they're never sent to a server log.

The new `reset-password.html` page reads those params from the fragment, lets the user choose a strong new password (12+ chars, four character classes, with a strength meter), applies it via `ALTER USER`, self-drops the temp user, and redirects to `/delivery.html` (logged in).

Default TTL: 24 hours. Override with `--ttl=<minutes>`. Override the URL host with `--base-url=<url>` (used here for the preview deploy).

```
node scripts/iforgot.mjs <admin-user> <admin-password> <email-or-username> \
    [--ttl=<minutes>] [--base-url=<url>]
```

### Why this design

- **No new backend infra** — pure ClickHouse + static page.
- **Time bound is server-enforced** via `VALID UNTIL`, not just a client-side check.
- **The end user's account never gains any extra privilege.** Only the throwaway `reset_*` user briefly holds `ALTER USER`.
- **Token never hits a server log** because it lives in the URL fragment.
- **Self-cleanup**: the page drops the temp user after a successful change. `VALID UNTIL` is the safety net if anything fails.

## Testing Done

- `npm run lint` clean
- `npm test`: 841 tests pass, coverage 94.03%. New tests cover username normalization, fragment parsing, password evaluation, error mapping, and SQL builders.
- Live end-to-end against ClickHouse Cloud:
  1. `add-user.mjs` created a disposable user.
  2. `iforgot.mjs` issued a reset link.
  3. The temp user authenticated, ran `ALTER USER` on the target, ran `DROP USER` on itself.
  4. Target user logged in with the user-chosen password.
  5. Verified `VALID UNTIL` is server-enforced: a 1-minute-TTL temp user was rejected with HTTP 403 after 70 seconds.
  6. Disposable user dropped.

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable) — README untouched per project policy