### PR TITLE
fix(lambda): commit facet MV DDL and add SELECT grant for lambda_logs_writer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ New users get SELECT access to `delivery`, `delivery_errors`, `admin`, `backend`
 - `max_parallel_replicas = 6` — use up to 6 replicas for parallel reads
 - `max_memory_usage = 4000000000` — 4 GB per-query memory limit to protect small replicas
 
-Writer users (`logpush_writer`, `releases_writer`, `lambda_logs_writer`) get only the memory limit (no parallel replicas for inserts).
+Writer users (`logpush_writer`, `releases_writer`, `lambda_logs_writer`) are managed manually, outside `add-user.mjs`. Their canonical grants live in [`sql/writer_users.sql`](sql/writer_users.sql) — diff with `SHOW GRANTS FOR <user>` before applying. They get only the memory limit (no parallel replicas for inserts). Note: chained materialized views run in the inserter's security context, so a writer needs `SELECT` on every table any downstream MV reads, not just `INSERT` on the staging table.
 
 ## Data Pipeline Architecture
 

--- a/sql/lambda_logs_tables.sql
+++ b/sql/lambda_logs_tables.sql
@@ -86,6 +86,60 @@ AS SELECT
     extractAll(message, '[a-zA-Z0-9_-]+--[a-zA-Z0-9_-]+--[a-zA-Z0-9_-]+')     AS refs
 FROM helix_logs_production.lambda_logs_incoming;
 
+-- Per-minute facet rollup: SummingMergeTree fed by the MV below.
+-- Mirrors cdn_facet_minutes (delivery dashboard); used by the Lambda Logs dashboard
+-- to serve low-cardinality breakdowns without scanning lambda_logs directly.
+CREATE TABLE IF NOT EXISTS helix_logs_production.lambda_facet_minutes
+(
+    `minute` DateTime,
+    `facet`  LowCardinality(String),
+    `dim`    String,
+    `cnt`    UInt64,
+    `cnt_ok`  UInt64,
+    `cnt_4xx` UInt64,
+    `cnt_5xx` UInt64
+)
+ENGINE = SummingMergeTree
+PARTITION BY toDate(minute)
+ORDER BY (facet, minute, dim)
+TTL minute + toIntervalDay(14);
+
+-- Materialized view: ARRAY JOINs each lambda_logs row into 7 facet entries
+-- (level, function_name, function_version, app_name, subsystem, log_group, admin_method)
+-- and pre-aggregates per minute.
+--
+-- IMPORTANT: This MV is chained off lambda_logs, which is itself written by the
+-- lambda_logs_ingestion MV from lambda_logs_incoming. Chained MVs run in the
+-- inserter's security context, so lambda_logs_writer must have SELECT on
+-- lambda_logs (see GRANT block below) — without it, every insert into
+-- lambda_logs_incoming fails with ACCESS_DENIED.
+CREATE MATERIALIZED VIEW IF NOT EXISTS helix_logs_production.lambda_facet_minutes_mv
+TO helix_logs_production.lambda_facet_minutes
+AS SELECT
+    toStartOfMinute(timestamp) AS minute,
+    facet,
+    dim,
+    count()                                                  AS cnt,
+    countIf(lower(level) NOT IN ('error', 'warn', 'warning')) AS cnt_ok,
+    countIf(lower(level) IN ('warn', 'warning'))             AS cnt_4xx,
+    countIf(lower(level) = 'error')                          AS cnt_5xx
+FROM helix_logs_production.lambda_logs
+ARRAY JOIN
+    ['level', 'function_name', 'function_version', 'app_name', 'subsystem', 'log_group', 'admin_method'] AS facet,
+    [
+        toString(level),
+        replaceRegexpOne(function_name, '/[^/]+$', ''),
+        arrayElement(splitByChar('/', function_name), -1),
+        toString(app_name),
+        toString(subsystem),
+        toString(log_group),
+        CAST(message_json.admin.method, 'String')
+    ] AS dim
+GROUP BY minute, facet, dim;
+
 -- Writer user (set password before running)
 -- CREATE USER lambda_logs_writer IDENTIFIED BY '<password>';
--- GRANT INSERT ON helix_logs_production.lambda_logs_incoming TO lambda_logs_writer;
+-- GRANT SELECT, INSERT ON helix_logs_production.lambda_logs_incoming TO lambda_logs_writer;
+-- GRANT INSERT ON helix_logs_production.lambda_logs TO lambda_logs_writer;
+-- -- Required because lambda_facet_minutes_mv reads lambda_logs in the inserter's context:
+-- GRANT SELECT ON helix_logs_production.lambda_logs TO lambda_logs_writer;

