### PR TITLE
feat: add path filter and helix facets to Backend view

### DIFF
--- a/backend.html
+++ b/backend.html
@@ -61,7 +61,7 @@
       <div class="header-right">
         <span class="kbd-control"><kbd class="kbd-hint" id="timeRangeHint">2</kbd><select id="timeRange"></select></span>
         <select id="topN"></select>
-        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by host..." list="hostSuggestions" autocomplete="off"></span>
+        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by path..." list="hostSuggestions" autocomplete="off"></span>
         <datalist id="hostSuggestions"></datalist>
         <span class="kbd-control">
           <kbd class="kbd-hint">t</kbd>
@@ -207,6 +207,18 @@
         </div>
         <div class="breakdown-card" id="breakdown-time-elapsed">
           <h3>Response Time</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-helix-owner">
+          <h3>Owner</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-helix-repo">
+          <h3>Repo</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-helix-path">
+          <h3>Resource path</h3>
           <div class="loading"><div class="spinner"></div>Loading...</div>
         </div>
       </section>

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -27,6 +27,11 @@ function populateHostDatalist(values) {
 
 export async function loadHostAutocomplete() {
   const isFunctionFilter = state.hostFilterColumn === 'function_name';
+  // No suggestions for arbitrary column filters (e.g. request.url paths).
+  if (state.hostFilterColumn && !isFunctionFilter) {
+    populateHostDatalist([]);
+    return;
+  }
   const cacheKey = isFunctionFilter ? FUNCTION_CACHE_KEY : HOST_CACHE_KEY;
 
   const cached = localStorage.getItem(cacheKey);

--- a/js/backend-main.js
+++ b/js/backend-main.js
@@ -22,6 +22,9 @@ const DEFAULT_HIDDEN_FACETS = [
   'breakdown-methods',
   'breakdown-content-encoding',
   'breakdown-ips',
+  'breakdown-helix-owner',
+  'breakdown-helix-repo',
+  'breakdown-helix-path',
 ];
 
 initDashboard({
@@ -30,4 +33,5 @@ initDashboard({
   weightColumn: 'weight',
   timeSeriesTemplate: 'time-series-backend',
   defaultHiddenFacets: DEFAULT_HIDDEN_FACETS,
+  hostFilterColumn: 'request.url',
 });

--- a/js/breakdowns/definitions.js
+++ b/js/breakdowns/definitions.js
@@ -143,6 +143,9 @@ export const allBreakdowns = [
   {
     id: 'breakdown-helix-owner', col: '`helix.owner`', extraFilter: "AND `helix.owner` != ''", highCardinality: true,
   },
+  {
+    id: 'breakdown-helix-path', col: '`helix.path`', extraFilter: "AND `helix.path` != ''", highCardinality: true,
+  },
   { id: 'breakdown-helix-ref', col: '`helix.ref`', extraFilter: "AND `helix.ref` != ''" },
   { id: 'breakdown-ratelimit-limit', col: '`response.headers.x_ratelimit_limit`', extraFilter: "AND `response.headers.x_ratelimit_limit` != ''" },
   {


### PR DESCRIPTION
## Summary
- Backend dashboard's header filter now applies to `request.url` (placeholder updated to "Filter by path...") instead of the default `request.host` / `x_forwarded_host` pair, via the existing `hostFilterColumn` mechanism.
- Added three new breakdown cards to the Backend view — **Owner** (`helix.owner`), **Repo** (`helix.repo`), and **Resource path** (`helix.path`) — all initially hidden via `DEFAULT_HIDDEN_FACETS`.
- Added a `breakdown-helix-path` definition to `js/breakdowns/definitions.js` (owner/repo already existed); marked high-cardinality so it queries the raw table rather than the facet table.
- `loadHostAutocomplete` now skips the host-suggestions fetch when a non-function `hostFilterColumn` is configured, since hostnames would be misleading suggestions for a path filter.

## Testing Done
- Verified against ClickHouse that the `backend` table has `helix.owner`, `helix.repo`, and `helix.path` columns and they return real data within the last hour.
- Confirmed the served `backend.html` reflects the new placeholder text and `js/backend-main.js` reflects the new `hostFilterColumn`.
- Did not exercise the new filter end-to-end in the live UI (no login credentials available in this checkout).

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)
