### PR TITLE
feat(ux): add split view mode for wide-screen dashboards

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -63,14 +63,17 @@
         <select id="topN"></select>
         <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by host..." list="hostSuggestions" autocomplete="off"></span>
         <datalist id="hostSuggestions"></datalist>
-        <button id="viewToggleBtn" class="menu-btn" title="View Logs">
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="2" y="3" width="14" height="12" rx="2"/>
-            <line x1="5" y1="7" x2="13" y2="7"/>
-            <line x1="5" y1="10.5" x2="13" y2="10.5"/>
-            <line x1="5" y1="14" x2="10" y2="14"/>
-          </svg>
-        </button>
+        <span class="kbd-control">
+          <kbd class="kbd-hint">t</kbd>
+          <button id="viewCycleBtn" class="menu-btn" title="Switch to Logs view">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="1" y="1" width="14" height="14" rx="2"/>
+              <line x1="4" y1="5" x2="12" y2="5"/>
+              <line x1="4" y1="8" x2="12" y2="8"/>
+              <line x1="4" y1="11" x2="9" y2="11"/>
+            </svg>
+          </button>
+        </span>
         <button id="refreshBtn" class="menu-btn" title="Refresh">
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
             <path d="M15 9A6 6 0 1 0 13.2 13.2"/>
@@ -103,6 +106,7 @@
         </div>
       </section>
 
+      <div id="contentArea">
       <!-- Filters View (Breakdowns) -->
       <div id="filtersView" class="visible">
         <!-- Breakdown Tables -->
@@ -227,6 +231,7 @@
           <div class="logs-loading"><div class="spinner"></div>Loading logs...</div>
         </div>
       </div>
+      </div><!-- end #contentArea -->
     </main>
   </div>
 
@@ -242,7 +247,7 @@
   <!-- More Actions Menu -->
   <dialog id="moreMenu" class="dropdown-menu">
     <button class="menu-item" id="moreViewToggleItem">
-      <span class="menu-item-label">View Logs</span>
+      <span class="menu-item-label">Cycle View</span>
       <kbd class="menu-item-kbd">t</kbd>
     </button>
     <button class="menu-item" id="moreRefreshItem">
@@ -300,7 +305,7 @@
         <div class="key-desc">Focus host filter</div>
 
         <div class="key-group"><kbd>t</kbd></div>
-        <div class="key-desc">Toggle logs view</div>
+        <div class="key-desc">Cycle logs view</div>
 
         <div class="key-group"><kbd>b</kbd> <kbd>#</kbd></div>
         <div class="key-desc">Toggle bytes/count mode</div>

--- a/admin.html
+++ b/admin.html
@@ -305,7 +305,7 @@
         <div class="key-desc">Focus host filter</div>
 
         <div class="key-group"><kbd>t</kbd></div>
-        <div class="key-desc">Cycle logs view</div>
+        <div class="key-desc">Cycle view</div>
 
         <div class="key-group"><kbd>b</kbd> <kbd>#</kbd></div>
         <div class="key-desc">Toggle bytes/count mode</div>

--- a/admin.html
+++ b/admin.html
@@ -247,7 +247,7 @@
   <!-- More Actions Menu -->
   <dialog id="moreMenu" class="dropdown-menu">
     <button class="menu-item" id="moreViewToggleItem">
-      <span class="menu-item-label">Cycle View</span>
+      <span class="menu-item-label">Switch to Logs view</span>
       <kbd class="menu-item-kbd">t</kbd>
     </button>
     <button class="menu-item" id="moreRefreshItem">

--- a/backend.html
+++ b/backend.html
@@ -63,14 +63,17 @@
         <select id="topN"></select>
         <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by host..." list="hostSuggestions" autocomplete="off"></span>
         <datalist id="hostSuggestions"></datalist>
-        <button id="viewToggleBtn" class="menu-btn" title="View Logs">
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="2" y="3" width="14" height="12" rx="2"/>
-            <line x1="5" y1="7" x2="13" y2="7"/>
-            <line x1="5" y1="10.5" x2="13" y2="10.5"/>
-            <line x1="5" y1="14" x2="10" y2="14"/>
-          </svg>
-        </button>
+        <span class="kbd-control">
+          <kbd class="kbd-hint">t</kbd>
+          <button id="viewCycleBtn" class="menu-btn" title="Switch to Logs view">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="1" y="1" width="14" height="14" rx="2"/>
+              <line x1="4" y1="5" x2="12" y2="5"/>
+              <line x1="4" y1="8" x2="12" y2="8"/>
+              <line x1="4" y1="11" x2="9" y2="11"/>
+            </svg>
+          </button>
+        </span>
         <button id="refreshBtn" class="menu-btn" title="Refresh">
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
             <path d="M15 9A6 6 0 1 0 13.2 13.2"/>
@@ -103,6 +106,7 @@
         </div>
       </section>
 
+      <div id="contentArea">
       <!-- Filters View (Breakdowns) -->
       <div id="filtersView" class="visible">
         <!-- Breakdown Tables -->
@@ -208,6 +212,7 @@
           <div class="logs-loading"><div class="spinner"></div>Loading logs...</div>
         </div>
       </div>
+      </div><!-- end #contentArea -->
     </main>
   </div>
 
@@ -223,7 +228,7 @@
   <!-- More Actions Menu -->
   <dialog id="moreMenu" class="dropdown-menu">
     <button class="menu-item" id="moreViewToggleItem">
-      <span class="menu-item-label">View Logs</span>
+      <span class="menu-item-label">Cycle View</span>
       <kbd class="menu-item-kbd">t</kbd>
     </button>
     <button class="menu-item" id="moreRefreshItem">
