### PR TITLE
feat: add owner/repo filter for admin and DA dashboards

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -61,8 +61,8 @@
       <div class="header-right">
         <span class="kbd-control"><kbd class="kbd-hint" id="timeRangeHint">2</kbd><select id="timeRange"></select></span>
         <select id="topN"></select>
-        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by host..." list="hostSuggestions" autocomplete="off"></span>
-        <datalist id="hostSuggestions"></datalist>
+        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="ownerRepoFilter" placeholder="Owner or owner/repo..." list="ownerRepoSuggestions" autocomplete="off"></span>
+        <datalist id="ownerRepoSuggestions"></datalist>
         <span class="kbd-control">
           <kbd class="kbd-hint">t</kbd>
           <button id="viewCycleBtn" class="menu-btn" title="Switch to Logs view">
@@ -175,12 +175,12 @@
           <h3>Site</h3>
           <div class="loading"><div class="spinner"></div>Loading...</div>
         </div>
-        <div class="breakdown-card" id="breakdown-helix-repo">
-          <h3>Repo</h3>
-          <div class="loading"><div class="spinner"></div>Loading...</div>
-        </div>
         <div class="breakdown-card" id="breakdown-helix-owner">
           <h3>Owner</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-helix-repo">
+          <h3>Repo</h3>
           <div class="loading"><div class="spinner"></div>Loading...</div>
         </div>
         <div class="breakdown-card" id="breakdown-helix-ref">
@@ -309,7 +309,7 @@
         <div class="key-desc">Refresh data</div>
 
         <div class="key-group"><kbd>f</kbd></div>
-        <div class="key-desc">Focus host filter</div>
+        <div class="key-desc">Focus owner filter</div>
 
         <div class="key-group"><kbd>t</kbd></div>
         <div class="key-desc">Cycle view</div>

--- a/da.html
+++ b/da.html
@@ -61,8 +61,8 @@
       <div class="header-right">
         <span class="kbd-control"><kbd class="kbd-hint" id="timeRangeHint">2</kbd><select id="timeRange"></select></span>
         <select id="topN"></select>
-        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by host..." list="hostSuggestions" autocomplete="off"></span>
-        <datalist id="hostSuggestions"></datalist>
+        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="ownerRepoFilter" placeholder="Owner or owner/repo..." list="ownerRepoSuggestions" autocomplete="off"></span>
+        <datalist id="ownerRepoSuggestions"></datalist>
         <span class="kbd-control">
           <kbd class="kbd-hint">t</kbd>
           <button id="viewCycleBtn" class="menu-btn" title="Switch to Logs view">
@@ -287,7 +287,7 @@
         <div class="key-desc">Refresh data</div>
 
         <div class="key-group"><kbd>f</kbd></div>
-        <div class="key-desc">Focus host filter</div>
+        <div class="key-desc">Focus owner filter</div>
 
         <div class="key-group"><kbd>t</kbd></div>
         <div class="key-desc">Cycle view</div>

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -18,11 +18,17 @@ import { loadSql } from './sql-loader.js';
 
 const HOST_CACHE_KEY = 'hostAutocompleteSuggestions';
 const FUNCTION_CACHE_KEY = 'functionAutocompleteSuggestions';
+const OWNER_REPO_CACHE_KEY = 'ownerRepoAutocompleteSuggestions';
 const CACHE_TTL = 60 * 60 * 1000; // 1 hour in milliseconds
 
-function populateHostDatalist(values) {
-  const datalist = document.getElementById('hostSuggestions');
+function populateDatalist(datalistId, values) {
+  const datalist = document.getElementById(datalistId);
+  if (!datalist) { return; }
   datalist.innerHTML = values.map((v) => `<option value="${escapeHtml(v)}">`).join('');
+}
+
+function populateHostDatalist(values) {
+  populateDatalist('hostSuggestions', values);
 }
 
 export async function loadHostAutocomplete() {
@@ -89,5 +95,35 @@ export async function loadHostAutocomplete() {
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error('Failed to load host autocomplete:', err);
+  }
+}
+
+export async function loadOwnerRepoAutocomplete() {
+  const table = getTable();
+  const cacheKey = `${OWNER_REPO_CACHE_KEY}_${table}`;
+  const cached = localStorage.getItem(cacheKey);
+  if (cached) {
+    try {
+      const { values, timestamp } = JSON.parse(cached);
+      if (Date.now() - timestamp < CACHE_TTL) {
+        populateDatalist('ownerRepoSuggestions', values);
+        return;
+      }
+    } catch (e) {
+      // Cache invalid, continue to fetch
+    }
+  }
+
+  try {
+    const sqlParams = { database: DATABASE, table };
+    const sql = await loadSql('autocomplete-owner-repo', sqlParams);
+    const result = await query(sql);
+    const values = (result.data || []).map((row) => row.owner_repo).filter(Boolean)
+      .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+    localStorage.setItem(cacheKey, JSON.stringify({ values, timestamp: Date.now() }));
+    populateDatalist('ownerRepoSuggestions', values);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to load owner/repo autocomplete:', err);
   }
 }

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -98,6 +98,36 @@ export async function loadHostAutocomplete() {
   }
 }
 
