### PR TITLE
fix(ux): fix split-view init — missing chart and wrong breakpoint

### DIFF
--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -374,7 +374,7 @@ export function initDashboard(config = {}) {
       state.credentials = storedCredentials;
       preloadAllTemplates();
       syncUIFromState();
-      applyViewMode();
+      applyViewMode(true);
       reorderFacets();
       showDashboard();
       updateTimeRangeHint();
@@ -454,7 +454,7 @@ export function initDashboard(config = {}) {
       try {
         preloadAllTemplates();
         syncUIFromState();
-        applyViewMode();
+        applyViewMode(true);
         reorderFacets();
         showDashboard();
         updateTimeRangeHint();

--- a/js/logs.js
+++ b/js/logs.js
@@ -96,7 +96,7 @@ let filtersView = null;
 let contentArea = null;
 
 const CYCLE_MODES = ['filters', 'logs', 'split'];
-const SPLIT_BREAKPOINT = window.matchMedia('(max-width: 1400px)');
+const SPLIT_BREAKPOINT = window.matchMedia('(max-width: 1500px)');
 const VIEW_META = {
   filters: {
     title: 'Switch to Filters view',
@@ -514,7 +514,7 @@ export function setOnShowLogsView(callback) {
   onShowLogsView = callback;
 }
 
-export function applyViewMode() {
+export function applyViewMode(suppressDataLoad = false) {
   const { viewMode } = state;
   const isSplit = viewMode === 'split';
   const isLogs = viewMode === 'logs';
@@ -538,11 +538,13 @@ export function applyViewMode() {
   const moreLabel = document.querySelector('#moreViewToggleItem .menu-item-label');
   if (moreLabel) { moreLabel.textContent = meta.title; }
 
-  if (showLogs && onShowLogsView && !state.logsReady) {
-    requestAnimationFrame(() => onShowLogsView());
-  }
-  if (viewMode !== 'logs' && onShowFiltersView) {
-    requestAnimationFrame(() => onShowFiltersView());
+  if (!suppressDataLoad) {
+    if (showLogs && onShowLogsView && !state.logsReady) {
+      requestAnimationFrame(() => onShowLogsView());
+    }
+    if (viewMode !== 'logs' && onShowFiltersView) {
+      requestAnimationFrame(() => onShowFiltersView());
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Two regressions introduced in PR #192 (split-view):

**1. Chart never renders on initial load in split/logs mode**

When `viewMode` is `'split'` or `'logs'` (stored in localStorage), `applyViewMode()` scheduled a `requestAnimationFrame` that called `onShowLogsView()`. That RAF fired after `loadDashboard()` had already suspended at `await loadLogs(...)`, and `onShowLogsView` called `startRequestContext('dashboard')` — which bumped the request ID and aborted the signal that `loadTimeSeries()` was holding. The chart fetch was immediately aborted, so the chart never rendered. Interacting with a filter called `loadDashboard()` again with a fresh signal, which is why it recovered then.

Fix: pass `suppressDataLoad = true` from both init call sites in `dashboard-init.js`. `loadDashboard()` already drives `loadLogs` and `loadDashboardQueries` — the RAF callbacks in `applyViewMode` are only needed for user-triggered view switches.

**2. Log panel stacks below filter cards between 1400–1500px viewports**

Commit `3cf634e` updated the split breakpoint to 1500px in `layout.css` and the resize listener in `dashboard-init.js`, but left `SPLIT_BREAKPOINT` in `logs.js` at `1400px`. Between 1400–1500px: CSS collapsed the grid to `display: block`, but JS still offered and allowed split mode, so users saw stacked panels while the state said "split."

Fix: update `SPLIT_BREAKPOINT` in `logs.js` to `(max-width: 1500px)`.

## Testing Done

- `npm test` — 866 tests, 0 failed
- `npm run lint` — clean

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)