### PR TITLE
feat: add color to level

### DIFF
--- a/js/logs.js
+++ b/js/logs.js
@@ -201,7 +201,7 @@ function formatDetailValue(col, value) {
     displayValue = String(value);
   }
 
-  const color = getColorForColumn(col, value);
+  const color = getColorForColumn(`\`${col}\``, value);
   const colorIndicator = color ? `<span class="log-color" style="background:${color}"></span>` : '';
 
   return { html: colorIndicator + escapeHtml(displayValue), className };

--- a/js/templates/logs-table.js
+++ b/js/templates/logs-table.js
@@ -68,7 +68,7 @@ export function formatLogCell(col, value) {
     displayValue = formatGenericValue(value);
   }
 
-  const color = value ? getColorForColumn(col, value) : '';
+  const color = value ? getColorForColumn(`\`${col}\``, value) : '';
   const colorIndicator = color ? `<span class="log-color" style="background:${color}"></span>` : '';
 
   return { displayValue, cellClass, colorIndicator };


### PR DESCRIPTION
## Summary
- Lambda Logs `level` column now renders with a colored indicator: `info`/`debug`/`trace` → green, `warn`/`warning` → yellow, `error` → red.
- Wrap the raw log column key in backticks at the two `getColorForColumn` call sites so the existing `` `level` `` pattern in `colorRules.lambdaLevel` resolves. Other patterns are substrings and remain unaffected by the surrounding backticks.

## Testing Done
- Loaded the Lambda Logs view in the browser and confirmed the indicator dot appears next to each level value with the expected color.
- `npm run lint` passes.

## Checklist
- [ ] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)