@@ -281,7 +286,7 @@
         <div class="key-desc">Focus host filter</div>
 
         <div class="key-group"><kbd>t</kbd></div>
-        <div class="key-desc">Toggle logs view</div>
+        <div class="key-desc">Cycle logs view</div>
 
         <div class="key-group"><kbd>b</kbd> <kbd>#</kbd></div>
         <div class="key-desc">Toggle bytes/count mode</div>

--- a/backend.html
+++ b/backend.html
@@ -286,7 +286,7 @@
         <div class="key-desc">Focus host filter</div>
 
         <div class="key-group"><kbd>t</kbd></div>
-        <div class="key-desc">Cycle logs view</div>
+        <div class="key-desc">Cycle view</div>
 
         <div class="key-group"><kbd>b</kbd> <kbd>#</kbd></div>
         <div class="key-desc">Toggle bytes/count mode</div>

--- a/backend.html
+++ b/backend.html
@@ -228,7 +228,7 @@
   <!-- More Actions Menu -->
   <dialog id="moreMenu" class="dropdown-menu">
     <button class="menu-item" id="moreViewToggleItem">
-      <span class="menu-item-label">Cycle View</span>
+      <span class="menu-item-label">Switch to Logs view</span>
       <kbd class="menu-item-kbd">t</kbd>
     </button>
     <button class="menu-item" id="moreRefreshItem">

--- a/css/facets.css
+++ b/css/facets.css
@@ -5,7 +5,7 @@
 
 .breakdowns {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 16px;
 }
 
@@ -16,18 +16,6 @@
   border: 1px solid var(--border);
   transition: filter 0.2s ease-out, opacity 0.2s ease;
   position: relative;
