### PR TITLE
feat: add Site Configs dashboard

### DIFF
--- a/configs.html
+++ b/configs.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Site Configs - CDN Analytics</title>
+  <script>
+    window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
+  </script>
+  <script defer type="text/javascript" src="https://ot.aem.live/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
+  <link rel="canonical" href="https://klickhaus.aemstatus.net/configs.html">
+
+  <!-- Favicon Icons -->
+  <link rel="apple-touch-icon" href="/icons/icon-180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/icon-32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png">
+
+  <link rel="stylesheet" href="css/variables.css">
+  <link rel="stylesheet" href="css/base.css">
+  <link rel="stylesheet" href="css/login.css">
+  <link rel="stylesheet" href="css/layout.css">
+  <link rel="stylesheet" href="css/modals.css">
+  <link rel="stylesheet" href="css/configs.css">
+</head>
+<body>
+  <!-- Login Form -->
+  <div id="login">
+    <div class="login-card">
+      <h1>Site Configs</h1>
+      <p>Sign in to browse Helix site configurations</p>
+      <div id="loginError" class="error-message"></div>
+      <form id="loginForm" method="post" action="">
+        <div class="form-group">
+          <label for="username">Email or username</label>
+          <input type="text" id="username" name="username" required autocomplete="username email" inputmode="email">
+        </div>
+        <div class="form-group">
+          <label for="password">Password</label>
+          <input type="password" id="password" name="password" required autocomplete="current-password">
+        </div>
+        <div class="form-group form-option">
+          <label class="checkbox-label">
+            <input type="checkbox" id="forgetMe" name="forgetMe">
+            Forget me on this device
+          </label>
+        </div>
+        <button type="submit" class="btn btn-primary">Sign In</button>
+      </form>
+    </div>
+  </div>
+
+  <!-- Dashboard -->
+  <div id="dashboard">
+    <header>
+      <div class="header-left">
+        <a href="index.html" class="menu-btn" title="Quick Links">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <rect y="3" width="20" height="2" rx="1"/>
+            <rect y="9" width="20" height="2" rx="1"/>
+            <rect y="15" width="20" height="2" rx="1"/>
+          </svg>
+        </a>
+        <h1>Site Configs <span id="queryTimer" class="query-timer"></span></h1>
+        <span id="rowCount" class="row-count"></span>
+      </div>
+      <div class="header-right">
+        <input type="text" id="searchInput" placeholder="Filter by org or site...">
+        <button id="moreBtn" class="menu-btn" title="More actions">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <circle cx="10" cy="4" r="1.5"/>
+            <circle cx="10" cy="10" r="1.5"/>
+            <circle cx="10" cy="16" r="1.5"/>
+          </svg>
+        </button>
+      </div>
+
+      <!-- More Actions Menu -->
+      <dialog id="moreMenu">
+        <button id="refreshBtn" class="menu-item">Refresh</button>
+        <div class="menu-divider"></div>
+        <button id="logoutBtn" class="menu-item">Logout</button>
+      </dialog>
+    </header>
+
+    <main class="configs-main">
+      <!-- Stats + type breakdown -->
+      <section class="stats-section" id="statsSection" style="display:none">
+        <div class="stats-chips" id="statsChips"></div>
+        <div class="type-breakdown">
+          <h3>CDN Type</h3>
+          <table class="type-table" id="typeTable">
+            <tbody id="typeBody"></tbody>
+          </table>
+        </div>
+        <div class="type-breakdown">
+          <h3>Content Source</h3>
+          <table class="type-table" id="contentTypeTable">
+            <tbody id="contentTypeBody"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- Site configs table -->
+      <section class="table-section">
+        <div id="loadingState" class="loading">
+          <div class="spinner"></div>
+          Loading site configurations...
+        </div>
+        <div id="errorState" class="error-message"></div>
+        <div id="tableContainer" class="table-container" style="display:none">
+          <table id="configsTable" class="configs-table">
+            <thead>
+              <tr>
+                <th data-col="org" class="sortable" aria-sort="ascending"><button type="button">Org</button></th>
+                <th data-col="site" class="sortable" aria-sort="none"><button type="button">Site</button></th>
+                <th data-col="cdn_prod_host" class="sortable" aria-sort="none"><button type="button">CDN Host</button></th>
+                <th data-col="cdn_prod_type" class="sortable" aria-sort="none"><button type="button">CDN Type</button></th>
+                <th data-col="code_source_type" class="sortable" aria-sort="none"><button type="button">Code Source</button></th>
+                <th data-col="content_source_type" class="sortable" aria-sort="none"><button type="button">Content Source</button></th>
+                <th data-col="profile" class="sortable" aria-sort="none"><button type="button">Profile</button></th>
+                <th data-col="last_modified_date" class="sortable" aria-sort="none"><button type="button">Modified</button></th>
+              </tr>
+            </thead>
+            <tbody id="configsBody"></tbody>
+          </table>
+        </div>
+        <div class="pagination" id="pagination" style="display:none">
+          <button id="prevBtn" class="page-btn" disabled>&#8592; Prev</button>
+          <span id="pageInfo" class="page-info"></span>
+          <button id="nextBtn" class="page-btn">Next &#8594;</button>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <!-- Config detail dialog -->
+  <dialog id="configDetail" class="config-detail-dialog">
+    <div class="detail-header">
+      <div>
+        <h2 id="detailTitle"></h2>
+        <div class="detail-subtitle" id="detailSubtitle"></div>
+      </div>
+      <button id="detailClose" class="detail-close" title="Close">&#x2715;</button>
+    </div>
+    <div class="detail-body" id="detailBody"></div>
+  </dialog>
+
+  <script type="module" src="js/configs-main.js"></script>
+</body>
+</html>

