### PR TITLE
fix: persist dashboard-specific URL filters across reload

### DIFF
--- a/js/dashboard-init.js
+++ b/js/dashboard-init.js
@@ -341,6 +341,15 @@ export function initDashboard(config = {}) {
       state.title = config.title;
     }
 
+    // Breakdowns drive the filter-column allowlist used by loadStateFromURL,
+    // so the dashboard's breakdowns must be installed before URL filters are parsed.
+    // Otherwise dashboard-specific columns (e.g. `level` on Lambda) get rejected
+    // by the default allowlist and silently dropped from the restored filter set.
+    if (config.breakdowns) {
+      state.breakdowns = config.breakdowns;
+      clearAllowedColumnsCache();
+    }
+
     loadStateFromURL();
     applyConfig(initialParams);
     applyDefaultHiddenFacets();


### PR DESCRIPTION
## Summary
- `loadStateFromURL()` validates each URL filter's column against an allowlist built from `state.breakdowns`. The dashboard config's breakdowns were applied one line *after* `loadStateFromURL()`, so the validator always fell back to the default (delivery) breakdowns.
- Result: dashboard-specific filter columns (e.g. `` `level` `` on Lambda) were rejected as invalid and silently dropped from the URL on every reload. Delivery's `status` filter worked only because `status` is in the default allowlist.
- Fix: install `config.breakdowns` and clear the allowlist cache before `loadStateFromURL()` runs.

## Testing Done
- `npm run lint` clean
- `npm test` — 884 tests pass
- Manual repro: Lambda view → filter level to `warn` → reload → before: filter gone, after: filter preserved. (Note: I wasn't able to verify the manual reload in my sandbox because `README.local.md` with credentials wasn't present — please confirm locally.)

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)