### PR TITLE
feat(lambda): search by invocation ID or message

### DIFF
--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -85,6 +85,7 @@ export function initDashboard(config = {}) {
     timeRangeSelect: document.getElementById('timeRange'),
     topNSelect: document.getElementById('topN'),
     hostFilterInput: document.getElementById('hostFilter'),
+    searchFilterInput: document.getElementById('searchFilter'),
     refreshBtn: document.getElementById('refreshBtn'),
     logoutBtn: document.getElementById('logoutBtn'),
     viewCycleBtn: document.getElementById('viewCycleBtn'),
@@ -298,6 +299,15 @@ export function initDashboard(config = {}) {
     }
   }
 
+  function applySearchConfig() {
+    if (config.requestIdColumn !== undefined) {
+      state.requestIdColumn = config.requestIdColumn;
+    }
+    if (config.messageColumn !== undefined) {
+      state.messageColumn = config.messageColumn;
+    }
+  }
+
   function applyConfig(initialParams) {
     if (config.title && !state.title) { state.title = config.title; }
     if (config.additionalWhereClause !== undefined) {
@@ -317,6 +327,7 @@ export function initDashboard(config = {}) {
       clearAllowedColumnsCache();
     }
     if (config.logColumnOrder) { state.logColumnOrder = config.logColumnOrder; }
+    applySearchConfig();
   }
 
   // Initialize
@@ -435,6 +446,34 @@ export function initDashboard(config = {}) {
         e.target.blur();
       }
     });
+
+    const commitSearchFilterIfChanged = () => {
+      const { value } = elements.searchFilterInput;
+      if (value === state.searchFilter) { return; }
+      state.searchFilter = value;
+      saveStateToURL();
+      loadDashboard();
+    };
+    let searchFilterOriginalValue = '';
+    if (elements.searchFilterInput) {
+      elements.searchFilterInput.addEventListener('focus', () => {
+        searchFilterOriginalValue = elements.searchFilterInput.value;
+      });
+      elements.searchFilterInput.addEventListener('change', commitSearchFilterIfChanged);
+      elements.searchFilterInput.addEventListener('blur', commitSearchFilterIfChanged);
+      elements.searchFilterInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          commitSearchFilterIfChanged();
+          e.target.blur();
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          e.target.value = searchFilterOriginalValue;
+          state.searchFilter = searchFilterOriginalValue;
+          e.target.blur();
+        }
+      });
+    }
 
     elements.viewCycleBtn.addEventListener('click', () => cycleViewMode(saveStateToURL));
 