--- a/sql/writer_users.sql
+++ b/sql/writer_users.sql
@@ -1,0 +1,97 @@
+-- Writer users for ingestion pipelines.
+--
+-- These users are managed manually, outside scripts/add-user.mjs (which only
+-- creates *read-only* dashboard users). roll-user.mjs rotates passwords but
+-- does not touch grants, so rotations are safe.
+--
+-- This file is the canonical source for *intentional* grants. Real grants in
+-- the cluster may have drifted — before applying, diff with:
+--   SHOW GRANTS FOR <user>;
+--
+-- Run as `default` (admin). Substitute the writer password from the password
+-- manager (see README.local.md).
+
+-- ============================================================================
+-- logpush_writer
+-- ----------------------------------------------------------------------------
+-- Used by:
+--   - Cloudflare Logpush jobs   (HTTPS POST to ClickHouse on each batch)
+--   - Fastly HTTP logging       (HTTPS POST to ClickHouse on each batch)
+--   - helix-gcs2clickhouse-ingestor (Cloud Run service for GCS → ClickHouse)
+--
+-- Ingest path: each source inserts into a per-source staging table; chained
+-- materialized views fan rows out into delivery / delivery_errors / backend /
+-- admin / da. Because chained MVs run in the inserter's security context, this
+-- user needs SELECT on `delivery` (the columns that cdn_facet_minutes_mv reads)
+-- in addition to the obvious INSERTs.
+-- ============================================================================
+
+-- CREATE USER logpush_writer IDENTIFIED BY '<password>';
+
+-- Raw staging tables (one per source):
+GRANT SELECT, INSERT ON helix_logs_production.cloudflare_http_requests TO logpush_writer;
+GRANT SELECT, INSERT ON helix_logs_production.fastly_logs_incoming2   TO logpush_writer;
+-- Per-Fastly-service backend staging tables:
+GRANT SELECT, INSERT ON helix_logs_production.fastly_logs_incoming_00QRLuuAsVNvsKgNWYVCbb TO logpush_writer;
+GRANT SELECT, INSERT ON helix_logs_production.fastly_logs_incoming_6a6O21m8WoIIVg5cliw7BW TO logpush_writer;
+GRANT SELECT, INSERT ON helix_logs_production.fastly_logs_incoming_ItVEMJu5q2pJE3ejseo0W6 TO logpush_writer;
+GRANT SELECT, INSERT ON helix_logs_production.fastly_logs_incoming_SIDuP3HxleUgBDR3Gi8T24 TO logpush_writer;
+GRANT SELECT, INSERT ON helix_logs_production.fastly_logs_incoming_UDBDj4zfyNdZEpZApUqhL3 TO logpush_writer;
+GRANT SELECT, INSERT ON helix_logs_production.fastly_logs_incoming_atG7Eq66bH88LhbNq7Fqq2 TO logpush_writer;
+GRANT SELECT, INSERT ON helix_logs_production.fastly_logs_incoming_cHpjIl1WNRu9SFyL1eBSj3 TO logpush_writer;
+GRANT SELECT, INSERT ON helix_logs_production.fastly_logs_incoming_s2dVksBUsvEKaaYF13wIh6 TO logpush_writer;
+
+-- Final tables (INSERT for the ingestion MVs, ALTER DELETE for retention jobs):
+GRANT INSERT, ALTER DELETE ON helix_logs_production.admin           TO logpush_writer;
+GRANT INSERT, ALTER DELETE ON helix_logs_production.backend         TO logpush_writer;
+GRANT INSERT             ON helix_logs_production.delivery_errors TO logpush_writer;
+GRANT SELECT, INSERT     ON helix_logs_production.da              TO logpush_writer;
+GRANT INSERT             ON helix_logs_production.asn_mapping     TO logpush_writer;
+
+-- delivery: INSERT plus ALTER DELETE for retention; SELECT on the specific
+-- columns that cdn_facet_minutes_mv reads (chained-MV permission requirement):
+GRANT INSERT, ALTER DELETE,
+      SELECT(
+          timestamp, source, weight,
+          `request.method`,
+          `request.headers.accept`, `request.headers.accept_encoding`, `request.headers.cache_control`,
+          `request.headers.x_byo_cdn_type`,
+          `response.status`, `response.headers.content_type`, `response.headers.x_error`,
+          `cdn.cache_status`, `cdn.datacenter`,
+          `helix.request_type`, `helix.backend_type`
+      )
+ON helix_logs_production.delivery TO logpush_writer;
+
+-- Mutation visibility (so retention jobs can poll progress):
+GRANT SELECT ON system.mutations TO logpush_writer;
+GRANT SELECT(query, query_id, user) ON system.processes TO logpush_writer;
+
+-- ============================================================================
+-- releases_writer
+-- ----------------------------------------------------------------------------
+-- Used by:
+--   - GitHub Action ingesting the AEM release feed → releases
+--   - On-call ingestion → oncall_shifts (reads user_shifts to resolve users)
+-- ============================================================================
+
+-- CREATE USER releases_writer IDENTIFIED BY '<password>';
+
+GRANT INSERT ON helix_logs_production.releases      TO releases_writer;
+GRANT INSERT ON helix_logs_production.oncall_shifts TO releases_writer;
+GRANT SELECT ON helix_logs_production.user_shifts   TO releases_writer;
+GRANT SELECT(query, query_id, user) ON system.processes TO releases_writer;
+
+-- ============================================================================
+-- lambda_logs_writer
+-- ----------------------------------------------------------------------------
+-- See sql/lambda_logs_tables.sql for the canonical setup. Repeated here for
+-- discoverability.
+-- ============================================================================
+
+-- CREATE USER lambda_logs_writer IDENTIFIED BY '<password>';
+
+GRANT SELECT, INSERT ON helix_logs_production.lambda_logs_incoming TO lambda_logs_writer;
+GRANT INSERT         ON helix_logs_production.lambda_logs          TO lambda_logs_writer;
+-- Required because lambda_facet_minutes_mv reads lambda_logs in the inserter's context:
+GRANT SELECT         ON helix_logs_production.lambda_logs          TO lambda_logs_writer;
+GRANT SELECT(query, query_id, user) ON system.processes TO lambda_logs_writer;