--- a/css/configs.css
+++ b/css/configs.css
@@ -1,0 +1,481 @@
+/*
+ * Site Configs Explorer
+ * Styles for the site configuration browser page
+ */
+
+html {
+  overflow: auto;
+}
+
+#moreMenu[open] {
+  z-index: 10;
+}
+
+.row-count {
+  font-size: 13px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+/* ── Main layout ────────────────────────────────────────────── */
+
+.configs-main {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 16px 24px 24px;
+}
+
+/* ── Stats section ──────────────────────────────────────────── */
+
+.stats-section {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.stats-chips {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  flex: 1;
+  min-width: 260px;
+}
+
+.stat-chip {
+  all: unset;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 12px 16px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  min-width: 120px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.stat-chip:hover {
+  border-color: var(--host-delivery);
+}
+
+.stat-chip.active {
+  background: color-mix(in srgb, var(--host-delivery) 10%, transparent);
+  border-color: var(--host-delivery);
+}
+
+.stat-chip.active .stat-value,
+.stat-chip.active .stat-label {
+  color: var(--host-delivery);
+}
+
+.stat-chip .stat-value {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.stat-chip .stat-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.stat-chip .stat-pct {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-top: 1px;
+}
+
+/* ── CDN type breakdown table ───────────────────────────────── */
+
+.type-breakdown {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 16px;
+  min-width: 200px;
+}
+
+.type-breakdown h3 {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  margin: 0 0 8px;
+}
+
+.type-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.type-table tbody tr {
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.type-table tbody tr:hover td {
+  background: var(--bg);
+}
+
+.type-table tbody tr.active td {
+  background: color-mix(in srgb, var(--host-delivery) 10%, transparent);
+}
+
+.type-table tbody tr.active td:first-child {
+  color: var(--host-delivery);
+  font-weight: 600;
+}
+
+.type-table td {
+  padding: 3px 0;
+  vertical-align: middle;
+}
+
+.type-table td:last-child {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+  padding-left: 16px;
+}
+
+.type-bar-cell {
+  width: 80px;
+  padding-left: 8px !important;
+}
+
+.type-bar-wrap {
+  height: 6px;
+  background: var(--border);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.type-bar-fill {
+  height: 100%;
+  background: var(--host-delivery);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+/* ── Site configs table section ─────────────────────────────── */
+
+.table-section {
+  background: var(--card-bg);
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+.configs-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.configs-table thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.configs-table th {
+  background: var(--bg);
+  border-bottom: 2px solid var(--border);
+  padding: 10px 14px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.configs-table th.sortable button {
+  all: unset;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+}
+
+.configs-table th.sortable:hover,
+.configs-table th.sortable button:hover {
+  color: var(--text);
+}
+
+.configs-table th.sort-asc::after {
+  content: ' \25B2 ';
+  font-size: 10px;
+}
+
+.configs-table th.sort-desc::after {
+  content: ' \25BC ';
+  font-size: 10px;
+}
+
+.configs-table td {
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+
+.configs-table tbody tr:hover {
+  background: var(--bg);
+  cursor: pointer;
+}
+
+.configs-table tbody tr.hidden {
+  display: none;
+}
+
+.org-cell {
+  font-weight: 600;
+  color: var(--host-delivery);
+}
+
+.site-cell {
+  color: var(--text);
+}
+
+.cdn-host-cell {
+  color: var(--host-customer);
+  font-size: 12px;
+}
+
+.cdn-type-cell,
+.source-type-cell {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.profile-cell {
+  color: var(--host-authoring);
+  font-size: 12px;
+}
+
+.date-cell {
+  color: var(--text-secondary);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+/* Empty and loading states inside table-section */
+.table-section .loading {
+  padding: 60px 20px;
+}
+
+.table-section .error-message {
+  margin: 20px;
+}
+
+/* ── Pagination ─────────────────────────────────────────────── */
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+}
+
+.page-btn {
+  all: unset;
+  cursor: pointer;
+  padding: 5px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  line-height: 1.4;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.page-btn:hover:not(:disabled) {
+  background: var(--card-bg);
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.page-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.page-info {
+  font-size: 13px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  min-width: 140px;
+  text-align: center;
+}
+
+/* ── Config detail dialog ───────────────────────────────────── */
+
+.config-detail-dialog {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0;
+  width: min(640px, 95vw);
+  max-height: 80vh;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+}
+
+.config-detail-dialog[open] {
+  display: flex;
+  flex-direction: column;
+}
+
+.config-detail-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.detail-header h2 {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0;
+}
+
+.detail-header .detail-subtitle {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.detail-config-link {
+  color: var(--host-delivery);
+  text-decoration: none;
+  font-size: 12px;
+}
+
+.detail-config-link:hover {
+  text-decoration: underline;
+}
+
+.detail-close {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 18px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.detail-close:hover {
+  background: var(--bg);
+  color: var(--text);
+}
+
+.detail-body {
+  overflow-y: auto;
+  padding: 16px 20px 20px;
+  flex: 1;
+}
+
+.detail-group {
+  margin-bottom: 16px;
+}
+
+.detail-group-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  margin: 0 0 6px;
+}
+
+.detail-rows {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 4px 12px;
+  font-size: 13px;
+}
+
+.detail-label {
+  color: var(--text-secondary);
+  padding: 3px 0;
+  align-self: start;
+}
+
+.detail-value {
+  color: var(--text);
+  padding: 3px 0;
+  word-break: break-all;
+  align-self: start;
+}
+
+.detail-value.empty {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.detail-json {
+  margin: 0;
+  font-size: 12px;
+  font-family: 'Menlo', 'Monaco', 'Consolas', monospace;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--text);
+  line-height: 1.5;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+/* ── Responsive ─────────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .configs-main {
+    margin: 0 12px 16px;
+  }
+
+  .stats-section {
+    flex-direction: column;
+  }
+
+  .type-breakdown {
+    width: 100%;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -68,6 +68,12 @@
           <div class="description">Map AEM Edge Delivery hostnames to customer domains via x-forwarded-host</div>
         </a>
       </li>
+      <li>
+        <a href="configs.html">
+          <div class="title">Site Configs</div>
+          <div class="description">Browse and search Helix site configurations: CDN host, code/content source types, features</div>
+        </a>
+      </li>
     </ul>
 
   </div>

--- a/js/api.js
+++ b/js/api.js
@@ -44,6 +44,18 @@ export function summarizeErrorText(text) {
     return 'Unknown error';
   }
   const trimmed = String(text).trim();
+  // ClickHouse Cloud sometimes returns errors as JSON: { "exception": "Code: X..." }
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      const inner = parsed.exception || parsed.error || parsed.message;
+      if (inner) {
+        return summarizeErrorText(inner);
+      }
+    } catch {
+      // not JSON, fall through to first-line logic
+    }
+  }
   const firstLine = trimmed.split('\n').map((line) => line.trim()).find(Boolean) || trimmed;
   const normalized = firstLine.replace(/\s+/g, ' ').trim();
   if (normalized.length > 200) {

--- a/js/configs-main.js
+++ b/js/configs-main.js
@@ -1,0 +1,504 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { state } from './state.js';
+import { query, setForceRefresh } from './api.js';
+import { DATABASE } from './config.js';
+import { formatNumber, formatQueryTime } from './format.js';
+import { escapeHtml } from './utils.js';
+import { loadSql } from './sql-loader.js';
+import {
+  setElements, loadStoredCredentials, handleLogin, handleLogout, showLogin, showDashboard,
+} from './auth.js';
+
+const PAGE_SIZE = 200;
+
+// All mutable state in one const object to avoid formatter const/let conflicts
+const s = {
+  rows: [],
+  typeRowsData: [],
+  contentTypeRowsData: [],
+  statsData: {},
+  // chip (boolean presence) filters
+  chipFilters: {
+    cdn_host: false, cdn_type: false, folders: false, profile: false,
+  },
+  sortCol: 'org',
+  sortAsc: true,
+  currentPage: 1,
+  cdnTypeFilter: null,
+  contentTypeFilter: null,
+};
+
+// DOM refs
+const els = {
+  loginSection: document.getElementById('login'),
+  dashboardSection: document.getElementById('dashboard'),
+  loginError: document.getElementById('loginError'),
+  queryTimer: document.getElementById('queryTimer'),
+  searchInput: document.getElementById('searchInput'),
+  rowCount: document.getElementById('rowCount'),
+  loadingState: document.getElementById('loadingState'),
+  errorState: document.getElementById('errorState'),
+  tableContainer: document.getElementById('tableContainer'),
+  configsBody: document.getElementById('configsBody'),
+  statsSection: document.getElementById('statsSection'),
+  statsChips: document.getElementById('statsChips'),
+  typeBody: document.getElementById('typeBody'),
+  contentTypeBody: document.getElementById('contentTypeBody'),
+  pagination: document.getElementById('pagination'),
+  pageInfo: document.getElementById('pageInfo'),
+  prevBtn: document.getElementById('prevBtn'),
+  nextBtn: document.getElementById('nextBtn'),
+  configDetail: document.getElementById('configDetail'),
+  detailTitle: document.getElementById('detailTitle'),
+  detailSubtitle: document.getElementById('detailSubtitle'),
+  detailBody: document.getElementById('detailBody'),
+};
+
+function updateAriaSort() {
+  document.querySelectorAll('.configs-table th.sortable').forEach((th) => {
+    th.classList.remove('sort-asc', 'sort-desc');
+    if (th.dataset.col === s.sortCol) {
+      th.classList.add(s.sortAsc ? 'sort-asc' : 'sort-desc');
+      th.setAttribute('aria-sort', s.sortAsc ? 'ascending' : 'descending');
+    } else {
+      th.setAttribute('aria-sort', 'none');
+    }
+  });
+}
+
+function renderStats(stats, total) {
+  s.statsData = stats;
+  const pct = (n) => (total > 0 ? ` (${Math.round((n / total) * 100)}%)` : '');
+  const anyChip = Object.values(s.chipFilters).some(Boolean);
+
+  const chips = [
+    {
+      label: anyChip ? 'Clear filters' : 'Total sites',
+      value: formatNumber(total),
+      key: null,
+    },
+    {
+      label: 'With CDN host',
+      value: formatNumber(Number(stats.with_cdn_host)),
+      pct: pct(Number(stats.with_cdn_host)),
+      key: 'cdn_host',
+    },
+    {
+      label: 'With CDN type',
+      value: formatNumber(Number(stats.with_cdn_type)),
+      pct: pct(Number(stats.with_cdn_type)),
+      key: 'cdn_type',
+    },
+    {
+      label: 'With folders',
+      value: formatNumber(Number(stats.with_folders)),
+      pct: pct(Number(stats.with_folders)),
+      key: 'folders',
+    },
+    {
+      label: 'With profile',
+      value: formatNumber(Number(stats.with_profile)),
+      pct: pct(Number(stats.with_profile)),
+      key: 'profile',
+    },
+  ];
+
+  els.statsChips.innerHTML = chips.map(({
+    label, value, pct: p, key,
+  }) => {
+    const active = key ? s.chipFilters[key] : anyChip;
+    const dataAttr = key ? `data-key="${escapeHtml(key)}"` : 'data-clear="1"';
+    return `<button type="button" class="stat-chip${active ? ' active' : ''}" ${dataAttr}>
+      <span class="stat-value">${escapeHtml(value)}</span>
+      <span class="stat-label">${escapeHtml(label)}</span>
+      ${p ? `<span class="stat-pct">${escapeHtml(p)}</span>` : ''}
+    </button>`;
+  }).join('');
+}
+
+function renderFacetBreakdown(tbodyEl, data, activeFilter) {
+  const maxCnt = data.reduce((m, r) => Math.max(m, Number(r.cnt)), 0);
+  const el = tbodyEl;
+  el.innerHTML = data.map((r) => {
+    const cnt = Number(r.cnt);
+    const barPct = maxCnt > 0 ? Math.round((cnt / maxCnt) * 100) : 0;
+    const active = activeFilter === r.type;
+    return `<tr class="type-row${active ? ' active' : ''}" data-type="${escapeHtml(r.type)}">
+      <td>${escapeHtml(r.type)}</td>
+      <td class="type-bar-cell">
+        <div class="type-bar-wrap"><div class="type-bar-fill" style="width:${barPct}%"></div></div>
+      </td>
+      <td>${formatNumber(cnt)}</td>
+    </tr>`;
+  }).join('');
+}
+
+function matchesText(row, filterText) {
+  if (!filterText) { return true; }
+  return row.org.toLowerCase().includes(filterText)
+    || row.site.toLowerCase().includes(filterText)
+    || row.cdn_prod_host.toLowerCase().includes(filterText);
+}
+
+function matchesFacets(row) {
+  if (s.cdnTypeFilter) {
+    const want = s.cdnTypeFilter === '(none)' ? '' : s.cdnTypeFilter;
+    if (row.cdn_prod_type !== want) { return false; }
+  }
+  if (s.contentTypeFilter) {
+    const want = s.contentTypeFilter === '(none)' ? '' : s.contentTypeFilter;
+    if (row.content_source_type !== want) { return false; }
+  }
+  return true;
+}
+
+function matchesChips(row) {
+  const {
+    cdn_host: fCdnHost, cdn_type: fCdnType, folders: fFolders, profile: fProfile,
+  } = s.chipFilters;
+  if (fCdnHost && !row.cdn_prod_host) { return false; }
+  if (fCdnType && !row.cdn_prod_type) { return false; }
+  if (fFolders && row.folders !== '1' && row.folders !== true) { return false; }
+  if (fProfile && !row.profile) { return false; }
+  return true;
+}
+
+function matchesRow(row, filterText) {
+  return matchesText(row, filterText) && matchesFacets(row) && matchesChips(row);
+}
+
+function renderTable() {
+  const filterText = els.searchInput.value.toLowerCase().trim();
+
+  const sorted = [...s.rows].sort((a, b) => {
+    const va = (a[s.sortCol] || '').toString().toLowerCase();
+    const vb = (b[s.sortCol] || '').toString().toLowerCase();
+    if (va < vb) { return s.sortAsc ? -1 : 1; }
+    if (va > vb) { return s.sortAsc ? 1 : -1; }
+    return 0;
+  });
+
+  const filtered = sorted.filter((row) => matchesRow(row, filterText));
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  if (s.currentPage > totalPages) { s.currentPage = totalPages; }
+
+  const start = (s.currentPage - 1) * PAGE_SIZE;
+  const end = Math.min(start + PAGE_SIZE, filtered.length);
+  const pageRows = filtered.slice(start, end);
+
+  els.configsBody.innerHTML = pageRows.map((row) => {
+    const cdnHost = row.cdn_prod_host
+      ? `<span class="cdn-host-cell">${escapeHtml(row.cdn_prod_host)}</span>`
+      : '<span style="color:var(--text-secondary)">—</span>';
+    return `<tr data-org="${escapeHtml(row.org)}" data-site="${escapeHtml(row.site)}">
+      <td class="org-cell">${escapeHtml(row.org)}</td>
+      <td class="site-cell">${escapeHtml(row.site)}</td>
+      <td>${cdnHost}</td>
+      <td class="cdn-type-cell">${escapeHtml(row.cdn_prod_type || '—')}</td>
+      <td class="source-type-cell">${escapeHtml(row.code_source_type || '—')}</td>
+      <td class="source-type-cell">${escapeHtml(row.content_source_type || '—')}</td>
+      <td class="profile-cell">${escapeHtml(row.profile || '—')}</td>
+      <td class="date-cell">${escapeHtml(row.last_modified_date || '—')}</td>
+    </tr>`;
+  }).join('');
+
+  const anyFilter = filterText || s.cdnTypeFilter || s.contentTypeFilter
+    || Object.values(s.chipFilters).some(Boolean);
+  els.rowCount.textContent = anyFilter
+    ? `${formatNumber(filtered.length)} of ${formatNumber(s.rows.length)} sites`
+    : `${formatNumber(s.rows.length)} sites`;
+
+  if (totalPages > 1) {
+    els.pagination.style.display = '';
+    els.pageInfo.textContent = `${formatNumber(start + 1)}–${formatNumber(end)} of ${formatNumber(filtered.length)}`;
+    els.prevBtn.disabled = s.currentPage <= 1;
+    els.nextBtn.disabled = s.currentPage >= totalPages;
+  } else {
+    els.pagination.style.display = 'none';
+  }
+
+  updateAriaSort();
+}
+
+function formatJson(raw) {
+  if (!raw || raw === '{}' || raw === '[]' || raw === 'null' || raw === '') {
+    return null;
+  }
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+function detailRow(label, value) {
+  const isEmpty = value === null || value === undefined || value === '';
+  const display = isEmpty ? '—' : escapeHtml(String(value));
+  return `<div class="detail-label">${escapeHtml(label)}</div>
+          <div class="detail-value${isEmpty ? ' empty' : ''}">${display}</div>`;
+}
+
+function showDetail(row) {
+  els.detailTitle.textContent = `${row.org} / ${row.site}`;
+  els.detailSubtitle.innerHTML = row.cdn_prod_host
+    ? `${escapeHtml(row.cdn_prod_host)} &mdash; <a href="https://admin.hlx.page/config/${encodeURIComponent(row.org)}/sites/${encodeURIComponent(row.site)}.json" target="_blank" rel="noopener" class="detail-config-link">config JSON</a>`
+    : `<a href="https://admin.hlx.page/config/${encodeURIComponent(row.org)}/sites/${encodeURIComponent(row.site)}.json" target="_blank" rel="noopener" class="detail-config-link">config JSON</a>`;
+
+  const featuresJson = formatJson(row.features);
+  const limitsJson = formatJson(row.limits);
+
+  els.detailBody.innerHTML = `
+    <div class="detail-group">
+      <div class="detail-group-title">CDN</div>
+      <div class="detail-rows">
+        ${detailRow('Prod host', row.cdn_prod_host)}
+        ${detailRow('Prod type', row.cdn_prod_type)}
+      </div>
+    </div>
+    <div class="detail-group">
+      <div class="detail-group-title">Code Source</div>
+      <div class="detail-rows">
+        ${detailRow('Owner', row.code_owner)}
+        ${detailRow('Repo', row.code_repo)}
+        ${detailRow('Source type', row.code_source_type)}
+        ${detailRow('Source URL', row.code_source_url)}
+      </div>
+    </div>
+    <div class="detail-group">
+      <div class="detail-group-title">Content Source</div>
+      <div class="detail-rows">
+        ${detailRow('Content bus ID', row.content_bus_id || '')}
+        ${detailRow('Source type', row.content_source_type)}
+        ${detailRow('Source URL', row.content_source_url)}
+        ${detailRow('Overlay type', row.content_source_overlay_type)}
+        ${detailRow('Overlay URL', row.content_source_overlay_url)}
+      </div>
+    </div>
+    <div class="detail-group">
+      <div class="detail-group-title">Config</div>
+      <div class="detail-rows">
+        ${detailRow('Profile', row.profile)}
+        ${detailRow('Folders', row.folders === '1' || row.folders === true ? 'Yes' : 'No')}
+        ${detailRow('Version', row.version)}
+        ${detailRow('Created', row.created_date)}
+        ${detailRow('Last modified', row.last_modified_date)}
+      </div>
+    </div>
+    ${featuresJson ? `
+    <div class="detail-group">
+      <div class="detail-group-title">Features</div>
+      <pre class="detail-json">${escapeHtml(featuresJson)}</pre>
+    </div>` : ''}
+    ${limitsJson ? `
+    <div class="detail-group">
+      <div class="detail-group-title">Limits</div>
+      <pre class="detail-json">${escapeHtml(limitsJson)}</pre>
+    </div>` : ''}
+  `;
+
+  els.configDetail.showModal();
+}
+
+async function loadData(refresh = false) {
+  els.loadingState.style.display = '';
+  els.errorState.classList.remove('visible');
+  els.tableContainer.style.display = 'none';
+  els.statsSection.style.display = 'none';
+
+  try {
+    setForceRefresh(refresh);
+    const [sqlStats, sqlByType, sqlByContentType, sqlList] = await Promise.all([
+      loadSql('configs-stats', { database: DATABASE }),
+      loadSql('configs-by-type', { database: DATABASE }),
+      loadSql('configs-by-content-type', { database: DATABASE }),
+      loadSql('configs-list', { database: DATABASE }),
+    ]);
+
+    const start = performance.now();
+    const [statsResult, typeResult, contentTypeResult, listResult] = await Promise.all([
+      query(sqlStats, { cacheTtl: 300 }),
+      query(sqlByType, { cacheTtl: 300 }),
+      query(sqlByContentType, { cacheTtl: 300 }),
+      query(sqlList, { cacheTtl: 300 }),
+    ]);
+    const elapsed = performance.now() - start;
+    setForceRefresh(false);
+
+    s.rows = listResult.data;
+    s.currentPage = 1;
+
+    els.queryTimer.textContent = `(${formatQueryTime(elapsed)})`;
+    renderStats(statsResult.data[0] || {}, s.rows.length);
+    s.typeRowsData = typeResult.data || [];
+    renderFacetBreakdown(els.typeBody, s.typeRowsData, s.cdnTypeFilter);
+    s.contentTypeRowsData = contentTypeResult.data || [];
+    renderFacetBreakdown(els.contentTypeBody, s.contentTypeRowsData, s.contentTypeFilter);
+    els.statsSection.style.display = '';
+    els.loadingState.style.display = 'none';
+    els.tableContainer.style.display = '';
+    renderTable();
+  } catch (err) {
+    setForceRefresh(false);
+    els.loadingState.style.display = 'none';
+    els.errorState.textContent = `Failed to load: ${err.message}`;
+    els.errorState.classList.add('visible');
+  }
+}
+
+// Sort on column header click
+document.querySelectorAll('.configs-table th.sortable').forEach((th) => {
+  th.addEventListener('click', () => {
+    const { col } = th.dataset;
+    if (s.sortCol === col) {
+      s.sortAsc = !s.sortAsc;
+    } else {
+      s.sortCol = col;
+      s.sortAsc = true;
+    }
+    s.currentPage = 1;
+    renderTable();
+  });
+});
+
+// Search filtering — reset to page 1
+els.searchInput.addEventListener('input', () => {
+  s.currentPage = 1;
+  renderTable();
+});
+
+// Stat chips — toggle presence filter; "Total sites" / "Clear filters" clears all
+els.statsChips.addEventListener('click', (e) => {
+  const chip = e.target.closest('.stat-chip');
+  if (!chip) { return; }
+  if (chip.dataset.clear) {
+    Object.keys(s.chipFilters).forEach((k) => { s.chipFilters[k] = false; });
+  } else if (chip.dataset.key) {
+    s.chipFilters[chip.dataset.key] = !s.chipFilters[chip.dataset.key];
+  }
+  s.currentPage = 1;
+  renderStats(s.statsData, s.rows.length);
+  renderTable();
+});
+
+// CDN type facet — click to filter, click again to clear
+document.getElementById('typeTable').addEventListener('click', (e) => {
+  const tr = e.target.closest('tr.type-row');
+  if (!tr) { return; }
+  s.cdnTypeFilter = s.cdnTypeFilter === tr.dataset.type ? null : tr.dataset.type;
+  s.currentPage = 1;
+  renderFacetBreakdown(els.typeBody, s.typeRowsData, s.cdnTypeFilter);
+  renderTable();
+});
+
+// Content source type facet — click to filter, click again to clear
+document.getElementById('contentTypeTable').addEventListener('click', (e) => {
+  const tr = e.target.closest('tr.type-row');
+  if (!tr) { return; }
+  s.contentTypeFilter = s.contentTypeFilter === tr.dataset.type ? null : tr.dataset.type;
+  s.currentPage = 1;
+  renderFacetBreakdown(els.contentTypeBody, s.contentTypeRowsData, s.contentTypeFilter);
+  renderTable();
+});
+
+// Pagination
+els.prevBtn.addEventListener('click', () => {
+  if (s.currentPage > 1) {
+    s.currentPage -= 1;
+    renderTable();
+    els.tableContainer.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+});
+
+els.nextBtn.addEventListener('click', () => {
+  s.currentPage += 1;
+  renderTable();
+  els.tableContainer.scrollIntoView({ behavior: 'smooth', block: 'start' });
+});
+
+// Row click → detail dialog
+els.configsBody.addEventListener('click', (e) => {
+  const tr = e.target.closest('tr');
+  if (!tr) { return; }
+  const { org, site } = tr.dataset;
+  const row = s.rows.find((r) => r.org === org && r.site === site);
+  if (row) { showDetail(row); }
+});
+
+// Close detail dialog
+document.getElementById('detailClose').addEventListener('click', () => {
+  els.configDetail.close();
+});
+
+els.configDetail.addEventListener('click', (e) => {
+  if (e.target === els.configDetail) { els.configDetail.close(); }
+});
+
+// Kebab menu
+const moreMenu = document.getElementById('moreMenu');
+const moreBtn = document.getElementById('moreBtn');
+
+moreBtn.addEventListener('click', () => {
+  if (moreMenu.open) {
+    moreMenu.close();
+    return;
+  }
+  const rect = moreBtn.getBoundingClientRect();
+  moreMenu.style.top = `${rect.bottom + 4}px`;
+  moreMenu.style.right = `${document.documentElement.clientWidth - rect.right}px`;
+  moreMenu.style.left = 'auto';
+  moreMenu.show();
+});
+
+document.addEventListener('click', (e) => {
+  if (moreMenu.open && !moreMenu.contains(e.target) && !moreBtn.contains(e.target)) {
+    moreMenu.close();
+  }
+});
+
+document.getElementById('refreshBtn').addEventListener('click', () => {
+  moreMenu.close();
+  loadData(true);
+});
+
+document.getElementById('logoutBtn').addEventListener('click', () => {
+  moreMenu.close();
+  handleLogout();
+});
+
+// Wire up auth module
+setElements({
+  loginSection: els.loginSection,
+  dashboardSection: els.dashboardSection,
+  loginError: els.loginError,
+});
+
+document.getElementById('loginForm').addEventListener('submit', handleLogin);
+
+window.addEventListener('login-success', () => {
+  showDashboard();
+  loadData();
+});
+
+const stored = loadStoredCredentials();
+if (stored) {
+  state.credentials = stored;
+  query('SELECT 1').then(() => {
+    showDashboard();
+    loadData();
+  }).catch(() => {
+    showLogin();
+  });
+} else {
+  showLogin();
+}

--- a/scripts/grant-config-tables.mjs
+++ b/scripts/grant-config-tables.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/**
+ * Grant SELECT on site_configs, profile_configs, org_configs to all *_adobe_com users.
+ * Usage: node grant-config-tables.mjs <admin-user> <admin-password>
+ */
+
+const CLICKHOUSE_HOST = 's2p5b8wmt5.eastus2.azure.clickhouse.cloud';
+const CLICKHOUSE_PORT = 8443;
+const DATABASE = 'helix_logs_production';
+const CONFIG_TABLES = ['site_configs', 'profile_configs', 'org_configs'];
+
+async function runQuery(sql, adminUser, adminPassword) {
+  const url = `https://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${adminUser}:${adminPassword}`).toString('base64')}`,
+      'Content-Type': 'text/plain',
+    },
+    body: sql,
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(text.trim());
+  }
+  return text;
+}
+
+async function main() {
+  const [,, adminUser, adminPassword] = process.argv;
+  if (!adminUser || !adminPassword) {
+    console.error('Usage: node grant-config-tables.mjs <admin-user> <admin-password>');
+    process.exit(1);
+  }
+
+  const listSql = "SELECT name FROM system.users WHERE endsWith(name, '_adobe_com') FORMAT TSV";
+  const result = await runQuery(listSql, adminUser, adminPassword);
+  const users = result.trim().split('\n').filter(Boolean);
+
+  if (users.length === 0) {
+    console.log('No *_adobe_com users found.');
+    return;
+  }
+
+  console.log(`Found ${users.length} user(s): ${users.join(', ')}\n`);
+
+  for (const user of users) {
+    for (const table of CONFIG_TABLES) {
+      const grantSql = `GRANT SELECT ON ${DATABASE}.${table} TO ${user}`;
+      // eslint-disable-next-line no-await-in-loop -- Sequential grants to avoid race conditions
+      await runQuery(grantSql, adminUser, adminPassword);
+      console.log(`  GRANT SELECT ON ${table} TO ${user}`);
+    }
+    console.log();
+  }
+
+  console.log('Done.');
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/sql/queries/configs-by-content-type.sql
+++ b/sql/queries/configs-by-content-type.sql
@@ -1,0 +1,6 @@
+SELECT
+  if(content_source_type = '', '(none)', content_source_type) AS type,
+  count() AS cnt
+FROM {{database}}.site_configs FINAL
+GROUP BY type
+ORDER BY cnt DESC

--- a/sql/queries/configs-by-type.sql
+++ b/sql/queries/configs-by-type.sql
@@ -1,0 +1,6 @@
+SELECT
+  if(cdn_prod_type = '', '(none)', cdn_prod_type) AS type,
+  count() AS cnt
+FROM {{database}}.site_configs FINAL
+GROUP BY type
+ORDER BY cnt DESC

--- a/sql/queries/configs-list.sql
+++ b/sql/queries/configs-list.sql
@@ -1,0 +1,22 @@
+SELECT
+  org,
+  site,
+  version,
+  formatDateTime(toDateTime(created), '%Y-%m-%d') AS created_date,
+  cdn_prod_host,
+  cdn_prod_type,
+  code_owner,
+  code_repo,
+  code_source_type,
+  content_bus_id,
+  content_source_type,
+  content_source_url,
+  content_source_overlay_type,
+  content_source_overlay_url,
+  profile,
+  folders,
+  features,
+  limits,
+  formatDateTime(toDateTime(last_modified), '%Y-%m-%d') AS last_modified_date
+FROM {{database}}.site_configs FINAL
+ORDER BY org, site

--- a/sql/queries/configs-stats.sql
+++ b/sql/queries/configs-stats.sql
@@ -1,0 +1,7 @@
+SELECT
+  count()                        AS total,
+  countIf(cdn_prod_host != '')   AS with_cdn_host,
+  countIf(cdn_prod_type != '')   AS with_cdn_type,
+  countIf(folders)               AS with_folders,
+  countIf(profile != '')         AS with_profile
+FROM {{database}}.site_configs FINAL


### PR DESCRIPTION
Browse and search Helix site configurations from site_configs table.
Stats chips (total, CDN host, CDN type, folders, profile) act as toggle
filters; CDN type and content source type facet breakdowns let users
drill down by category. Full-text search, sortable table, pagination
(200 rows/page), and a detail dialog with config JSON link.

Also fixes summarizeErrorText in api.js to handle JSON-formatted error
responses from ClickHouse Cloud, and adds grant-config-tables.mjs to
backfill SELECT grants on the three config tables for existing users.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