--- a/js/lambda-main.js
+++ b/js/lambda-main.js
@@ -52,6 +52,8 @@ initDashboard({
   timeSeriesTemplate: 'time-series-lambda',
   aggregations: LAMBDA_AGGREGATIONS,
   hostFilterColumn: 'function_name',
+  requestIdColumn: 'request_id',
+  messageColumn: 'message',
   defaultTimeRange: '24h',
   logColumnOrder: LOG_COLUMN_ORDER,
   defaultHiddenFacets: DEFAULT_HIDDEN_FACETS,

--- a/js/logs.js
+++ b/js/logs.js
@@ -346,6 +346,10 @@ export function setupLogRowClickHandler() {
     // Don't open modal if clicking on a clickable cell (filter action)
     if (target.classList.contains('clickable')) { return; }
 
+    // Don't open modal if the user is selecting text
+    const selection = window.getSelection?.();
+    if (selection && selection.toString().length > 0) { return; }
+
     // Find the row
     const row = target.closest('tr');
     if (!row || !row.dataset.rowIdx) { return; }

--- a/js/state.js
+++ b/js/state.js
@@ -44,6 +44,9 @@ export const state = {
   weightColumn: null, // When set (e.g. 'weight'), counts use sum(weight) / sumIf(weight, ...)
   aggregations: null, // Optional { aggTotal, aggOk, agg4xx, agg5xx } for non-CDN tables
   hostFilterColumn: null, // Optional column for header filter (e.g. function_name for lambda)
+  searchFilter: '', // Free-text search routed to requestIdColumn (UUID input) or messageColumn
+  requestIdColumn: null, // Column to exact-match when input is a UUID (e.g. request_id)
+  messageColumn: null, // Column to substring-match otherwise (e.g. message)
   breakdowns: null, // Optional override breakdown list (e.g. lambda facets)
   logColumnOrder: null, // Optional preferred column ordering for the logs table
 };

--- a/js/time.js
+++ b/js/time.js
@@ -266,15 +266,32 @@ export function getTimeFilter() {
   return `toStartOfMinute(timestamp) BETWEEN toStartOfMinute(toDateTime('${startIso}')) AND toStartOfMinute(toDateTime('${endIso}'))`;
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function getSearchClause() {
+  if (!state.searchFilter) { return ''; }
+  const escaped = state.searchFilter.replace(/'/g, "\\'");
+  if (UUID_RE.test(state.searchFilter) && state.requestIdColumn) {
+    return `AND \`${state.requestIdColumn}\` = '${escaped}'`;
+  }
+  if (state.messageColumn) {
+    return `AND \`${state.messageColumn}\` LIKE '%${escaped}%'`;
+  }
+  return '';
+}
+
 export function getHostFilter() {
-  if (!state.hostFilter) {
-    return '';
+  let hostClause = '';
+  if (state.hostFilter) {
+    const escaped = state.hostFilter.replace(/'/g, "\\'");
+    if (state.hostFilterColumn) {
+      hostClause = `AND \`${state.hostFilterColumn}\` LIKE '%${escaped}%'`;
+    } else {
+      hostClause = `AND (\`request.host\` LIKE '%${escaped}%' OR \`request.headers.x_forwarded_host\` LIKE '%${escaped}%')`;
+    }
   }
-  const escaped = state.hostFilter.replace(/'/g, "\\'");
-  if (state.hostFilterColumn) {
-    return `AND \`${state.hostFilterColumn}\` LIKE '%${escaped}%'`;
-  }
-  return `AND (\`request.host\` LIKE '%${escaped}%' OR \`request.headers.x_forwarded_host\` LIKE '%${escaped}%')`;
+  const searchClause = getSearchClause();
+  return [hostClause, searchClause].filter(Boolean).join(' ');
 }
 
 // Get aligned time range for chart rendering and WITH FILL bounds

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -50,6 +50,7 @@ export function setUrlStateElements(els) {
 function addBasicParams(params) {
   if (state.timeRange !== DEFAULT_TIME_RANGE) { params.set('t', state.timeRange); }
   if (state.hostFilter) { params.set('host', state.hostFilter); }
+  if (state.searchFilter) { params.set('q', state.searchFilter); }
   if (state.topN !== DEFAULT_TOP_N) { params.set('n', state.topN); }
   if (state.viewMode !== 'filters') { params.set('view', state.viewMode); }
   if (state.title) { params.set('title', state.title); }
@@ -119,6 +120,7 @@ function loadBasicState(params) {
     state.timeRange = params.get('t');
   }
   if (params.has('host')) { state.hostFilter = params.get('host'); }
+  if (params.has('q')) { state.searchFilter = params.get('q'); }
   if (params.has('n')) {
     const n = parseInt(params.get('n'), 10);
     if (TOP_N_OPTIONS.includes(n)) { state.topN = n; }
@@ -208,6 +210,9 @@ export function syncUIFromState() {
   elements.topNSelect.value = state.topN;
   document.body.dataset.topn = state.topN;
   elements.hostFilterInput.value = state.hostFilter;
+  if (elements.searchFilterInput) {
+    elements.searchFilterInput.value = state.searchFilter;
+  }
   renderActiveFilters();
 
   // Update title if custom title is set

--- a/lambda.html
+++ b/lambda.html
@@ -63,6 +63,7 @@
         <select id="topN"></select>
         <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by function..." list="hostSuggestions" autocomplete="off"></span>
         <datalist id="hostSuggestions"></datalist>
+        <input type="text" id="searchFilter" placeholder="Invocation ID or message..." autocomplete="off">
         <span class="kbd-control">
           <kbd class="kbd-hint">t</kbd>
           <button id="viewCycleBtn" class="menu-btn" title="Switch to Logs view">


### PR DESCRIPTION
## Summary
- Adds a text input next to the function filter on the Lambda view. Typed input is routed to one of two ClickHouse predicates:
  - **UUID-shaped input** (`/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i`) → `AND \`request_id\` = '<value>'` (exact match, cheap).
  - **Anything else** → `AND \`message\` LIKE '%<value>%'` (substring match).
- Generic plumbing on `state.requestIdColumn` / `state.messageColumn` + `state.searchFilter`, configurable per dashboard. Currently wired only on Lambda.
- Persisted in the URL as `?q=...`. Combines with the existing `host` filter via AND.

## Testing Done
- `npm run lint` — clean
- `npm test` — 884/884 passing
- Browser eval against `getHostFilter()`:
  - empty input → `""`
  - UUID → ``AND `request_id` = '...'``
  - free text → ``AND `message` LIKE '%...%'``
  - quote escaping: `O'Brien` → `O\'Brien`
  - combined with host filter → both AND'd
  - non-UUID-shaped IDs fall through to `LIKE`

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)