### PR TITLE
feat: add DA owner, repo and route

### DIFF
--- a/da.html
+++ b/da.html
@@ -176,6 +176,18 @@
           <h3>Worker Script</h3>
           <div class="loading"><div class="spinner"></div>Loading...</div>
         </div>
+        <div class="breakdown-card" id="breakdown-helix-route">
+          <h3>Route</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-helix-owner">
+          <h3>Owner</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-helix-repo">
+          <h3>Repo</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
         <div class="breakdown-card" id="breakdown-accept-encoding">
           <h3>Accept-Encoding</h3>
           <div class="loading"><div class="spinner"></div>Loading...</div>

--- a/js/breakdowns/definitions-da.js
+++ b/js/breakdowns/definitions-da.js
@@ -68,6 +68,13 @@ export const daBreakdowns = [
   {
     id: 'breakdown-script-name', col: '`cdn.script_name`', extraFilter: "AND `cdn.script_name` != ''",
   },
+  { id: 'breakdown-helix-route', col: '`helix.route`', extraFilter: "AND `helix.route` != ''" },
+  {
+    id: 'breakdown-helix-owner', col: '`helix.owner`', extraFilter: "AND `helix.owner` != ''", highCardinality: true,
+  },
+  {
+    id: 'breakdown-helix-repo', col: '`helix.repo`', extraFilter: "AND `helix.repo` != ''", highCardinality: true,
+  },
   {
     id: 'breakdown-accept-encoding', col: COLUMN_DEFS.acceptEncoding.facetCol, extraFilter: "AND `request.headers.accept_encoding` != ''", modeToggle: 'contentTypeMode',
   },


### PR DESCRIPTION
Adds owner, repo and route breakdowns to the da.html dashboard.

Matches https://github.com/adobe/helix-gcs2clickhouse-ingestor/pull/7.