+// All owner/repo values held in memory for client-side filtering
+let ownerRepoAllValues = [];
+
+/**
+ * Filter the ownerRepoSuggestions datalist to entries matching `text`,
+ * with prefix matches ranked before contains matches.
+ * Called on every input event so Chrome always sees the right top N options.
+ */
+export function filterOwnerRepoDatalist(text) {
+  const datalist = document.getElementById('ownerRepoSuggestions');
+  if (!datalist) { return; }
+  if (!text) {
+    datalist.innerHTML = '';
+    return;
+  }
+  const lower = text.toLowerCase();
+  const prefix = [];
+  const contains = [];
+  for (const v of ownerRepoAllValues) {
+    const vl = v.toLowerCase();
+    if (vl.startsWith(lower)) {
+      prefix.push(v);
+    } else if (vl.includes(lower)) {
+      contains.push(v);
+    }
+  }
+  const top = [...prefix, ...contains].slice(0, 20);
+  datalist.innerHTML = top.map((v) => `<option value="${escapeHtml(v)}">`).join('');
+}
+
 export async function loadOwnerRepoAutocomplete() {
   const table = getTable();
   const cacheKey = `${OWNER_REPO_CACHE_KEY}_${table}`;
@@ -106,7 +136,7 @@ export async function loadOwnerRepoAutocomplete() {
     try {
       const { values, timestamp } = JSON.parse(cached);
       if (Date.now() - timestamp < CACHE_TTL) {
-        populateDatalist('ownerRepoSuggestions', values);
+        ownerRepoAllValues = values;
         return;
       }
     } catch (e) {
@@ -121,7 +151,7 @@ export async function loadOwnerRepoAutocomplete() {
     const values = (result.data || []).map((row) => row.owner_repo).filter(Boolean)
       .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
     localStorage.setItem(cacheKey, JSON.stringify({ values, timestamp: Date.now() }));
-    populateDatalist('ownerRepoSuggestions', values);
+    ownerRepoAllValues = values;
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error('Failed to load owner/repo autocomplete:', err);

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -18,7 +18,6 @@ import { loadSql } from './sql-loader.js';
 
 const HOST_CACHE_KEY = 'hostAutocompleteSuggestions';
 const FUNCTION_CACHE_KEY = 'functionAutocompleteSuggestions';
-const OWNER_REPO_CACHE_KEY = 'ownerRepoAutocompleteSuggestions';
 const CACHE_TTL = 60 * 60 * 1000; // 1 hour in milliseconds
 
 function populateDatalist(datalistId, values) {
@@ -114,44 +113,53 @@ export function filterOwnerRepoDatalist(text) {
     return;
   }
   const lower = text.toLowerCase();
-  const prefix = [];
+  const ownerPrefix = [];
+  const repoPrefix = [];
   const contains = [];
   for (const v of ownerRepoAllValues) {
     const vl = v.toLowerCase();
+    const isOwnerOnly = !v.includes('/');
     if (vl.startsWith(lower)) {
-      prefix.push(v);
+      (isOwnerOnly ? ownerPrefix : repoPrefix).push(v);
     } else if (vl.includes(lower)) {
       contains.push(v);
     }
   }
-  const top = [...prefix, ...contains].slice(0, 20);
+  const top = [...ownerPrefix, ...repoPrefix, ...contains].slice(0, 20);
   datalist.innerHTML = top.map((v) => `<option value="${escapeHtml(v)}">`).join('');
+}
+
+// Track which table's owner/repo values are currently loaded
+let ownerRepoLoadedTable = null;
+
+/**
+ * Returns true if `value` is a known owner or owner/repo entry.
+ * Empty string is always valid (clears the filter).
+ * Returns true unconditionally when values haven't loaded yet.
+ */
+export function isValidOwnerRepoValue(value) {
+  if (!value) { return true; }
+  if (ownerRepoAllValues.length === 0) { return true; }
+  return ownerRepoAllValues.includes(value);
+}
+
+export function resetOwnerRepoState() {
+  ownerRepoAllValues = [];
+  ownerRepoLoadedTable = null;
 }
 
 export async function loadOwnerRepoAutocomplete() {
   const table = getTable();
-  const cacheKey = `${OWNER_REPO_CACHE_KEY}_${table}`;
-  const cached = localStorage.getItem(cacheKey);
-  if (cached) {
-    try {
-      const { values, timestamp } = JSON.parse(cached);
-      if (Date.now() - timestamp < CACHE_TTL) {
-        ownerRepoAllValues = values;
-        return;
-      }
-    } catch (e) {
-      // Cache invalid, continue to fetch
-    }
-  }
+  // Already loaded for this table in this session — skip refetch
+  if (ownerRepoLoadedTable === table && ownerRepoAllValues.length > 0) { return; }
 
   try {
     const sqlParams = { database: DATABASE, table };
     const sql = await loadSql('autocomplete-owner-repo', sqlParams);
     const result = await query(sql);
-    const values = (result.data || []).map((row) => row.owner_repo).filter(Boolean)
+    ownerRepoAllValues = (result.data || []).map((row) => row.owner_repo).filter(Boolean)
       .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
-    localStorage.setItem(cacheKey, JSON.stringify({ values, timestamp: Date.now() }));
-    ownerRepoAllValues = values;
+    ownerRepoLoadedTable = table;
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error('Failed to load owner/repo autocomplete:', err);

--- a/js/autocomplete.test.js
+++ b/js/autocomplete.test.js
@@ -11,10 +11,40 @@
  */
 import { assert } from 'chai';
 import { state } from './state.js';
-import { loadHostAutocomplete } from './autocomplete.js';
+import {
+  loadHostAutocomplete,
+  filterOwnerRepoDatalist,
+  loadOwnerRepoAutocomplete,
+  resetOwnerRepoState,
+  isValidOwnerRepoValue,
+} from './autocomplete.js';
 
 const HOST_CACHE_KEY = 'hostAutocompleteSuggestions';
 const FUNCTION_CACHE_KEY = 'functionAutocompleteSuggestions';
+
+// Returns a fetch mock that routes based on URL:
+//  - .sql requests  → return the raw SQL text
+//  - ClickHouse URL → return { data: rows }
+function makeFetchMock(rows) {
+  const calls = [];
+  const fn = async (url) => {
+    calls.push(url);
+    if (url.endsWith('.sql')) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () => 'SELECT owner_repo FROM test',
+      };
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: rows }),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
 
 describe('loadHostAutocomplete', () => {
   let datalist;
@@ -89,5 +119,248 @@ describe('loadHostAutocomplete', () => {
 
     assert.strictEqual(datalist.children.length, 1);
     assert.strictEqual(datalist.children[0].value, 'cached.example.com');
+  });
+});
+
+describe('loadOwnerRepoAutocomplete', () => {
+  let originalFetch;
+  let savedCredentials;
+
+  beforeEach(() => {
+    originalFetch = window.fetch;
+    savedCredentials = state.credentials;
+    state.credentials = { user: 'testuser', password: 'testpass' };
+    resetOwnerRepoState();
+    document.getElementById('ownerRepoSuggestions')?.remove();
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    state.credentials = savedCredentials;
+    resetOwnerRepoState();
+    document.getElementById('ownerRepoSuggestions')?.remove();
+  });
+
+  it('fetches owner/repo pairs from the DB and makes them available for filtering', async () => {
+    const rows = [
+      { owner_repo: 'adobe/helix-pages' },
+      { owner_repo: 'adobe/helix-importer' },
+    ];
+    window.fetch = makeFetchMock(rows);
+
+    await loadOwnerRepoAutocomplete();
+
+    const dl = document.createElement('datalist');
+    dl.id = 'ownerRepoSuggestions';
+    document.body.appendChild(dl);
+    filterOwnerRepoDatalist('adobe');
+
+    assert.strictEqual(dl.children.length, 2);
+    assert.strictEqual(dl.children[0].value, 'adobe/helix-importer');
+    assert.strictEqual(dl.children[1].value, 'adobe/helix-pages');
+  });
+
+  it('sorts results case-insensitively', async () => {
+    const rows = [
+      { owner_repo: 'Zorg/repo' },
+      { owner_repo: 'adobe/helix-pages' },
+      { owner_repo: 'Beta/repo' },
+    ];
+    window.fetch = makeFetchMock(rows);
+
+    await loadOwnerRepoAutocomplete();
+
+    const dl = document.createElement('datalist');
+    dl.id = 'ownerRepoSuggestions';
+    document.body.appendChild(dl);
+    filterOwnerRepoDatalist('repo');
+
+    const values = Array.from(dl.children).map((o) => o.value);
+    assert.deepEqual(values, ['Beta/repo', 'Zorg/repo']);
+  });
+
+  it('skips refetch when already loaded for the same table', async () => {
+    const fetchMock = makeFetchMock([{ owner_repo: 'adobe/helix-pages' }]);
+    window.fetch = fetchMock;
+
+    await loadOwnerRepoAutocomplete();
+    await loadOwnerRepoAutocomplete();
+
+    // Only the initial SQL + query calls should have been made (2 fetches total for first call)
+    assert.isAtMost(fetchMock.calls.length, 2);
+  });
+
+  it('ignores rows with empty owner_repo', async () => {
+    const rows = [
+      { owner_repo: 'adobe/helix-pages' },
+      { owner_repo: '' },
+      { owner_repo: null },
+    ];
+    window.fetch = makeFetchMock(rows);
+
+    await loadOwnerRepoAutocomplete();
+
+    const dl = document.createElement('datalist');
+    dl.id = 'ownerRepoSuggestions';
+    document.body.appendChild(dl);
+    filterOwnerRepoDatalist('adobe');
+
+    assert.strictEqual(dl.children.length, 1);
+    assert.strictEqual(dl.children[0].value, 'adobe/helix-pages');
+  });
+});
+
+describe('isValidOwnerRepoValue', () => {
+  let originalFetch;
+  let savedCredentials;
+
+  beforeEach(async () => {
+    originalFetch = window.fetch;
+    savedCredentials = state.credentials;
+    state.credentials = { user: 'testuser', password: 'testpass' };
+    resetOwnerRepoState();
+    window.fetch = makeFetchMock([
+      { owner_repo: 'adobe' },
+      { owner_repo: 'adobe/helix-pages' },
+    ]);
+    await loadOwnerRepoAutocomplete();
+    window.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    state.credentials = savedCredentials;
+    resetOwnerRepoState();
+  });
+
+  it('returns true for empty string', () => {
+    assert.isTrue(isValidOwnerRepoValue(''));
+  });
+
+  it('returns true for a known owner-only entry', () => {
+    assert.isTrue(isValidOwnerRepoValue('adobe'));
+  });
+
+  it('returns true for a known owner/repo entry', () => {
+    assert.isTrue(isValidOwnerRepoValue('adobe/helix-pages'));
+  });
+
+  it('returns false for partial text not in the list', () => {
+    assert.isFalse(isValidOwnerRepoValue('adobe/helix'));
+  });
+
+  it('returns false for unknown owner', () => {
+    assert.isFalse(isValidOwnerRepoValue('unknown'));
+  });
+
+  it('returns true for any value when list is not yet loaded', () => {
+    resetOwnerRepoState();
+    assert.isTrue(isValidOwnerRepoValue('anything'));
+  });
+});
+
+describe('filterOwnerRepoDatalist', () => {
+  let datalist;
+  let originalFetch;
+  let savedCredentials;
+  const testValues = [
+    'adobe/helix-pages',
+    'adobe/helix-importer',
+    'myorg/adobe-tools',
+    'other/repo',
+  ];
+
+  beforeEach(async () => {
+    originalFetch = window.fetch;
+    savedCredentials = state.credentials;
+    state.credentials = { user: 'testuser', password: 'testpass' };
+    resetOwnerRepoState();
+
+    window.fetch = makeFetchMock(testValues.map((v) => ({ owner_repo: v })));
+    await loadOwnerRepoAutocomplete();
+    window.fetch = originalFetch;
+
+    document.getElementById('ownerRepoSuggestions')?.remove();
+    datalist = document.createElement('datalist');
+    datalist.id = 'ownerRepoSuggestions';
+    document.body.appendChild(datalist);
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    state.credentials = savedCredentials;
+    resetOwnerRepoState();
+    datalist?.remove();
+  });
+
+  it('returns early when datalist element is absent', () => {
+    datalist.remove();
+    datalist = null;
+    filterOwnerRepoDatalist('adobe');
+    // no error thrown
+  });
+
+  it('clears datalist when text is empty', () => {
+    datalist.innerHTML = '<option value="stale">';
+    filterOwnerRepoDatalist('');
+    assert.strictEqual(datalist.innerHTML, '');
+  });
+
+  it('ranks owner-only prefix matches before owner/repo prefix matches before contains', () => {
+    // For 'adobe': no owner-only prefix matches, owner/repo prefix matches, then contains
+    filterOwnerRepoDatalist('adobe');
+
+    const values = Array.from(datalist.children).map((o) => o.value);
+    assert.deepEqual(values, [
+      'adobe/helix-importer',
+      'adobe/helix-pages',
+      'myorg/adobe-tools',
+    ]);
+  });
+
+  it('returns only entries that match the query', () => {
+    filterOwnerRepoDatalist('helix');
+
+    const values = Array.from(datalist.children).map((o) => o.value);
+    assert.deepEqual(values, ['adobe/helix-importer', 'adobe/helix-pages']);
+  });
+
+  it('is case-insensitive', () => {
+    filterOwnerRepoDatalist('ADOBE');
+
+    const values = Array.from(datalist.children).map((o) => o.value);
+    assert.include(values, 'adobe/helix-pages');
+    assert.include(values, 'myorg/adobe-tools');
+  });
+
+  it('ranks owner-only entries above owner/repo entries when both match', async () => {
+    resetOwnerRepoState();
+    const rows = [
+      { owner_repo: 'adobe' },
+      { owner_repo: 'adobe/helix-pages' },
+      { owner_repo: 'adobe/helix-importer' },
+    ];
+    window.fetch = makeFetchMock(rows);
+    await loadOwnerRepoAutocomplete();
+    window.fetch = originalFetch;
+
+    filterOwnerRepoDatalist('adobe');
+
+    const values = Array.from(datalist.children).map((o) => o.value);
+    assert.strictEqual(values[0], 'adobe', 'owner-only entry should come first');
+    assert.include(values, 'adobe/helix-importer');
+    assert.include(values, 'adobe/helix-pages');
+  });
+
+  it('limits results to 20 entries', async () => {
+    resetOwnerRepoState();
+    const manyValues = Array.from({ length: 30 }, (_, i) => `org/repo-${i}`);
+    window.fetch = makeFetchMock(manyValues.map((v) => ({ owner_repo: v })));
+    await loadOwnerRepoAutocomplete();
+    window.fetch = originalFetch;
+
+    filterOwnerRepoDatalist('repo');
+
+    assert.strictEqual(datalist.children.length, 20);
   });
 });

--- a/js/breakdowns/render.js
+++ b/js/breakdowns/render.js
@@ -17,9 +17,24 @@ import { state } from '../state.js';
 import { TOP_N_OPTIONS } from '../constants.js';
 import { buildBreakdownRow, buildOtherRow } from '../templates/breakdown-table.js';
 
-// Get filters for a specific column
+const OWNER_COL = '`helix.owner`';
+const REPO_COL = '`helix.repo`';
+
+// Get filters for a specific column, including a synthetic entry from ownerRepoFilter
 export function getFiltersForColumn(col) {
-  return state.filters.filter((f) => f.col === col);
+  const fromState = state.filters.filter((f) => f.col === col);
+  if (!state.ownerRepoFilter || (col !== OWNER_COL && col !== REPO_COL)) { return fromState; }
+  const slashIdx = state.ownerRepoFilter.indexOf('/');
+  let value;
+  if (col === OWNER_COL) {
+    value = slashIdx !== -1 ? state.ownerRepoFilter.substring(0, slashIdx) : state.ownerRepoFilter;
+  } else {
+    value = slashIdx !== -1 ? state.ownerRepoFilter.substring(slashIdx + 1) : null;
+  }
+  if (!value || fromState.some((f) => f.value === value)) { return fromState; }
+  return [...fromState, {
+    col, value, exclude: false, matchAny: true,
+  }];
 }
 
 // Get next topN value for "show more" functionality
@@ -141,7 +156,8 @@ export function renderBreakdownTable(
   const { title } = card.dataset;
 
   const columnFilters = getFiltersForColumn(col);
-  const hasFilters = columnFilters.length > 0;
+  // Only real column filters (not synthetic ownerRepoFilter entries) show the Clear button
+  const hasFilters = state.filters.some((f) => f.col === col);
   const mode = modeToggle ? state[modeToggle] : 'count';
   const isBytes = mode === 'bytes';
   const valueFormatter = isBytes ? formatBytes : formatNumber;

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -48,7 +48,9 @@ import {
   loadLogs, cycleViewMode, setViewMode, applyViewMode,
   setLogsElements, setOnShowFiltersView, setOnShowLogsView,
 } from './logs.js';
-import { loadHostAutocomplete, loadOwnerRepoAutocomplete } from './autocomplete.js';
+import {
+  loadHostAutocomplete, loadOwnerRepoAutocomplete, filterOwnerRepoDatalist,
+} from './autocomplete.js';
 import { initModal, closeQuickLinksModal } from './modal.js';
 import {
   initKeyboardNavigation, restoreKeyboardFocus, initScrollTracking, getFocusedFacetId,
@@ -505,8 +507,9 @@ export function initDashboard(config = {}) {
         ownerRepoFilterOriginalValue = elements.ownerRepoFilterInput.value;
         ownerRepoSelectedFromDatalist = false;
       });
-      elements.ownerRepoFilterInput.addEventListener('input', () => {
+      elements.ownerRepoFilterInput.addEventListener('input', (e) => {
         ownerRepoSelectedFromDatalist = false;
+        filterOwnerRepoDatalist(e.target.value);
       });
       elements.ownerRepoFilterInput.addEventListener('change', () => {
         ownerRepoSelectedFromDatalist = true;

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -50,6 +50,7 @@ import {
 } from './logs.js';
 import {
   loadHostAutocomplete, loadOwnerRepoAutocomplete, filterOwnerRepoDatalist,
+  isValidOwnerRepoValue,
 } from './autocomplete.js';
 import { initModal, closeQuickLinksModal } from './modal.js';
 import {
@@ -516,11 +517,16 @@ export function initDashboard(config = {}) {
         commitOwnerRepoFilterIfChanged();
       });
       elements.ownerRepoFilterInput.addEventListener('blur', () => {
+        if (!isValidOwnerRepoValue(elements.ownerRepoFilterInput.value)) {
+          elements.ownerRepoFilterInput.value = state.ownerRepoFilter;
+          return;
+        }
         commitOwnerRepoFilterIfChanged();
       });
       elements.ownerRepoFilterInput.addEventListener('keydown', (e) => {
         if (e.key === 'Enter') {
           e.preventDefault();
+          if (!isValidOwnerRepoValue(e.target.value)) { return; }
           commitOwnerRepoFilterIfChanged();
           e.target.blur();
         } else if (e.key === 'Escape') {

--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -41,14 +41,14 @@ import {
 import { getNextTopN } from './breakdowns/render.js';
 import {
   addFilter, removeFilter, removeFilterByValue, clearFiltersForColumn, setFilterCallbacks,
-  getFilterForValue,
+  getFilterForValue, setOnOwnerRepoFilterChange, renderActiveFilters, clearOwnerRepoFilter,
 } from './filters.js';
 import { clearAllowedColumnsCache } from './filter-sql.js';
 import {
   loadLogs, cycleViewMode, setViewMode, applyViewMode,
   setLogsElements, setOnShowFiltersView, setOnShowLogsView,
 } from './logs.js';
-import { loadHostAutocomplete } from './autocomplete.js';
+import { loadHostAutocomplete, loadOwnerRepoAutocomplete } from './autocomplete.js';
 import { initModal, closeQuickLinksModal } from './modal.js';
 import {
   initKeyboardNavigation, restoreKeyboardFocus, initScrollTracking, getFocusedFacetId,
@@ -86,6 +86,7 @@ export function initDashboard(config = {}) {
     timeRangeSelect: document.getElementById('timeRange'),
     topNSelect: document.getElementById('topN'),
     hostFilterInput: document.getElementById('hostFilter'),
+    ownerRepoFilterInput: document.getElementById('ownerRepoFilter'),
     searchFilterInput: document.getElementById('searchFilter'),
     refreshBtn: document.getElementById('refreshBtn'),
     logoutBtn: document.getElementById('logoutBtn'),
@@ -332,6 +333,22 @@ export function initDashboard(config = {}) {
     applySearchConfig();
   }
 
+  // Migrate helix.owner/helix.repo column filters loaded from URL into ownerRepoFilter input
+  function migrateOwnerRepoColumnFilters(input) {
+    const ownerF = state.filters.find((f) => f.col === '`helix.owner`' && !f.exclude);
+    const repoF = state.filters.find((f) => f.col === '`helix.repo`' && !f.exclude);
+    if (!ownerF && !repoF) { return; }
+    const owner = ownerF ? ownerF.value : '';
+    const repo = repoF ? repoF.value : '';
+    const migrated = (owner && repo) ? `${owner}/${repo}` : owner || repo;
+    state.ownerRepoFilter = migrated;
+    state.filters = state.filters.filter(
+      (f) => f.col !== '`helix.owner`' && f.col !== '`helix.repo`',
+    );
+    // eslint-disable-next-line no-param-reassign
+    input.value = migrated;
+  }
+
   // Initialize
   async function init() {
     // Set title before loadStateFromURL → loadFacetPrefs() so the storage key matches
@@ -353,6 +370,14 @@ export function initDashboard(config = {}) {
     loadStateFromURL();
     applyConfig(initialParams);
     applyDefaultHiddenFacets();
+
+    // When this dashboard uses the ownerRepoFilter input, sync breakdown clicks to it
+    if (elements.ownerRepoFilterInput) {
+      setOnOwnerRepoFilterChange((value) => {
+        elements.ownerRepoFilterInput.value = value;
+      });
+      migrateOwnerRepoColumnFilters(elements.ownerRepoFilterInput);
+    }
 
     populateTimeRangeSelect(elements.timeRangeSelect);
     populateTopNSelect(elements.topNSelect);
@@ -383,6 +408,7 @@ export function initDashboard(config = {}) {
       closeDialog: (el) => el.closest('dialog')?.close(),
       openFacetSearch,
       copyFacetTsv: copyFacetAsTsv,
+      clearOwnerRepoFilter,
     });
 
     const storedCredentials = loadStoredCredentials();
@@ -433,30 +459,76 @@ export function initDashboard(config = {}) {
     }
 
     let hostFilterOriginalValue = '';
-    elements.hostFilterInput.addEventListener('focus', () => {
-      hostFilterOriginalValue = elements.hostFilterInput.value;
-    });
-
-    elements.hostFilterInput.addEventListener('change', () => {
-      commitHostFilterIfChanged();
-    });
-
-    elements.hostFilterInput.addEventListener('blur', () => {
-      commitHostFilterIfChanged();
-    });
-
-    elements.hostFilterInput.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
+    if (elements.hostFilterInput) {
+      elements.hostFilterInput.addEventListener('focus', () => {
+        hostFilterOriginalValue = elements.hostFilterInput.value;
+      });
+      elements.hostFilterInput.addEventListener('change', () => {
         commitHostFilterIfChanged();
-        e.target.blur();
-      } else if (e.key === 'Escape') {
-        e.preventDefault();
-        e.target.value = hostFilterOriginalValue;
-        state.hostFilter = hostFilterOriginalValue;
-        e.target.blur();
-      }
-    });
+      });
+      elements.hostFilterInput.addEventListener('blur', () => {
+        commitHostFilterIfChanged();
+      });
+      elements.hostFilterInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          commitHostFilterIfChanged();
+          e.target.blur();
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          e.target.value = hostFilterOriginalValue;
+          state.hostFilter = hostFilterOriginalValue;
+          e.target.blur();
+        }
+      });
+    }
+
+    let ownerRepoSelectedFromDatalist = false;
+
+    function commitOwnerRepoFilterIfChanged() {
+      const { value } = elements.ownerRepoFilterInput;
+      const exact = ownerRepoSelectedFromDatalist && value.includes('/');
+      if (value === state.ownerRepoFilter && exact === state.ownerRepoFilterExact) { return; }
+      state.ownerRepoFilter = value;
+      state.ownerRepoFilterExact = exact;
+      state.filters = state.filters.filter(
+        (f) => f.col !== '`helix.owner`' && f.col !== '`helix.repo`',
+      );
+      renderActiveFilters();
+      saveStateToURL();
+      loadDashboard();
+    }
+
+    let ownerRepoFilterOriginalValue = '';
+    if (elements.ownerRepoFilterInput) {
+      elements.ownerRepoFilterInput.addEventListener('focus', () => {
+        ownerRepoFilterOriginalValue = elements.ownerRepoFilterInput.value;
+        ownerRepoSelectedFromDatalist = false;
+      });
+      elements.ownerRepoFilterInput.addEventListener('input', () => {
+        ownerRepoSelectedFromDatalist = false;
+      });
+      elements.ownerRepoFilterInput.addEventListener('change', () => {
+        ownerRepoSelectedFromDatalist = true;
+        commitOwnerRepoFilterIfChanged();
+      });
+      elements.ownerRepoFilterInput.addEventListener('blur', () => {
+        commitOwnerRepoFilterIfChanged();
+      });
+      elements.ownerRepoFilterInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          commitOwnerRepoFilterIfChanged();
+          e.target.blur();
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          e.target.value = ownerRepoFilterOriginalValue;
+          state.ownerRepoFilter = ownerRepoFilterOriginalValue;
+          state.ownerRepoFilterExact = false;
+          e.target.blur();
+        }
+      });
+    }
 
     const commitSearchFilterIfChanged = () => {
       const { value } = elements.searchFilterInput;
@@ -516,11 +588,16 @@ export function initDashboard(config = {}) {
   }
 
   window.addEventListener('dashboard-shown', () => {
-    setTimeout(loadHostAutocomplete, 100);
+    if (elements.ownerRepoFilterInput) {
+      setTimeout(loadOwnerRepoAutocomplete, 100);
+    } else {
+      setTimeout(loadHostAutocomplete, 100);
+    }
   });
 
   init();
   initHostFilterDoubleTap(elements.hostFilterInput);
+  if (elements.ownerRepoFilterInput) { initHostFilterDoubleTap(elements.ownerRepoFilterInput); }
   initMobileTouchSupport();
   initPullToRefresh(() => loadDashboard(true));
   initMobileFiltersPosition();

--- a/js/filters.js
+++ b/js/filters.js
@@ -13,6 +13,7 @@ import { state } from './state.js';
 import { getColorIndicatorHtml } from './colors/index.js';
 import { allBreakdowns } from './breakdowns/definitions.js';
 import { renderFilterTags } from './templates/filter-tags.js';
+import { escapeHtml } from './utils.js';
 
 // Callbacks set by main.js to avoid circular dependencies
 let saveStateToURL = null;
@@ -21,6 +22,17 @@ let loadDashboard = null;
 export function setFilterCallbacks(saveUrl, loadDash) {
   saveStateToURL = saveUrl;
   loadDashboard = loadDash;
+}
+
+const OWNER_COL = '`helix.owner`';
+const REPO_COL = '`helix.repo`';
+
+// Set by dashboard-init when ownerRepoFilter input is present (admin/da dashboards).
+// Called with the new filter value whenever it changes via breakdown click.
+let onOwnerRepoFilterChange = null;
+
+export function setOnOwnerRepoFilterChange(cb) {
+  onOwnerRepoFilterChange = cb;
 }
 
 // Fix header position when in keyboard mode or with 2+ filters
@@ -50,16 +62,20 @@ function getFacetTitle(col) {
 
 export function renderActiveFilters() {
   const container = document.getElementById('activeFilters');
-  if (state.filters.length === 0) {
+  const hasOwnerRepo = !!state.ownerRepoFilter;
+  if (state.filters.length === 0 && !hasOwnerRepo) {
     container.innerHTML = '';
     updateHeaderFixed();
     return;
   }
+  let html = '';
+  if (hasOwnerRepo) {
+    html += `<span class="filter-tag" data-action="clear-owner-repo-filter">${escapeHtml(state.ownerRepoFilter)}</span>`;
+  }
   const filterData = state.filters.map((f) => {
-    let label;
     const facetTitle = getFacetTitle(f.col) || 'Empty';
+    let label;
     if (f.value === '') {
-      // Empty value - show facet name with ! prefix
       label = f.exclude ? `NOT !${facetTitle}` : `!${facetTitle}`;
     } else {
       label = f.exclude ? `NOT ${f.value}` : f.value;
@@ -69,8 +85,19 @@ export function renderActiveFilters() {
       label, exclude: f.exclude, colorIndicator, title: facetTitle,
     };
   });
-  container.innerHTML = renderFilterTags(filterData);
+  html += renderFilterTags(filterData);
+  container.innerHTML = html;
   updateHeaderFixed();
+}
+
+export function clearOwnerRepoFilter() {
+  if (!state.ownerRepoFilter) { return; }
+  state.ownerRepoFilter = '';
+  state.ownerRepoFilterExact = false;
+  if (onOwnerRepoFilterChange) { onOwnerRepoFilterChange(''); }
+  renderActiveFilters();
+  if (saveStateToURL) { saveStateToURL(); }
+  if (loadDashboard) { loadDashboard(); }
 }
 
 export function getFiltersForColumn(col) {
@@ -137,22 +164,71 @@ function updateRowFilterStyling(col, value) {
   });
 }
 
+function clearOwnerRepoFilterIfOwnerOrRepo(col) {
+  if (!onOwnerRepoFilterChange) { return; }
+  if (col !== OWNER_COL && col !== REPO_COL) { return; }
+  if (col === REPO_COL) {
+    // Keep the owner part — only drop the /repo portion
+    const slashIdx = state.ownerRepoFilter.indexOf('/');
+    if (slashIdx !== -1) {
+      state.ownerRepoFilter = state.ownerRepoFilter.substring(0, slashIdx);
+      state.ownerRepoFilterExact = false;
+      onOwnerRepoFilterChange(state.ownerRepoFilter);
+      return;
+    }
+  }
+  state.ownerRepoFilter = '';
+  state.ownerRepoFilterExact = false;
+  onOwnerRepoFilterChange('');
+}
+
 export function clearFiltersForColumn(col) {
   state.filters = state.filters.filter((f) => f.col !== col);
+  clearOwnerRepoFilterIfOwnerOrRepo(col);
   renderActiveFilters();
   if (saveStateToURL) { saveStateToURL(); }
   if (loadDashboard) { loadDashboard(); }
 }
 
 export function clearAllFilters() {
-  if (state.filters.length === 0) { return; }
+  if (state.filters.length === 0 && !state.ownerRepoFilter) { return; }
   state.filters = [];
+  if (onOwnerRepoFilterChange && state.ownerRepoFilter) {
+    state.ownerRepoFilter = '';
+    state.ownerRepoFilterExact = false;
+    onOwnerRepoFilterChange('');
+  }
   renderActiveFilters();
   if (saveStateToURL) { saveStateToURL(); }
   if (loadDashboard) { loadDashboard(); }
 }
 
+function buildOwnerRepoValue(col, value) {
+  const current = state.ownerRepoFilter || '';
+  const slashIdx = current.indexOf('/');
+  const currentOwner = slashIdx !== -1 ? current.substring(0, slashIdx) : current;
+  if (col === OWNER_COL) { return value; }
+  return currentOwner ? `${currentOwner}/${value}` : value;
+}
+
+function routeToOwnerRepoFilter(col, value, exclude, skipReload) {
+  if (exclude || !onOwnerRepoFilterChange) { return false; }
+  if (col !== OWNER_COL && col !== REPO_COL) { return false; }
+  state.ownerRepoFilter = buildOwnerRepoValue(col, value);
+  state.ownerRepoFilterExact = state.ownerRepoFilter.includes('/');
+  state.filters = state.filters.filter((f) => f.col !== OWNER_COL && f.col !== REPO_COL);
+  onOwnerRepoFilterChange(state.ownerRepoFilter);
+  renderActiveFilters();
+  if (!skipReload) {
+    if (saveStateToURL) { saveStateToURL(); }
+    if (loadDashboard) { loadDashboard(); }
+  }
+  return true;
+}
+
 export function addFilter(col, value, exclude, filterCol, filterValue, filterOp, skipReload) {
+  if (routeToOwnerRepoFilter(col, value, exclude, skipReload)) { return; }
+
   // Remove existing filter for same col+value
   state.filters = state.filters.filter((f) => !(f.col === col && f.value === value));
 
@@ -188,7 +264,9 @@ export function addFilter(col, value, exclude, filterCol, filterValue, filterOp,
 }
 
 export function removeFilter(index) {
+  const removed = state.filters[index];
   state.filters.splice(index, 1);
+  if (removed) { clearOwnerRepoFilterIfOwnerOrRepo(removed.col); }
   renderActiveFilters();
   if (saveStateToURL) { saveStateToURL(); }
   if (loadDashboard) { loadDashboard(); }
@@ -196,6 +274,7 @@ export function removeFilter(index) {
 
 export function removeFilterByValue(col, value, skipReload) {
   state.filters = state.filters.filter((f) => !(f.col === col && f.value === value));
+  clearOwnerRepoFilterIfOwnerOrRepo(col);
   renderActiveFilters();
   updateRowFilterStyling(col, value);
   if (!skipReload) {

--- a/js/keyboard.js
+++ b/js/keyboard.js
@@ -405,7 +405,8 @@ function handleKeyboardShortcut(e) {
   } else if (key === 'f') {
     e.preventDefault();
     deactivateKeyboardMode();
-    document.getElementById('hostFilter').focus();
+    const filterEl = document.getElementById('ownerRepoFilter') || document.getElementById('hostFilter');
+    if (filterEl) { filterEl.focus(); }
   } else if (key === 'b' || key === '#') {
     e.preventDefault();
     if (onToggleFacetMode) { onToggleFacetMode('contentTypeMode'); }

--- a/js/state.js
+++ b/js/state.js
@@ -23,6 +23,8 @@ export const state = {
   credentials: null,
   timeRange: DEFAULT_TIME_RANGE,
   hostFilter: '',
+  ownerRepoFilter: '',
+  ownerRepoFilterExact: false, // true = exact match (=), false = LIKE search
   topN: DEFAULT_TOP_N,
   filters: [], // [{col: '`request.url`', value: '/foo', exclude: false}]
   logsData: null,

--- a/js/templates/breakdown-table.js
+++ b/js/templates/breakdown-table.js
@@ -125,7 +125,7 @@ function calculateBarPercentages(cnt, cntOk, cnt4xx, cnt5xx) {
  * Determine filter state for a row
  */
 function getFilterState(columnFilters, rowDim) {
-  const activeFilter = columnFilters.find((f) => f.value === (rowDim || ''));
+  const activeFilter = columnFilters.find((f) => f.matchAny || f.value === (rowDim || ''));
   return {
     isIncluded: activeFilter && !activeFilter.exclude,
     isExcluded: activeFilter && activeFilter.exclude,

--- a/js/time.js
+++ b/js/time.js
@@ -281,17 +281,32 @@ function getSearchClause() {
 }
 
 export function getHostFilter() {
-  let hostClause = '';
+  const clauses = [];
   if (state.hostFilter) {
     const escaped = state.hostFilter.replace(/'/g, "\\'");
     if (state.hostFilterColumn) {
-      hostClause = `AND \`${state.hostFilterColumn}\` LIKE '%${escaped}%'`;
+      clauses.push(`AND \`${state.hostFilterColumn}\` LIKE '%${escaped}%'`);
     } else {
-      hostClause = `AND (\`request.host\` LIKE '%${escaped}%' OR \`request.headers.x_forwarded_host\` LIKE '%${escaped}%')`;
+      clauses.push(`AND (\`request.host\` LIKE '%${escaped}%' OR \`request.headers.x_forwarded_host\` LIKE '%${escaped}%')`);
+    }
+  }
+  if (state.ownerRepoFilter) {
+    const slashIdx = state.ownerRepoFilter.indexOf('/');
+    if (slashIdx !== -1) {
+      const owner = state.ownerRepoFilter.substring(0, slashIdx).replace(/'/g, "\\'");
+      const repo = state.ownerRepoFilter.substring(slashIdx + 1).replace(/'/g, "\\'");
+      if (state.ownerRepoFilterExact) {
+        clauses.push(`AND \`helix.owner\` = '${owner}' AND \`helix.repo\` = '${repo}'`);
+      } else {
+        clauses.push(`AND \`helix.owner\` LIKE '%${owner}%' AND \`helix.repo\` LIKE '%${repo}%'`);
+      }
+    } else {
+      const escaped = state.ownerRepoFilter.replace(/'/g, "\\'");
+      clauses.push(`AND (\`helix.owner\` LIKE '%${escaped}%' OR \`helix.repo\` LIKE '%${escaped}%')`);
     }
   }
   const searchClause = getSearchClause();
-  return [hostClause, searchClause].filter(Boolean).join(' ');
+  return [...clauses, searchClause].filter(Boolean).join(' ');
 }
 
 // Get aligned time range for chart rendering and WITH FILL bounds

--- a/js/ui/actions.js
+++ b/js/ui/actions.js
@@ -105,6 +105,7 @@ export function initActionHandlers(handlers) {
       'close-quick-links': () => handlers.closeQuickLinksModal?.(),
       'close-dialog': () => handlers.closeDialog?.(target),
       'copy-facet-tsv': () => handlers.copyFacetTsv?.(target.dataset.facet || ''),
+      'clear-owner-repo-filter': () => handlers.clearOwnerRepoFilter?.(),
     };
 
     if (simpleActions[action]) {

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -50,6 +50,7 @@ export function setUrlStateElements(els) {
 function addBasicParams(params) {
   if (state.timeRange !== DEFAULT_TIME_RANGE) { params.set('t', state.timeRange); }
   if (state.hostFilter) { params.set('host', state.hostFilter); }
+  if (state.ownerRepoFilter) { params.set('owner', state.ownerRepoFilter); }
   if (state.searchFilter) { params.set('q', state.searchFilter); }
   if (state.topN !== DEFAULT_TOP_N) { params.set('n', state.topN); }
   if (state.viewMode !== 'filters') { params.set('view', state.viewMode); }
@@ -120,6 +121,7 @@ function loadBasicState(params) {
     state.timeRange = params.get('t');
   }
   if (params.has('host')) { state.hostFilter = params.get('host'); }
+  if (params.has('owner')) { state.ownerRepoFilter = params.get('owner'); }
   if (params.has('q')) { state.searchFilter = params.get('q'); }
   if (params.has('n')) {
     const n = parseInt(params.get('n'), 10);
@@ -206,17 +208,36 @@ export function loadStateFromURL() {
   if (params.has('hf')) { state.hiddenFacets = params.get('hf').split(',').filter((f) => f); }
 }
 
+function hideControl(name, el) {
+  if (state.hiddenControls.includes(name) && el) {
+    // eslint-disable-next-line no-param-reassign
+    el.style.display = 'none';
+  }
+}
+
+function applyHiddenControls() {
+  hideControl('timeRange', elements.timeRangeSelect);
+  hideControl('topN', elements.topNSelect);
+  hideControl('host', elements.hostFilterInput);
+  hideControl('owner', elements.ownerRepoFilterInput);
+  hideControl('refresh', elements.refreshBtn);
+  hideControl('logout', elements.logoutBtn);
+  hideControl('logs', elements.viewCycleBtn);
+}
+
 export function syncUIFromState() {
   syncTimeRangeSelectDisplay(elements.timeRangeSelect);
   elements.topNSelect.value = state.topN;
   document.body.dataset.topn = state.topN;
-  elements.hostFilterInput.value = state.hostFilter;
+  if (elements.hostFilterInput) { elements.hostFilterInput.value = state.hostFilter; }
+  if (elements.ownerRepoFilterInput) {
+    elements.ownerRepoFilterInput.value = state.ownerRepoFilter;
+  }
   if (elements.searchFilterInput) {
     elements.searchFilterInput.value = state.searchFilter;
   }
   renderActiveFilters();
 
-  // Update title if custom title is set
   const titleEl = document.getElementById('dashboardTitle');
   if (state.title) {
     titleEl.textContent = state.title;
@@ -226,7 +247,6 @@ export function syncUIFromState() {
     document.title = 'CDN Analytics';
   }
 
-  // Apply view mode to DOM
   const { viewMode } = state;
   const isSplit = viewMode === 'split';
   const isLogs = viewMode === 'logs';
@@ -234,25 +254,7 @@ export function syncUIFromState() {
   elements.filtersView.classList.toggle('visible', !isLogs);
   elements.filtersView.classList.toggle('in-split', isSplit);
   if (elements.contentArea) { elements.contentArea.classList.toggle('split', isSplit); }
-  // Apply hidden controls from URL
-  if (state.hiddenControls.includes('timeRange')) {
-    elements.timeRangeSelect.style.display = 'none';
-  }
-  if (state.hiddenControls.includes('topN')) {
-    elements.topNSelect.style.display = 'none';
-  }
-  if (state.hiddenControls.includes('host')) {
-    elements.hostFilterInput.style.display = 'none';
-  }
-  if (state.hiddenControls.includes('refresh')) {
-    elements.refreshBtn.style.display = 'none';
-  }
-  if (state.hiddenControls.includes('logout')) {
-    elements.logoutBtn.style.display = 'none';
-  }
-  if (state.hiddenControls.includes('logs')) {
-    if (elements.viewCycleBtn) { elements.viewCycleBtn.style.display = 'none'; }
-  }
+  applyHiddenControls();
 }
 
 // Handle browser back/forward navigation

--- a/js/url-state.js
+++ b/js/url-state.js
@@ -121,7 +121,10 @@ function loadBasicState(params) {
     state.timeRange = params.get('t');
   }
   if (params.has('host')) { state.hostFilter = params.get('host'); }
-  if (params.has('owner')) { state.ownerRepoFilter = params.get('owner'); }
+  if (params.has('owner')) {
+    state.ownerRepoFilter = params.get('owner');
+    state.ownerRepoFilterExact = state.ownerRepoFilter.includes('/');
+  }
   if (params.has('q')) { state.searchFilter = params.get('q'); }
   if (params.has('n')) {
     const n = parseInt(params.get('n'), 10);

--- a/js/url-state.test.js
+++ b/js/url-state.test.js
@@ -25,6 +25,8 @@ const ORIGINAL_PATH = window.location.pathname;
 function resetState() {
   state.timeRange = DEFAULT_TIME_RANGE;
   state.hostFilter = '';
+  state.ownerRepoFilter = '';
+  state.ownerRepoFilterExact = false;
   state.topN = DEFAULT_TOP_N;
   state.filters = [];
   state.viewMode = 'filters';
@@ -104,6 +106,29 @@ describe('loadStateFromURL', () => {
       setURL({});
       loadStateFromURL();
       assert.strictEqual(state.hostFilter, '');
+    });
+  });
+
+  describe('owner/repo filter', () => {
+    it('loads owner-only value with exact=false', () => {
+      setURL({ owner: 'adobe' });
+      loadStateFromURL();
+      assert.strictEqual(state.ownerRepoFilter, 'adobe');
+      assert.isFalse(state.ownerRepoFilterExact);
+    });
+
+    it('loads owner/repo value with exact=true', () => {
+      setURL({ owner: 'adobe-experience-league/exlm' });
+      loadStateFromURL();
+      assert.strictEqual(state.ownerRepoFilter, 'adobe-experience-league/exlm');
+      assert.isTrue(state.ownerRepoFilterExact);
+    });
+
+    it('keeps empty when owner is absent', () => {
+      setURL({});
+      loadStateFromURL();
+      assert.strictEqual(state.ownerRepoFilter, '');
+      assert.isFalse(state.ownerRepoFilterExact);
     });
   });
 

--- a/sql/queries/autocomplete-owner-repo.sql
+++ b/sql/queries/autocomplete-owner-repo.sql
@@ -1,0 +1,14 @@
+SELECT owner_repo FROM (
+    SELECT `helix.owner` AS owner_repo
+    FROM {{database}}.{{table}}
+    WHERE timestamp > now() - INTERVAL 7 DAY AND `helix.owner` != ''
+    GROUP BY `helix.owner`
+    UNION ALL
+    SELECT concat(`helix.owner`, '/', `helix.repo`) AS owner_repo
+    FROM {{database}}.{{table}}
+    WHERE timestamp > now() - INTERVAL 7 DAY AND `helix.owner` != '' AND `helix.repo` != ''
+    GROUP BY `helix.owner`, `helix.repo`
+)
+GROUP BY owner_repo
+ORDER BY lower(owner_repo) ASC
+LIMIT 500

--- a/sql/queries/autocomplete-owner-repo.sql
+++ b/sql/queries/autocomplete-owner-repo.sql
@@ -6,9 +6,10 @@ SELECT owner_repo FROM (
     UNION ALL
     SELECT concat(`helix.owner`, '/', `helix.repo`) AS owner_repo
     FROM {{database}}.{{table}}
-    WHERE timestamp > now() - INTERVAL 7 DAY AND `helix.owner` != '' AND `helix.repo` != ''
+    WHERE timestamp > now() - INTERVAL 7 DAY
+      AND `helix.owner` != ''
+      AND `helix.repo` != ''
     GROUP BY `helix.owner`, `helix.repo`
 )
 GROUP BY owner_repo
 ORDER BY lower(owner_repo) ASC
-LIMIT 500


### PR DESCRIPTION
## Summary

Adds an **owner/repo filter** input to `admin.html` and `da.html` that lets users narrow all breakdown queries to a specific `helix.owner` and/or `helix.repo`.

**Search vs. exact-match modes:**
- Typing partial text (e.g. `adobe-ex`) applies a `LIKE` filter — all matching owners/repos are shown in breakdowns and highlighted as active
- Selecting a full `owner/repo` entry from the datalist dropdown switches to exact `=` match so only that specific repo is returned (not `exlm-prod`, `exlm-stage`, etc.)
- Clicking a `helix.owner` row in a breakdown sets the owner filter; clicking a `helix.repo` row narrows to `owner/repo`; deselecting the repo reverts to owner-only (owner filter is preserved)

**Autocomplete:**
- New `sql/queries/autocomplete-owner-repo.sql` queries the last 7 days (widened from 1 day) and sorts case-insensitively so `adobe-experience-league` appears next to `AdobeEXL` in the dropdown instead of being hidden past Chrome's 6-item cutoff
- Cache key is now table-specific (`ownerRepoAutocompleteSuggestions_<table>`) to avoid cross-dashboard contamination between admin/da/delivery

**UI integration:**
- Active filter pill shown in the filters bar; clicking it clears the filter
- `?owner=` URL param persists/restores the filter across page loads
- `f` keyboard shortcut focuses `ownerRepoFilter` if present, falls back to `hostFilter`
- Breakdown rows for `helix.owner`/`helix.repo` show as visually selected when the filter is active

## Testing Done

- Typed partial owner (`adobe-ex`) → LIKE filter applied, multiple matching owners appear in breakdowns, rows highlighted
- Selected `adobe-experience-league/exlm` from dropdown → exact filter, only `exlm` repo data shown (not `exlm-prod`, `exlm-stage`)
- Clicked `helix.owner` row → owner filter set; clicked `helix.repo` row → narrowed to owner/repo; deselected repo → reverted to owner-only
- Active filter pill appears and clears correctly
- `?owner=` param round-trips correctly via URL
- `npm run lint` passes

## Checklist
- [ ] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)