### PR TITLE
fix: do not filter when selection non-empty

### DIFF
--- a/js/ui/actions.js
+++ b/js/ui/actions.js
@@ -31,6 +31,8 @@
  * Handle add-filter action
  */
 function handleAddFilter(handlers, target, event) {
+  const selection = window.getSelection?.();
+  if (selection && selection.toString().length > 0) { return; }
   const exclude = event.shiftKey || target.dataset.exclude === 'true';
   handlers.addFilter?.(
     target.dataset.col || '',


### PR DESCRIPTION
## Summary
- Clicking a cell with `data-action="add-filter"` previously fired after a text-selection drag, because mouseup-on-same-element synthesizes a click. Now `handleAddFilter` bails out when `window.getSelection()` is non-empty, so users can drag-select cell contents without unintentionally applying a filter.
- Clicks without an active selection still add filters as before.

## Testing Done
- `npm run lint` clean
- `npm test` — all 884 tests pass
- Manual: dragging to select text inside a log cell no longer triggers a filter; a plain click still does.

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)