-}
-
-@media (max-width: 1400px) {
-  .breakdowns {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-@media (max-width: 1000px) {
-  .breakdowns {
-    grid-template-columns: repeat(2, 1fr);
-  }
 }
 
 @media (max-width: 600px) {
@@ -61,23 +49,6 @@
   }
 }
 
-@media (min-width: 1800px) {
-  .breakdowns {
-    grid-template-columns: repeat(5, 1fr);
-  }
-}
-
-@media (min-width: 2200px) {
-  .breakdowns {
-    grid-template-columns: repeat(6, 1fr);
-  }
-}
-
-@media (min-width: 2600px) {
-  .breakdowns {
-    grid-template-columns: repeat(7, 1fr);
-  }
-}
 
 .breakdown-card.updating {
   filter: blur(2px);

--- a/css/layout.css
+++ b/css/layout.css
@@ -92,7 +92,7 @@ header h1 {
     font-size: 16px;
   }
 
-  #viewToggleBtn,
+  .kbd-control:has(#viewCycleBtn),
   #refreshBtn,
   #logoutBtn {
     display: none;
@@ -251,5 +251,37 @@ main {
 @media (max-width: 600px) {
   main {
     padding: 0 12px 16px 12px;
+  }
+}
+
+@media (max-width: 600px) {
+  .kbd-control:has(#viewCycleBtn) {
+    display: none;
+  }
+}
+
+/* Split View Layout */
+#contentArea.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+/* Allow grid children to shrink below content size so overflow-x works */
+#contentArea.split #filtersView,
+#contentArea.split #logsView {
+  min-width: 0;
+}
+
+/* Remove top padding so table and filter cards align at the top */
+#contentArea.split #logsView {
+  padding-top: 0;
+}
+
+/* Below split threshold: stack vertically */
+@media (max-width: 1400px) {
+  #contentArea.split {
+    display: block;
   }
 }

--- a/css/layout.css
+++ b/css/layout.css
@@ -280,7 +280,7 @@ main {
 }
 
 /* Below split threshold: stack vertically */
-@media (max-width: 1400px) {
+@media (max-width: 1500px) {
   #contentArea.split {
     display: block;
   }

--- a/da.html
+++ b/da.html
@@ -271,7 +271,7 @@
         <div class="key-desc">Focus host filter</div>
 
         <div class="key-group"><kbd>t</kbd></div>
-        <div class="key-desc">Cycle logs view</div>
+        <div class="key-desc">Cycle view</div>
 
         <div class="key-group"><kbd>b</kbd> <kbd>#</kbd></div>
         <div class="key-desc">Toggle bytes/count mode</div>

--- a/da.html
+++ b/da.html
@@ -213,7 +213,7 @@
   <!-- More Actions Menu -->
   <dialog id="moreMenu" class="dropdown-menu">
     <button class="menu-item" id="moreViewToggleItem">
-      <span class="menu-item-label">Cycle View</span>
+      <span class="menu-item-label">Switch to Logs view</span>
       <kbd class="menu-item-kbd">t</kbd>
     </button>
     <button class="menu-item" id="moreRefreshItem">

--- a/da.html
+++ b/da.html
@@ -63,14 +63,17 @@
         <select id="topN"></select>
         <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by host..." list="hostSuggestions" autocomplete="off"></span>
         <datalist id="hostSuggestions"></datalist>
-        <button id="viewToggleBtn" class="menu-btn" title="View Logs">
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="2" y="3" width="14" height="12" rx="2"/>
-            <line x1="5" y1="7" x2="13" y2="7"/>
-            <line x1="5" y1="10.5" x2="13" y2="10.5"/>
-            <line x1="5" y1="14" x2="10" y2="14"/>
-          </svg>
-        </button>
+        <span class="kbd-control">
+          <kbd class="kbd-hint">t</kbd>
+          <button id="viewCycleBtn" class="menu-btn" title="Switch to Logs view">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="1" y="1" width="14" height="14" rx="2"/>
+              <line x1="4" y1="5" x2="12" y2="5"/>
+              <line x1="4" y1="8" x2="12" y2="8"/>
+              <line x1="4" y1="11" x2="9" y2="11"/>
+            </svg>
+          </button>
+        </span>
         <button id="refreshBtn" class="menu-btn" title="Refresh">
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
             <path d="M15 9A6 6 0 1 0 13.2 13.2"/>
@@ -103,6 +106,7 @@
         </div>
       </section>
 
+      <div id="contentArea">
       <!-- Filters View (Breakdowns) -->
       <div id="filtersView" class="visible">
         <!-- Breakdown Tables -->
@@ -192,6 +196,7 @@
           <div class="logs-loading"><div class="spinner"></div>Loading logs...</div>
         </div>
       </div>
+      </div><!-- end #contentArea -->
     </main>
   </div>
 
@@ -208,7 +213,7 @@
   <!-- More Actions Menu -->
   <dialog id="moreMenu" class="dropdown-menu">
     <button class="menu-item" id="moreViewToggleItem">
-      <span class="menu-item-label">View Logs</span>
+      <span class="menu-item-label">Cycle View</span>
       <kbd class="menu-item-kbd">t</kbd>
     </button>
     <button class="menu-item" id="moreRefreshItem">
@@ -266,7 +271,7 @@
         <div class="key-desc">Focus host filter</div>
 
         <div class="key-group"><kbd>t</kbd></div>
-        <div class="key-desc">Toggle logs view</div>
+        <div class="key-desc">Cycle logs view</div>
 
         <div class="key-group"><kbd>b</kbd> <kbd>#</kbd></div>
         <div class="key-desc">Toggle bytes/count mode</div>

--- a/delivery.html
+++ b/delivery.html
@@ -303,7 +303,7 @@
         <div class="key-desc">Focus host filter</div>
 
         <div class="key-group"><kbd>t</kbd></div>
-        <div class="key-desc">Cycle logs view</div>
+        <div class="key-desc">Cycle view</div>
 
         <div class="key-group"><kbd>b</kbd> <kbd>#</kbd></div>
         <div class="key-desc">Toggle bytes/count mode</div>

--- a/delivery.html
+++ b/delivery.html
@@ -245,7 +245,7 @@
   <!-- More Actions Menu -->
   <dialog id="moreMenu" class="dropdown-menu">
     <button class="menu-item" id="moreViewToggleItem">
-      <span class="menu-item-label">Cycle View</span>
+      <span class="menu-item-label">Switch to Logs view</span>
       <kbd class="menu-item-kbd">t</kbd>
     </button>
     <button class="menu-item" id="moreRefreshItem">

--- a/delivery.html
+++ b/delivery.html
@@ -63,14 +63,17 @@
         <select id="topN"></select>
         <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by host..." list="hostSuggestions" autocomplete="off"></span>
         <datalist id="hostSuggestions"></datalist>
-        <button id="viewToggleBtn" class="menu-btn" title="View Logs">
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="2" y="3" width="14" height="12" rx="2"/>
-            <line x1="5" y1="7" x2="13" y2="7"/>
-            <line x1="5" y1="10.5" x2="13" y2="10.5"/>
-            <line x1="5" y1="14" x2="10" y2="14"/>
-          </svg>
-        </button>
+        <span class="kbd-control">
+          <kbd class="kbd-hint">t</kbd>
+          <button id="viewCycleBtn" class="menu-btn" title="Switch to Logs view">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="1" y="1" width="14" height="14" rx="2"/>
+              <line x1="4" y1="5" x2="12" y2="5"/>
+              <line x1="4" y1="8" x2="12" y2="8"/>
+              <line x1="4" y1="11" x2="9" y2="11"/>
+            </svg>
+          </button>
+        </span>
         <button id="refreshBtn" class="menu-btn" title="Refresh">
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
             <path d="M15 9A6 6 0 1 0 13.2 13.2"/>
@@ -103,6 +106,7 @@
         </div>
       </section>
 
+      <div id="contentArea">
       <!-- Filters View (Breakdowns) -->
       <div id="filtersView" class="visible">
         <!-- Breakdown Tables -->
@@ -224,6 +228,7 @@
           <div class="logs-loading"><div class="spinner"></div>Loading logs...</div>
         </div>
       </div>
+      </div><!-- end #contentArea -->
     </main>
   </div>
 
@@ -240,7 +245,7 @@
   <!-- More Actions Menu -->
   <dialog id="moreMenu" class="dropdown-menu">
     <button class="menu-item" id="moreViewToggleItem">
-      <span class="menu-item-label">View Logs</span>
+      <span class="menu-item-label">Cycle View</span>
       <kbd class="menu-item-kbd">t</kbd>
     </button>
     <button class="menu-item" id="moreRefreshItem">
@@ -298,7 +303,7 @@
         <div class="key-desc">Focus host filter</div>
 
         <div class="key-group"><kbd>t</kbd></div>
-        <div class="key-desc">Toggle logs view</div>
+        <div class="key-desc">Cycle logs view</div>
 
         <div class="key-group"><kbd>b</kbd> <kbd>#</kbd></div>
         <div class="key-desc">Toggle bytes/count mode</div>

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -44,7 +44,7 @@ import {
   getFilterForValue,
 } from './filters.js';
 import {
-  loadLogs, toggleLogsView, setLogsElements, setOnShowFiltersView, setOnShowLogsView,
+  loadLogs, cycleViewMode, setViewMode, setLogsElements, setOnShowFiltersView, setOnShowLogsView,
 } from './logs.js';
 import { loadHostAutocomplete } from './autocomplete.js';
 import { initModal, closeQuickLinksModal } from './modal.js';
@@ -85,16 +85,21 @@ export function initDashboard(config = {}) {
     hostFilterInput: document.getElementById('hostFilter'),
     refreshBtn: document.getElementById('refreshBtn'),
     logoutBtn: document.getElementById('logoutBtn'),
-    viewToggleBtn: document.getElementById('viewToggleBtn'),
+    viewCycleBtn: document.getElementById('viewCycleBtn'),
     logsView: document.getElementById('logsView'),
     filtersView: document.getElementById('filtersView'),
+    contentArea: document.getElementById('contentArea'),
     dashboardContent: document.getElementById('dashboardContent'),
   };
 
   // Pass elements to modules that need them
   setElements(elements);
   setUrlStateElements(elements);
-  setLogsElements(elements.logsView, elements.viewToggleBtn, elements.filtersView);
+  setLogsElements(
+    elements.logsView,
+    elements.filtersView,
+    elements.contentArea,
+  );
 
   // Load dashboard queries (chart and facets)
   async function loadDashboardQueries(
@@ -182,7 +187,7 @@ export function initDashboard(config = {}) {
     const timeFilter = getTimeFilter();
     const hostFilter = getHostFilter();
 
-    if (state.showLogs) {
+    if (state.viewMode === 'logs' || state.viewMode === 'split') {
       await loadLogs(dashboardContext);
       loadDashboardQueries(timeFilter, hostFilter, dashboardContext, facetsContext, refresh);
     } else {
@@ -439,7 +444,13 @@ export function initDashboard(config = {}) {
       }
     });
 
-    elements.viewToggleBtn.addEventListener('click', () => toggleLogsView(saveStateToURL));
+    elements.viewCycleBtn.addEventListener('click', () => cycleViewMode(saveStateToURL));
+
+    window.matchMedia('(max-width: 1400px)').addEventListener('change', (e) => {
+      if (e.matches && state.viewMode === 'split') {
+        setViewMode('filters', saveStateToURL);
+      }
+    });
 
     window.addEventListener('login-success', () => {
       try {

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -444,7 +444,7 @@ export function initDashboard(config = {}) {
 
     elements.viewCycleBtn.addEventListener('click', () => cycleViewMode(saveStateToURL));
 
-    window.matchMedia('(max-width: 1400px)').addEventListener('change', (e) => {
+    window.matchMedia('(max-width: 1500px)').addEventListener('change', (e) => {
       if (e.matches && state.viewMode === 'split') {
         setViewMode('filters', saveStateToURL);
       }

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -95,11 +95,7 @@ export function initDashboard(config = {}) {
   // Pass elements to modules that need them
   setElements(elements);
   setUrlStateElements(elements);
-  setLogsElements(
-    elements.logsView,
-    elements.filtersView,
-    elements.contentArea,
-  );
+  setLogsElements(elements.logsView, elements.filtersView, elements.contentArea);
 
   // Load dashboard queries (chart and facets)
   async function loadDashboardQueries(

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -44,7 +44,8 @@ import {
   getFilterForValue,
 } from './filters.js';
 import {
-  loadLogs, cycleViewMode, setViewMode, setLogsElements, setOnShowFiltersView, setOnShowLogsView,
+  loadLogs, cycleViewMode, setViewMode, applyViewMode,
+  setLogsElements, setOnShowFiltersView, setOnShowLogsView,
 } from './logs.js';
 import { loadHostAutocomplete } from './autocomplete.js';
 import { initModal, closeQuickLinksModal } from './modal.js';
@@ -373,6 +374,7 @@ export function initDashboard(config = {}) {
       state.credentials = storedCredentials;
       preloadAllTemplates();
       syncUIFromState();
+      applyViewMode();
       reorderFacets();
       showDashboard();
       updateTimeRangeHint();
@@ -452,6 +454,7 @@ export function initDashboard(config = {}) {
       try {
         preloadAllTemplates();
         syncUIFromState();
+        applyViewMode();
         reorderFacets();
         showDashboard();
         updateTimeRangeHint();

--- a/js/keyboard.js
+++ b/js/keyboard.js
@@ -15,7 +15,7 @@ import { openFacetPalette, isPaletteOpen, setOnFacetNavigate } from './facet-pal
 import { zoomToAnomaly, zoomToAnomalyByRank, getAnomalyCount } from './chart.js';
 import { zoomOut } from './time.js';
 import { saveStateToURL } from './url-state.js';
-import { toggleLogsView } from './logs.js';
+import { cycleViewMode } from './logs.js';
 import { openFacetSearch } from './ui/facet-search.js';
 
 // Keyboard navigation state
@@ -368,7 +368,7 @@ const ACTION_HANDLERS = {
   d: () => toggleHideCurrentFacet(),
   r: () => document.getElementById('refreshBtn').click(),
   s: () => openFacetSearchForCurrentFacet(),
-  t: () => toggleLogsView(saveStateToURL),
+  t: () => cycleViewMode(saveStateToURL),
   Escape: () => deactivateKeyboardMode(),
   '+': () => zoomToAnomaly(),
   '=': () => zoomToAnomaly(),

--- a/js/logs.js
+++ b/js/logs.js
@@ -514,7 +514,7 @@ export function setOnShowLogsView(callback) {
   onShowLogsView = callback;
 }
 
-function applyViewMode() {
+export function applyViewMode() {
   const { viewMode } = state;
   const isSplit = viewMode === 'split';
   const isLogs = viewMode === 'logs';

--- a/js/logs.js
+++ b/js/logs.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { DATABASE } from './config.js';
-import { state, setOnPinnedColumnsChange } from './state.js';
+import { state, setOnPinnedColumnsChange, saveViewMode } from './state.js';
 import { query, isAbortError } from './api.js';
 import { getTimeFilter, getHostFilter, getLogsTable } from './time.js';
 import { getFacetFilters } from './breakdowns/index.js';
@@ -92,8 +92,25 @@ function updatePinnedOffsets(container, pinned) {
 
 // DOM elements (set by main.js)
 let logsView = null;
-let viewToggleBtn = null;
 let filtersView = null;
+let contentArea = null;
+
+const CYCLE_MODES = ['filters', 'logs', 'split'];
+const SPLIT_BREAKPOINT = window.matchMedia('(max-width: 1400px)');
+const VIEW_META = {
+  filters: {
+    title: 'Switch to Filters view',
+    icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="6" height="6" rx="1"/><rect x="9" y="1" width="6" height="6" rx="1"/><rect x="1" y="9" width="6" height="6" rx="1"/><rect x="9" y="9" width="6" height="6" rx="1"/></svg>',
+  },
+  logs: {
+    title: 'Switch to Logs view',
+    icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="14" height="14" rx="2"/><line x1="4" y1="5" x2="12" y2="5"/><line x1="4" y1="8" x2="12" y2="8"/><line x1="4" y1="11" x2="9" y2="11"/></svg>',
+  },
+  split: {
+    title: 'Switch to Split view',
+    icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="14" height="14" rx="2"/><line x1="8" y1="1" x2="8" y2="15"/></svg>',
+  },
+};
 
 // Pagination state
 const pagination = new PaginationState();
@@ -457,7 +474,7 @@ async function loadMoreLogs() {
 
 function handleLogsScroll() {
   // Only handle scroll when logs view is visible
-  if (!state.showLogs) { return; }
+  if (state.viewMode === 'filters') { return; }
 
   const { scrollHeight } = document.documentElement;
   const scrollTop = window.scrollY;
@@ -470,10 +487,10 @@ function handleLogsScroll() {
   }
 }
 
-export function setLogsElements(view, toggleBtn, filtersViewEl) {
+export function setLogsElements(view, filtersViewEl, contentAreaEl) {
   logsView = view;
-  viewToggleBtn = toggleBtn;
   filtersView = filtersViewEl;
+  contentArea = contentAreaEl;
 
   // Set up scroll listener for infinite scroll on window
   window.addEventListener('scroll', handleLogsScroll);
@@ -497,26 +514,50 @@ export function setOnShowLogsView(callback) {
   onShowLogsView = callback;
 }
 
-export function toggleLogsView(saveStateToURL) {
-  state.showLogs = !state.showLogs;
-  if (state.showLogs) {
-    logsView.classList.add('visible');
-    filtersView.classList.remove('visible');
-    viewToggleBtn.title = 'View Filters';
-    // Load logs if not already loaded
-    if (onShowLogsView && !state.logsReady) {
-      requestAnimationFrame(() => onShowLogsView());
-    }
-  } else {
-    logsView.classList.remove('visible');
-    filtersView.classList.add('visible');
-    viewToggleBtn.title = 'View Logs';
-    // Redraw chart after view becomes visible
-    if (onShowFiltersView) {
-      requestAnimationFrame(() => onShowFiltersView());
-    }
+function applyViewMode() {
+  const { viewMode } = state;
+  const isSplit = viewMode === 'split';
+  const isLogs = viewMode === 'logs';
+  const showLogs = isLogs || isSplit;
+
+  logsView.classList.toggle('visible', showLogs);
+  filtersView.classList.toggle('visible', !isLogs);
+  filtersView.classList.toggle('in-split', isSplit);
+  if (contentArea) { contentArea.classList.toggle('split', isSplit); }
+
+  const cycleBtn = document.getElementById('viewCycleBtn');
+  if (cycleBtn) {
+    const modes = SPLIT_BREAKPOINT.matches ? ['filters', 'logs'] : CYCLE_MODES;
+    const nextMode = modes[(modes.indexOf(viewMode) + 1) % modes.length];
+    const meta = VIEW_META[nextMode] || VIEW_META.filters;
+    cycleBtn.innerHTML = meta.icon;
+    cycleBtn.title = meta.title;
   }
+
+  if (showLogs && onShowLogsView && !state.logsReady) {
+    requestAnimationFrame(() => onShowLogsView());
+  }
+  if (viewMode !== 'logs' && onShowFiltersView) {
+    requestAnimationFrame(() => onShowFiltersView());
+  }
+}
+
+export function setViewMode(mode, saveStateToURL) {
+  state.viewMode = mode;
+  saveViewMode(mode);
+  applyViewMode();
   saveStateToURL();
+}
+
+export function cycleViewMode(saveStateToURL) {
+  const modes = SPLIT_BREAKPOINT.matches ? ['filters', 'logs'] : CYCLE_MODES;
+  const next = modes[(modes.indexOf(state.viewMode) + 1) % modes.length];
+  setViewMode(next, saveStateToURL);
+}
+
+/** @deprecated use setViewMode / cycleViewMode */
+export function toggleLogsView(saveStateToURL) {
+  cycleViewMode(saveStateToURL);
 }
 
 export async function loadLogs(requestContext = getRequestContext('dashboard')) {

--- a/js/logs.js
+++ b/js/logs.js
@@ -525,14 +525,18 @@ function applyViewMode() {
   filtersView.classList.toggle('in-split', isSplit);
   if (contentArea) { contentArea.classList.toggle('split', isSplit); }
 
+  const modes = SPLIT_BREAKPOINT.matches ? ['filters', 'logs'] : CYCLE_MODES;
+  const nextMode = modes[(modes.indexOf(viewMode) + 1) % modes.length];
+  const meta = VIEW_META[nextMode] || VIEW_META.filters;
+
   const cycleBtn = document.getElementById('viewCycleBtn');
   if (cycleBtn) {
-    const modes = SPLIT_BREAKPOINT.matches ? ['filters', 'logs'] : CYCLE_MODES;
-    const nextMode = modes[(modes.indexOf(viewMode) + 1) % modes.length];
-    const meta = VIEW_META[nextMode] || VIEW_META.filters;
     cycleBtn.innerHTML = meta.icon;
     cycleBtn.title = meta.title;
   }
+
+  const moreLabel = document.querySelector('#moreViewToggleItem .menu-item-label');
+  if (moreLabel) { moreLabel.textContent = meta.title; }
 
   if (showLogs && onShowLogsView && !state.logsReady) {
     requestAnimationFrame(() => onShowLogsView());

--- a/js/modal.js
+++ b/js/modal.js
@@ -9,6 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { cycleViewMode } from './logs.js';
+import { saveStateToURL } from './url-state.js';
+
 let quickLinksModal = null;
 let moreMenu = null;
 let menuBtn = null;
@@ -114,7 +117,7 @@ export function initModal() {
 
     // Delegate menu item clicks to real header buttons
     document.getElementById('moreViewToggleItem')?.addEventListener('click', () => {
-      document.getElementById('viewToggleBtn').click();
+      cycleViewMode(saveStateToURL);
     });
     document.getElementById('moreRefreshItem')?.addEventListener('click', () => {
       document.getElementById('refreshBtn').click();

--- a/js/state.js
+++ b/js/state.js
@@ -28,7 +28,7 @@ export const state = {
   logsData: null,
   logsLoading: false,
   logsReady: false,
-  showLogs: false,
+  viewMode: storage.getItem('viewMode') || 'filters', // 'filters' | 'logs' | 'split'
   pinnedColumns: JSON.parse(storage.getItem('pinnedColumns') || '[]'),
   hiddenControls: [], // ['timeRange', 'topN', 'host', 'refresh', 'logout', 'logs']
   title: '', // Custom title from URL
@@ -45,6 +45,10 @@ export const state = {
   hostFilterColumn: null, // Optional column for header filter (e.g. function_name for lambda)
   breakdowns: null, // Optional override breakdown list (e.g. lambda facets)
 };
+
+export function saveViewMode(mode) {
+  storage.setItem('viewMode', mode);
+}
 
 // Callback for re-rendering logs table when pinned columns change
 // Set by logs.js to avoid circular dependencies

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -51,7 +51,7 @@ function addBasicParams(params) {
   if (state.timeRange !== DEFAULT_TIME_RANGE) { params.set('t', state.timeRange); }
   if (state.hostFilter) { params.set('host', state.hostFilter); }
   if (state.topN !== DEFAULT_TOP_N) { params.set('n', state.topN); }
-  if (state.showLogs) { params.set('view', 'logs'); }
+  if (state.viewMode !== 'filters') { params.set('view', state.viewMode); }
   if (state.title) { params.set('title', state.title); }
   if (state.contentTypeMode !== 'count') { params.set('ctm', state.contentTypeMode); }
 }
@@ -123,7 +123,8 @@ function loadBasicState(params) {
     const n = parseInt(params.get('n'), 10);
     if (TOP_N_OPTIONS.includes(n)) { state.topN = n; }
   }
-  if (params.get('view') === 'logs') { state.showLogs = true; }
+  const view = params.get('view');
+  if (view === 'logs' || view === 'split') { state.viewMode = view; }
   if (params.has('title')) { state.title = params.get('title'); }
   if (params.has('ctm') && ['count', 'bytes'].includes(params.get('ctm'))) {
     state.contentTypeMode = params.get('ctm');
@@ -219,17 +220,14 @@ export function syncUIFromState() {
     document.title = 'CDN Analytics';
   }
 
-  // Update view toggle based on state
-  if (state.showLogs) {
-    elements.logsView.classList.add('visible');
-    elements.filtersView.classList.remove('visible');
-    elements.viewToggleBtn.title = 'View Filters';
-  } else {
-    elements.logsView.classList.remove('visible');
-    elements.filtersView.classList.add('visible');
-    elements.viewToggleBtn.title = 'View Logs';
-  }
-
+  // Apply view mode to DOM
+  const { viewMode } = state;
+  const isSplit = viewMode === 'split';
+  const isLogs = viewMode === 'logs';
+  elements.logsView.classList.toggle('visible', isLogs || isSplit);
+  elements.filtersView.classList.toggle('visible', !isLogs);
+  elements.filtersView.classList.toggle('in-split', isSplit);
+  if (elements.contentArea) { elements.contentArea.classList.toggle('split', isSplit); }
   // Apply hidden controls from URL
   if (state.hiddenControls.includes('timeRange')) {
     elements.timeRangeSelect.style.display = 'none';
@@ -247,7 +245,7 @@ export function syncUIFromState() {
     elements.logoutBtn.style.display = 'none';
   }
   if (state.hiddenControls.includes('logs')) {
-    elements.viewToggleBtn.style.display = 'none';
+    if (elements.viewCycleBtn) { elements.viewCycleBtn.style.display = 'none'; }
   }
 }
 

--- a/js/url-state.test.js
+++ b/js/url-state.test.js
@@ -27,7 +27,7 @@ function resetState() {
   state.hostFilter = '';
   state.topN = DEFAULT_TOP_N;
   state.filters = [];
-  state.showLogs = false;
+  state.viewMode = 'filters';
   state.title = '';
   state.contentTypeMode = 'count';
   state.hiddenControls = [];
@@ -137,22 +137,28 @@ describe('loadStateFromURL', () => {
   });
 
   describe('view mode', () => {
-    it('sets showLogs when view=logs', () => {
+    it('sets viewMode to logs when view=logs', () => {
       setURL({ view: 'logs' });
       loadStateFromURL();
-      assert.strictEqual(state.showLogs, true);
+      assert.strictEqual(state.viewMode, 'logs');
     });
 
-    it('does not set showLogs for other values', () => {
+    it('sets viewMode to split when view=split', () => {
+      setURL({ view: 'split' });
+      loadStateFromURL();
+      assert.strictEqual(state.viewMode, 'split');
+    });
+
+    it('keeps default viewMode for other values', () => {
       setURL({ view: 'other' });
       loadStateFromURL();
-      assert.strictEqual(state.showLogs, false);
+      assert.strictEqual(state.viewMode, 'filters');
     });
 
-    it('does not set showLogs when absent', () => {
+    it('keeps default viewMode when absent', () => {
       setURL({});
       loadStateFromURL();
-      assert.strictEqual(state.showLogs, false);
+      assert.strictEqual(state.viewMode, 'filters');
     });
   });
 
@@ -390,7 +396,7 @@ describe('loadStateFromURL', () => {
       assert.strictEqual(state.timeRange, '7d');
       assert.strictEqual(state.hostFilter, 'cdn.example.com');
       assert.strictEqual(state.topN, 20);
-      assert.strictEqual(state.showLogs, true);
+      assert.strictEqual(state.viewMode, 'logs');
       assert.strictEqual(state.title, 'Test Dashboard');
       assert.strictEqual(state.filters.length, 1);
     });
@@ -493,15 +499,22 @@ describe('saveStateToURL', () => {
     assert.strictEqual(new Date(params.get('ts')).toISOString(), '2026-01-20T12:00:00.000Z');
   });
 
-  it('encodes showLogs as view=logs', () => {
-    state.showLogs = true;
+  it('encodes logs viewMode as view=logs', () => {
+    state.viewMode = 'logs';
     saveStateToURL();
     const params = new URLSearchParams(window.location.search);
     assert.strictEqual(params.get('view'), 'logs');
   });
 
-  it('omits view param when showLogs is false', () => {
-    state.showLogs = false;
+  it('encodes split viewMode as view=split', () => {
+    state.viewMode = 'split';
+    saveStateToURL();
+    const params = new URLSearchParams(window.location.search);
+    assert.strictEqual(params.get('view'), 'split');
+  });
+
+  it('omits view param when viewMode is filters', () => {
+    state.viewMode = 'filters';
     saveStateToURL();
     const params = new URLSearchParams(window.location.search);
     assert.isFalse(params.has('view'));
@@ -642,7 +655,7 @@ describe('saveStateToURL and loadStateFromURL round-trip', () => {
     state.timeRange = '24h';
     state.hostFilter = 'example.com';
     state.topN = 20;
-    state.showLogs = true;
+    state.viewMode = 'logs';
     state.title = 'Test';
     state.contentTypeMode = 'bytes';
     state.filters = [{ col: '`request.host`', value: 'test.com', exclude: false }];
@@ -660,7 +673,7 @@ describe('saveStateToURL and loadStateFromURL round-trip', () => {
     assert.strictEqual(state.timeRange, '24h');
     assert.strictEqual(state.hostFilter, 'example.com');
     assert.strictEqual(state.topN, 20);
-    assert.strictEqual(state.showLogs, true);
+    assert.strictEqual(state.viewMode, 'logs');
     assert.strictEqual(state.title, 'Test');
     assert.strictEqual(state.contentTypeMode, 'bytes');
     assert.strictEqual(state.filters.length, 1);
@@ -726,7 +739,8 @@ describe('syncUIFromState', () => {
       hostFilterInput: document.createElement('input'),
       logsView: document.createElement('div'),
       filtersView: document.createElement('div'),
-      viewToggleBtn: document.createElement('button'),
+      contentArea: document.createElement('div'),
+      viewCycleBtn: document.createElement('button'),
       refreshBtn: document.createElement('button'),
       logoutBtn: document.createElement('button'),
     };
@@ -794,20 +808,26 @@ describe('syncUIFromState', () => {
     assert.strictEqual(document.title, 'CDN Analytics');
   });
 
-  it('shows logs view when showLogs is true', () => {
-    state.showLogs = true;
+  it('shows logs view when viewMode is logs', () => {
+    state.viewMode = 'logs';
     syncUIFromState();
     assert.isTrue(mockElements.logsView.classList.contains('visible'));
     assert.isFalse(mockElements.filtersView.classList.contains('visible'));
-    assert.strictEqual(mockElements.viewToggleBtn.title, 'View Filters');
   });
 
-  it('shows filters view when showLogs is false', () => {
-    state.showLogs = false;
+  it('shows filters view when viewMode is filters', () => {
+    state.viewMode = 'filters';
     syncUIFromState();
     assert.isFalse(mockElements.logsView.classList.contains('visible'));
     assert.isTrue(mockElements.filtersView.classList.contains('visible'));
-    assert.strictEqual(mockElements.viewToggleBtn.title, 'View Logs');
+  });
+
+  it('shows both panels in split view', () => {
+    state.viewMode = 'split';
+    syncUIFromState();
+    assert.isTrue(mockElements.logsView.classList.contains('visible'));
+    assert.isTrue(mockElements.filtersView.classList.contains('visible'));
+    assert.isTrue(mockElements.contentArea.classList.contains('split'));
   });
 
   it('hides controls based on hiddenControls', () => {
@@ -818,7 +838,7 @@ describe('syncUIFromState', () => {
     assert.strictEqual(mockElements.hostFilterInput.style.display, 'none');
     assert.strictEqual(mockElements.refreshBtn.style.display, 'none');
     assert.strictEqual(mockElements.logoutBtn.style.display, 'none');
-    assert.strictEqual(mockElements.viewToggleBtn.style.display, 'none');
+    assert.strictEqual(mockElements.viewCycleBtn.style.display, 'none');
   });
 
   it('does not hide controls when hiddenControls is empty', () => {

--- a/lambda.html
+++ b/lambda.html
@@ -252,7 +252,7 @@
         <div class="key-desc">Focus function filter</div>
 
         <div class="key-group"><kbd>t</kbd></div>
-        <div class="key-desc">Cycle logs view</div>
+        <div class="key-desc">Cycle view</div>
 
         <div class="key-group"><kbd>1</kbd>-<kbd>5</kbd></div>
         <div class="key-desc">Zoom to anomaly by rank</div>

--- a/lambda.html
+++ b/lambda.html
@@ -194,7 +194,7 @@
   <!-- More Actions Menu -->
   <dialog id="moreMenu" class="dropdown-menu">
     <button class="menu-item" id="moreViewToggleItem">
-      <span class="menu-item-label">Cycle View</span>
+      <span class="menu-item-label">Switch to Logs view</span>
       <kbd class="menu-item-kbd">t</kbd>
     </button>
     <button class="menu-item" id="moreRefreshItem">

--- a/lambda.html
+++ b/lambda.html
@@ -63,14 +63,17 @@
         <select id="topN"></select>
         <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by function..." list="hostSuggestions" autocomplete="off"></span>
         <datalist id="hostSuggestions"></datalist>
-        <button id="viewToggleBtn" class="menu-btn" title="View Logs">
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="2" y="3" width="14" height="12" rx="2"/>
-            <line x1="5" y1="7" x2="13" y2="7"/>
-            <line x1="5" y1="10.5" x2="13" y2="10.5"/>
-            <line x1="5" y1="14" x2="10" y2="14"/>
-          </svg>
-        </button>
+        <span class="kbd-control">
+          <kbd class="kbd-hint">t</kbd>
+          <button id="viewCycleBtn" class="menu-btn" title="Switch to Logs view">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="1" y="1" width="14" height="14" rx="2"/>
+              <line x1="4" y1="5" x2="12" y2="5"/>
+              <line x1="4" y1="8" x2="12" y2="8"/>
+              <line x1="4" y1="11" x2="9" y2="11"/>
+            </svg>
+          </button>
+        </span>
         <button id="refreshBtn" class="menu-btn" title="Refresh">
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
             <path d="M15 9A6 6 0 1 0 13.2 13.2"/>
@@ -103,6 +106,7 @@
         </div>
       </section>
 
+      <div id="contentArea">
       <!-- Filters View (Breakdowns) -->
       <div id="filtersView" class="visible">
         <!-- Breakdown Tables -->
@@ -174,6 +178,7 @@
           <div class="logs-loading"><div class="spinner"></div>Loading logs...</div>
         </div>
       </div>
+      </div><!-- end #contentArea -->
     </main>
   </div>
 
@@ -189,7 +194,7 @@
   <!-- More Actions Menu -->
   <dialog id="moreMenu" class="dropdown-menu">
     <button class="menu-item" id="moreViewToggleItem">
-      <span class="menu-item-label">View Logs</span>
+      <span class="menu-item-label">Cycle View</span>
       <kbd class="menu-item-kbd">t</kbd>
     </button>
     <button class="menu-item" id="moreRefreshItem">
@@ -247,7 +252,7 @@
         <div class="key-desc">Focus function filter</div>
 
         <div class="key-group"><kbd>t</kbd></div>
-        <div class="key-desc">Toggle logs view</div>
+        <div class="key-desc">Cycle logs view</div>
 
         <div class="key-group"><kbd>1</kbd>-<kbd>5</kbd></div>
         <div class="key-desc">Zoom to anomaly by rank</div>


### PR DESCRIPTION
## Summary

Adds a **split view** mode to the dashboard so filters/breakdowns and the log table can be visible simultaneously on wide screens, with the chart spanning full width at the top.

Previously the view toggle was binary (filters OR logs). This PR introduces a third mode and replaces the old toggle button with a cycle button whose icon shows the next destination view.

- `viewMode` string enum (`'filters' | 'logs' | 'split'`) replaces the previous `showLogs` boolean; preference is persisted in localStorage and survives navigation between dashboards
- New cycle button replaces the old toggle; icon always reflects the actual next mode
- Split is excluded from the cycle on viewports ≤1400px; a `matchMedia` listener auto-switches from split to filters when resizing below that threshold
- `?view=split` URL param supported for deep-linking (existing `?view=logs` behaviour unchanged)
- Breakdowns grid uses `repeat(auto-fit, minmax(300px, 1fr))` so cards never overflow into the log column at any width
- `t` kbd hint is attached to the cycle button and the entire wrapper is hidden on mobile, preventing the hint from floating loose when the button is hidden
- All 5 dashboards updated (delivery, backend, admin, da, lambda)

## Testing Done

- `npm test` — 866/866 pass
- `npm run lint` — clean
- Verified split/filters/logs cycle, icon updates, and `?view=split` URL loading
- Verified kbd hint placement on mobile

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)