### PR DESCRIPTION
## Summary

Today (2026-05-07) Tobias noticed `lambda_logs` was missing ~98% of recent rows: `lambda_logs_incoming` had ~48M rows over 24h while `lambda_logs` only had ~30k.

Root cause: on **2026-05-05 16:37:59 UTC** a new chained materialized view `lambda_facet_minutes_mv` was created **out-of-band** (no commit in this repo). It reads from `lambda_logs`, and ClickHouse runs chained MVs in the **inserter's** security context — so `lambda_logs_writer` suddenly needed `SELECT` on `lambda_logs`. It only had `INSERT`. Every insert into `lambda_logs_incoming` from that minute on failed with `Code: 497. ACCESS_DENIED`, and `system.text_log` filled up at ~30k errors/hour.

The fix grant `GRANT SELECT ON helix_logs_production.lambda_logs TO lambda_logs_writer` was applied to the cluster directly during the incident. This PR captures the missing DDL and grant in source so it's reproducible, plus closes a broader gap.

### What's in here

- **`sql/lambda_logs_tables.sql`** — adds the `lambda_facet_minutes` table + `lambda_facet_minutes_mv` definitions (previously only existed in the cluster), and updates the writer-user setup block to include the missing `GRANT SELECT ON lambda_logs`. A comment block explains *why* the SELECT is required (chained-MV security context) so the next person doesn't re-introduce the same bug.
- **`sql/writer_users.sql`** *(new)* — canonical setup for `logpush_writer`, `releases_writer`, and `lambda_logs_writer`. Until now these users had no source-controlled definition at all (`add-user.mjs` is read-only-only; `roll-user.mjs` is grant-safe but doesn't manage them). The file is annotated to diff against `SHOW GRANTS FOR <user>` before applying, since live grants may have drifted.
- **`CLAUDE.md`** — updates the "Writer users" line to point at the new file and note the chained-MV gotcha.

### What's *not* in here

- The grant has already been applied to the cluster (during incident response), so this PR is just source-of-truth.
- A separate task: backfill the ~46M lost rows from `lambda_logs_incoming` (still inside its 1-day TTL window) into `lambda_logs`. Will follow as a one-shot SQL script once we agree on dedup approach.

## Testing Done

- Verified the grant fixed live ingestion: post-grant minutes show 100% pass-through (`incoming` count == `lambda_logs` count) and `ACCESS_DENIED` errors in `system.text_log` dropped to zero by 2026-05-07 11:55 UTC.
- Cross-checked `logpush_writer` grants in production to model the writer-user file accurately (it has the same chained-MV pattern with `cdn_facet_minutes_mv` reading from `delivery`, hence the column-level SELECT grants).
- DDL parses against current ClickHouse Cloud (the table and MV are already live, so the `IF NOT EXISTS` clauses make this idempotent).

## Checklist
- [ ] Tests pass (`npm test`) — n/a, SQL/docs only
- [ ] Lint passes (`npm run lint`) — n/a, no JS changes
- [x] Documentation updated (CLAUDE.md updated to reference new file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)