### PR TITLE
feat: add Manage Columns modal for log tables

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -74,6 +74,13 @@
             </svg>
           </button>
         </span>
+        <button id="manageColumnsBtn" class="menu-btn" title="Manage Columns">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="2" width="3" height="12"/>
+            <rect x="6.5" y="2" width="3" height="12"/>
+            <rect x="11" y="2" width="3" height="12"/>
+          </svg>
+        </button>
         <button id="refreshBtn" class="menu-btn" title="Refresh">
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
             <path d="M15 9A6 6 0 1 0 13.2 13.2"/>

--- a/backend.html
+++ b/backend.html
@@ -74,6 +74,13 @@
             </svg>
           </button>
         </span>
+        <button id="manageColumnsBtn" class="menu-btn" title="Manage Columns">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="2" width="3" height="12"/>
+            <rect x="6.5" y="2" width="3" height="12"/>
+            <rect x="11" y="2" width="3" height="12"/>
+          </svg>
+        </button>
         <button id="refreshBtn" class="menu-btn" title="Refresh">
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
             <path d="M15 9A6 6 0 1 0 13.2 13.2"/>

--- a/css/modals.css
+++ b/css/modals.css
@@ -439,3 +439,202 @@
     width: 120px;
   }
 }
+
+/* Manage Columns Modal */
+#manageColumnsModal {
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--card-bg);
+  color: var(--text);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  width: 90vw;
+  max-width: 1100px;
+  height: 80vh;
+  max-height: 800px;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
+}
+
+#manageColumnsModal[open] {
+  display: flex;
+  flex-direction: column;
+}
+
+#manageColumnsModal::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.manage-cols-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  border-radius: 12px 12px 0 0;
+  flex-shrink: 0;
+}
+
+.manage-cols-header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.manage-cols-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  padding: 16px 20px;
+  flex: 1;
+  min-height: 0;
+}
+
+.manage-cols-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+}
+
+.manage-cols-panel h3 {
+  margin: 0;
+  padding: 12px 14px 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.manage-cols-search {
+  margin: 0 14px 8px 14px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--card-bg);
+  color: var(--text);
+  font-size: 13px;
+}
+
+.manage-cols-search:focus {
+  outline: 1px solid var(--primary);
+  outline-offset: -1px;
+}
+
+.manage-cols-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 8px 8px 8px;
+  min-height: 0;
+}
+
+.manage-cols-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  margin: 4px 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--card-bg);
+  font-size: 13px;
+  cursor: grab;
+  user-select: none;
+}
+
+.manage-cols-item.dragging {
+  opacity: 0.5;
+}
+
+.manage-cols-item.drop-target-above {
+  border-top-color: var(--primary);
+  box-shadow: 0 -2px 0 0 var(--primary);
+}
+
+.manage-cols-item.drop-target-below {
+  border-bottom-color: var(--primary);
+  box-shadow: 0 2px 0 0 var(--primary);
+}
+
+.manage-cols-handle {
+  color: var(--text-secondary);
+  font-family: monospace;
+  font-size: 14px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.manage-cols-label {
+  flex: 1;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.manage-cols-remove {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.manage-cols-remove:hover {
+  background: var(--bg);
+  color: var(--text);
+}
+
+.manage-cols-empty {
+  padding: 24px 12px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-style: italic;
+}
+
+.manage-cols-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  border-radius: 0 0 12px 12px;
+  flex-shrink: 0;
+}
+
+.manage-cols-btn {
+  padding: 8px 18px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--card-bg);
+  color: var(--text);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.manage-cols-btn:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.manage-cols-btn.primary {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
+
+.manage-cols-btn.primary:hover {
+  filter: brightness(1.1);
+  color: white;
+}

--- a/da.html
+++ b/da.html
@@ -74,6 +74,13 @@
             </svg>
           </button>
         </span>
+        <button id="manageColumnsBtn" class="menu-btn" title="Manage Columns">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="2" width="3" height="12"/>
+            <rect x="6.5" y="2" width="3" height="12"/>
+            <rect x="11" y="2" width="3" height="12"/>
+          </svg>
+        </button>
         <button id="refreshBtn" class="menu-btn" title="Refresh">
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
             <path d="M15 9A6 6 0 1 0 13.2 13.2"/>

--- a/delivery.html
+++ b/delivery.html
@@ -74,6 +74,13 @@
             </svg>
           </button>
         </span>
+        <button id="manageColumnsBtn" class="menu-btn" title="Manage Columns">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="2" width="3" height="12"/>
+            <rect x="6.5" y="2" width="3" height="12"/>
+            <rect x="11" y="2" width="3" height="12"/>
+          </svg>
+        </button>
         <button id="refreshBtn" class="menu-btn" title="Refresh">
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
             <path d="M15 9A6 6 0 1 0 13.2 13.2"/>

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -64,6 +64,7 @@ import {
   initHostFilterDoubleTap, initMobileTouchSupport, initPullToRefresh, initMobileFiltersPosition,
 } from './ui/mobile.js';
 import { initActionHandlers } from './ui/actions.js';
+import { openManageColumns } from './manage-columns.js';
 import { preloadAllTemplates } from './sql-loader.js';
 import { startRequestContext, isRequestCurrent } from './request-context.js';
 
@@ -88,6 +89,7 @@ export function initDashboard(config = {}) {
     refreshBtn: document.getElementById('refreshBtn'),
     logoutBtn: document.getElementById('logoutBtn'),
     viewCycleBtn: document.getElementById('viewCycleBtn'),
+    manageColumnsBtn: document.getElementById('manageColumnsBtn'),
     logsView: document.getElementById('logsView'),
     filtersView: document.getElementById('filtersView'),
     contentArea: document.getElementById('contentArea'),
@@ -437,6 +439,10 @@ export function initDashboard(config = {}) {
     });
 
     elements.viewCycleBtn.addEventListener('click', () => cycleViewMode(saveStateToURL));
+
+    if (elements.manageColumnsBtn) {
+      elements.manageColumnsBtn.addEventListener('click', () => openManageColumns());
+    }
 
     window.matchMedia('(max-width: 1500px)').addEventListener('change', (e) => {
       if (e.matches && state.viewMode === 'split') {

--- a/js/logs.js
+++ b/js/logs.js
@@ -10,7 +10,9 @@
  * governing permissions and limitations under the License.
  */
 import { DATABASE } from './config.js';
-import { state, setOnPinnedColumnsChange, saveViewMode } from './state.js';
+import {
+  state, setOnPinnedColumnsChange, setOnLogColumnPrefsChange, saveViewMode,
+} from './state.js';
 import { query, isAbortError } from './api.js';
 import { getTimeFilter, getHostFilter, getLogsTable } from './time.js';
 import { getFacetFilters } from './breakdowns/index.js';
@@ -30,11 +32,13 @@ import { PAGE_SIZE, PaginationState } from './pagination.js';
  * @returns {string[]}
  */
 function getLogColumns(allColumns) {
-  const columnOrder = state.logColumnOrder ?? LOG_COLUMN_ORDER;
-  const pinned = state.pinnedColumns.filter((col) => allColumns.includes(col));
+  const hidden = new Set(state.hiddenLogColumns || []);
+  const visible = allColumns.filter((col) => !hidden.has(col));
+  const columnOrder = state.userLogColumnOrder ?? state.logColumnOrder ?? LOG_COLUMN_ORDER;
+  const pinned = state.pinnedColumns.filter((col) => visible.includes(col));
   const preferred = columnOrder
-    .filter((col) => allColumns.includes(col) && !pinned.includes(col));
-  const rest = allColumns.filter((col) => !pinned.includes(col) && !columnOrder.includes(col));
+    .filter((col) => visible.includes(col) && !pinned.includes(col));
+  const rest = visible.filter((col) => !pinned.includes(col) && !columnOrder.includes(col));
   return [...pinned, ...preferred, ...rest];
 }
 
@@ -507,6 +511,7 @@ export function setLogsElements(view, filtersViewEl, contentAreaEl) {
 
 // Register callback for pinned column changes
 setOnPinnedColumnsChange(renderLogsTable);
+setOnLogColumnPrefsChange(renderLogsTable);
 
 // Callback for redrawing chart when switching views
 let onShowFiltersView = null;

--- a/js/manage-columns.js
+++ b/js/manage-columns.js
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { state, saveLogColumnPrefs } from './state.js';
+import { escapeHtml } from './utils.js';
+import { LOG_COLUMN_ORDER, LOG_COLUMN_SHORT_LABELS } from './columns.js';
+
+let dialog = null;
+let inUse = []; // columns currently shown, in order
+let available = []; // columns hidden
+
+function getAllColumns() {
+  if (state.logsData && state.logsData.length > 0) {
+    return Object.keys(state.logsData[0]);
+  }
+  return [];
+}
+
+function computeInitialPartition() {
+  const all = getAllColumns();
+  const hidden = new Set(state.hiddenLogColumns || []);
+  const baseOrder = state.userLogColumnOrder ?? state.logColumnOrder ?? LOG_COLUMN_ORDER;
+  const visible = all.filter((c) => !hidden.has(c));
+  const orderedVisible = [
+    ...baseOrder.filter((c) => visible.includes(c)),
+    ...visible.filter((c) => !baseOrder.includes(c)),
+  ];
+  const hiddenList = all.filter((c) => hidden.has(c));
+  return { inUse: orderedVisible, available: hiddenList };
+}
+
+function buildItemHtml(col, panel) {
+  const label = LOG_COLUMN_SHORT_LABELS[col] || col;
+  const remove = panel === 'inUse'
+    ? '<button type="button" class="manage-cols-remove" data-action="hide" aria-label="Hide">×</button>'
+    : '';
+  return `
+    <div class="manage-cols-item" draggable="true" data-col="${escapeHtml(col)}" data-panel="${panel}">
+      <span class="manage-cols-handle" aria-hidden="true">⋮⋮</span>
+      <span class="manage-cols-label" title="${escapeHtml(col)}">${escapeHtml(label)}</span>
+      ${remove}
+    </div>
+  `;
+}
+
+function renderList(panel) {
+  const list = dialog.querySelector(`[data-list="${panel}"]`);
+  const search = dialog.querySelector(`[data-search="${panel}"]`).value.trim().toLowerCase();
+  const cols = panel === 'inUse' ? inUse : available;
+  const filtered = search
+    ? cols.filter((c) => c.toLowerCase().includes(search)
+      || (LOG_COLUMN_SHORT_LABELS[c] || '').toLowerCase().includes(search))
+    : cols;
+  if (filtered.length === 0) {
+    list.innerHTML = `<div class="manage-cols-empty">${search ? 'No matches' : 'No columns'}</div>`;
+    return;
+  }
+  list.innerHTML = filtered.map((c) => buildItemHtml(c, panel)).join('');
+}
+
+function rerender() {
+  renderList('inUse');
+  renderList('available');
+}
+
+function findInsertIndex(list, panel, clientY) {
+  const items = Array.from(list.querySelectorAll('.manage-cols-item'));
+  for (let i = 0; i < items.length; i += 1) {
+    const rect = items[i].getBoundingClientRect();
+    if (clientY < rect.top + rect.height / 2) {
+      return { index: i, panel };
+    }
+  }
+  return { index: items.length, panel };
+}
+
+function clearDropMarkers() {
+  dialog.querySelectorAll('.drop-target-above, .drop-target-below').forEach((el) => {
+    el.classList.remove('drop-target-above', 'drop-target-below');
+  });
+}
+
+function attachDragHandlers() {
+  let dragged = null;
+
+  dialog.addEventListener('dragstart', (e) => {
+    const item = e.target.closest('.manage-cols-item');
+    if (!item) { return; }
+    dragged = { col: item.dataset.col, panel: item.dataset.panel };
+    item.classList.add('dragging');
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', item.dataset.col);
+  });
+
+  dialog.addEventListener('dragend', (e) => {
+    const item = e.target.closest('.manage-cols-item');
+    if (item) { item.classList.remove('dragging'); }
+    clearDropMarkers();
+    dragged = null;
+  });
+
+  dialog.addEventListener('dragover', (e) => {
+    const list = e.target.closest('[data-list]');
+    if (!list || !dragged) { return; }
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    clearDropMarkers();
+    const targetPanel = list.dataset.list;
+    const items = Array.from(list.querySelectorAll('.manage-cols-item'));
+    const { index } = findInsertIndex(list, targetPanel, e.clientY);
+    if (items[index]) {
+      items[index].classList.add('drop-target-above');
+    } else if (items[index - 1]) {
+      items[index - 1].classList.add('drop-target-below');
+    }
+  });
+
+  dialog.addEventListener('drop', (e) => {
+    if (!dragged) { return; }
+    const list = e.target.closest('[data-list]');
+    if (!list) { return; }
+    e.preventDefault();
+    const targetPanel = list.dataset.list;
+    const { index } = findInsertIndex(list, targetPanel, e.clientY);
+
+    // Remove from source list
+    const sourceList = dragged.panel === 'inUse' ? inUse : available;
+    const srcIdx = sourceList.indexOf(dragged.col);
+    if (srcIdx >= 0) { sourceList.splice(srcIdx, 1); }
+
+    // Insert into destination list (clamp index if same list)
+    const destList = targetPanel === 'inUse' ? inUse : available;
+    let insertAt = index;
+    if (dragged.panel === targetPanel && srcIdx >= 0 && srcIdx < index) {
+      insertAt = index - 1;
+    }
+    destList.splice(Math.max(0, Math.min(insertAt, destList.length)), 0, dragged.col);
+
+    clearDropMarkers();
+    dragged = null;
+    rerender();
+  });
+}
+
+function buildDialog() {
+  if (dialog) { return dialog; }
+  dialog = document.createElement('dialog');
+  dialog.id = 'manageColumnsModal';
+  dialog.innerHTML = `
+    <div class="manage-cols-header">
+      <h2>Manage Columns</h2>
+      <button type="button" class="modal-close" data-action="close" aria-label="Close">×</button>
+    </div>
+    <div class="manage-cols-body">
+      <div class="manage-cols-panel">
+        <h3>Available Fields</h3>
+        <input type="text" class="manage-cols-search" data-search="available" placeholder="Search fields" autocomplete="off">
+        <div class="manage-cols-list" data-list="available"></div>
+      </div>
+      <div class="manage-cols-panel">
+        <h3>In Use</h3>
+        <input type="text" class="manage-cols-search" data-search="inUse" placeholder="Search fields" autocomplete="off">
+        <div class="manage-cols-list" data-list="inUse"></div>
+      </div>
+    </div>
+    <div class="manage-cols-footer">
+      <button type="button" class="manage-cols-btn" data-action="cancel">Cancel</button>
+      <button type="button" class="manage-cols-btn primary" data-action="apply">Apply</button>
+    </div>
+  `;
+  document.body.appendChild(dialog);
+
+  dialog.addEventListener('click', (e) => {
+    const target = e.target.closest('[data-action]');
+    if (!target) { return; }
+    const { action } = target.dataset;
+    if (action === 'close' || action === 'cancel') {
+      dialog.close();
+    } else if (action === 'apply') {
+      saveLogColumnPrefs(inUse, available);
+      dialog.close();
+    } else if (action === 'hide') {
+      const item = target.closest('.manage-cols-item');
+      const { col } = item.dataset;
+      const idx = inUse.indexOf(col);
+      if (idx >= 0) {
+        inUse.splice(idx, 1);
+        available.push(col);
+        rerender();
+      }
+    }
+  });
+
+  dialog.addEventListener('input', (e) => {
+    if (e.target.matches('[data-search]')) {
+      renderList(e.target.dataset.search);
+    }
+  });
+
+  attachDragHandlers();
+  return dialog;
+}
+
+export function openManageColumns() {
+  buildDialog();
+  const partition = computeInitialPartition();
+  inUse = partition.inUse;
+  available = partition.available;
+  dialog.querySelectorAll('[data-search]').forEach((input) => {
+    // eslint-disable-next-line no-param-reassign
+    input.value = '';
+  });
+  rerender();
+  dialog.showModal();
+}

--- a/js/state.js
+++ b/js/state.js
@@ -46,6 +46,8 @@ export const state = {
   hostFilterColumn: null, // Optional column for header filter (e.g. function_name for lambda)
   breakdowns: null, // Optional override breakdown list (e.g. lambda facets)
   logColumnOrder: null, // Optional preferred column ordering for the logs table
+  userLogColumnOrder: null, // User-customised column order (per-dashboard, localStorage)
+  hiddenLogColumns: [], // User-hidden columns (per-dashboard, localStorage)
 };
 
 export function saveViewMode(mode) {
@@ -138,6 +140,42 @@ export function togglePinnedFacet(facetId) {
   saveFacetPrefs();
   if (onFacetOrderChange) {
     onFacetOrderChange();
+  }
+}
+
+// Get localStorage key for log column preferences (keyed by title if present)
+function getLogColumnPrefsKey() {
+  return state.title ? `logColumnPrefs_${state.title}` : 'logColumnPrefs';
+}
+
+let onLogColumnPrefsChange = null;
+
+export function setOnLogColumnPrefsChange(callback) {
+  onLogColumnPrefsChange = callback;
+}
+
+export function loadLogColumnPrefs() {
+  const key = getLogColumnPrefsKey();
+  try {
+    const prefs = JSON.parse(storage.getItem(key) || '{}');
+    state.userLogColumnOrder = Array.isArray(prefs.order) ? prefs.order : null;
+    state.hiddenLogColumns = Array.isArray(prefs.hidden) ? prefs.hidden : [];
+  } catch (e) {
+    state.userLogColumnOrder = null;
+    state.hiddenLogColumns = [];
+  }
+}
+
+export function saveLogColumnPrefs(order, hidden) {
+  state.userLogColumnOrder = Array.isArray(order) && order.length > 0 ? order : null;
+  state.hiddenLogColumns = Array.isArray(hidden) ? hidden : [];
+  const key = getLogColumnPrefsKey();
+  storage.setItem(key, JSON.stringify({
+    order: state.userLogColumnOrder,
+    hidden: state.hiddenLogColumns,
+  }));
+  if (onLogColumnPrefsChange && state.logsData) {
+    onLogColumnPrefsChange(state.logsData);
   }
 }
 

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { state, loadFacetPrefs } from './state.js';
+import { state, loadFacetPrefs, loadLogColumnPrefs } from './state.js';
 import {
   queryTimestamp, setQueryTimestamp, customTimeRange, setCustomTimeRange, clearCustomTimeRange,
 } from './time.js';
@@ -198,6 +198,7 @@ export function loadStateFromURL() {
   }
 
   loadFacetPrefs();
+  loadLogColumnPrefs();
 
   if (params.has('pf')) { state.pinnedFacets = params.get('pf').split(',').filter((f) => f); }
   if (params.has('hf')) { state.hiddenFacets = params.get('hf').split(',').filter((f) => f); }

--- a/lambda.html
+++ b/lambda.html
@@ -74,6 +74,13 @@
             </svg>
           </button>
         </span>
+        <button id="manageColumnsBtn" class="menu-btn" title="Manage Columns">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="2" width="3" height="12"/>
+            <rect x="6.5" y="2" width="3" height="12"/>
+            <rect x="11" y="2" width="3" height="12"/>
+          </svg>
+        </button>
         <button id="refreshBtn" class="menu-btn" title="Refresh">
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
             <path d="M15 9A6 6 0 1 0 13.2 13.2"/>


### PR DESCRIPTION
## Summary
- Adds a **Columns** button to the header of every dashboard (delivery, admin, da, backend, lambda) that opens a two-panel modal: **Available Fields** (hidden) on the left, **In Use** (visible, in display order) on the right.
- Users can drag rows between panels, drag-reorder within a panel, search each panel independently, hide a column via the X button, and Cancel/Apply.
- Order + hidden set persist per-dashboard in localStorage under `logColumnPrefs_<title>`, mirroring the existing `facetPrefs` pattern.
- `getLogColumns()` now filters out hidden columns and prefers `state.userLogColumnOrder` over the dashboard's config default. The existing pinned-columns and column-resize features are unaffected.

## Testing Done
- `npm run lint` — clean
- `npm test` — 884/884 passing
- Browser verification (seeded mock `state.logsData`):
  - Modal opens, populates In Use from default order, Available empty initially
  - X moves a column to Available; Apply persists to `localStorage["logColumnPrefs_Lambda Logs"]`
  - Reopen restores state correctly
  - Search filters each panel independently
  - Cross-panel drag (Available → In Use) inserts at the drop position
  - Cancel discards in-modal edits

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)