### PR TITLE
feat: rename 7d label to "Last week" and add 14d range

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The dashboard state can be controlled via URL parameters for bookmarking and sha
 
 | Parameter | Description                                       | Example                                                                     |
 | --------- | ------------------------------------------------- | --------------------------------------------------------------------------- |
-| `t`       | Time range: `15m`, `1h`, `12h`, `24h`, `3d`, `7d` | `?t=24h`                                                                    |
+| `t`       | Time range: `15m`, `1h`, `12h`, `24h`, `3d`, `7d`, `14d` | `?t=24h`                                                             |
 | `n`       | Top N facet values: `5`, `10`, `20`, `50`, `100`  | `?n=20`                                                                     |
 | `host`    | Filter by host (substring match)                  | `?host=example.com`                                                         |
 | `view`    | View mode: `logs` for logs table                  | `?view=logs`                                                                |

--- a/js/constants.js
+++ b/js/constants.js
@@ -23,7 +23,7 @@
  */
 
 /** @type {string[]} */
-export const TIME_RANGE_ORDER = ['15m', '1h', '12h', '24h', '3d', '7d'];
+export const TIME_RANGE_ORDER = ['15m', '1h', '12h', '24h', '3d', '7d', '14d'];
 
 /** @type {Record<string, TimeRangeDefinition>} */
 export const TIME_RANGES = {
@@ -73,12 +73,21 @@ export const TIME_RANGES = {
     cacheTtl: 1800,
   },
   '7d': {
-    label: 'Last 7 days',
+    label: 'Last week',
     shortLabel: '7d',
     interval: 'INTERVAL 7 DAY',
     bucket: 'toStartOfTenMinutes(timestamp)',
     step: 'INTERVAL 10 MINUTE',
     periodMs: 7 * 24 * 60 * 60 * 1000,
+    cacheTtl: 1800,
+  },
+  '14d': {
+    label: 'Last 2 weeks',
+    shortLabel: '14d',
+    interval: 'INTERVAL 14 DAY',
+    bucket: 'toStartOfInterval(timestamp, INTERVAL 20 MINUTE)',
+    step: 'INTERVAL 20 MINUTE',
+    periodMs: 14 * 24 * 60 * 60 * 1000,
     cacheTtl: 1800,
   },
 };

--- a/js/time.test.js
+++ b/js/time.test.js
@@ -421,8 +421,8 @@ describe('zoomOut', () => {
     assert.strictEqual(result.timeRange, '1h');
   });
 
-  it('returns null when already at 7d (largest range)', () => {
-    state.timeRange = '7d';
+  it('returns null when already at 14d (largest range)', () => {
+    state.timeRange = '14d';
     clearCustomTimeRange();
     setQueryTimestamp(new Date('2026-01-20T12:34:56Z'));
     const result = zoomOut();

--- a/js/url-state.test.js
+++ b/js/url-state.test.js
@@ -60,7 +60,7 @@ describe('loadStateFromURL', () => {
     });
 
     it('loads all valid time ranges', () => {
-      for (const key of ['15m', '1h', '12h', '24h', '3d', '7d']) {
+      for (const key of ['15m', '1h', '12h', '24h', '3d', '7d', '14d']) {
         resetState();
         setURL({ t: key });
         loadStateFromURL();
@@ -718,7 +718,7 @@ describe('syncUIFromState', () => {
 
     // Create mock DOM elements
     const timeSelect = document.createElement('select');
-    ['15m', '1h', '12h', '24h', '3d', '7d', 'custom'].forEach((v) => {
+    ['15m', '1h', '12h', '24h', '3d', '7d', '14d', 'custom'].forEach((v) => {
       const opt = document.createElement('option');
       opt.value = v;
       opt.textContent = v;


### PR DESCRIPTION
## Summary
- Renamed the existing `7d` time range's display label from "Last 7 days" to "Last week". The URL key (`?t=7d`), `shortLabel` (mobile), and `DEFAULT_TIME_RANGE` are all unchanged, so existing links and bookmarks keep working.
- Added a new `14d` time range labeled "Last 2 weeks", with 20-minute buckets (yielding ~1008 chart bars, matching the density of `7d`). Appended to `TIME_RANGE_ORDER` and documented in the `t` query-parameter table in `README.md`.
- Updated the two hard-coded time-range key lists in `js/url-state.test.js` and the `zoomOut` "largest range" test in `js/time.test.js` (now anchored on `14d` instead of `7d`).

## Caveats
- The underlying tables have a 2-week TTL. Queries against `14d` sit right at the retention edge, so some rows near the start of the window may already be evicted by the time a query runs. This is acceptable but worth noting.

## Testing Done
- `npm test` — all 884 tests pass.
- `npm run lint` — clean.

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (`README.md` `t` parameter)
