### PR TITLE
feat: improve config detail view and lambda log UX

### DIFF
--- a/configs.html
+++ b/configs.html
@@ -123,6 +123,7 @@
                 <th data-col="content_source_type" class="sortable" aria-sort="none"><button type="button">Content Source</button></th>
                 <th data-col="profile" class="sortable" aria-sort="none"><button type="button">Profile</button></th>
                 <th data-col="last_modified_date" class="sortable" aria-sort="none"><button type="button">Modified</button></th>
+                <th data-col="created_date" class="sortable" aria-sort="none"><button type="button">Created</button></th>
               </tr>
             </thead>
             <tbody id="configsBody"></tbody>

--- a/css/configs.css
+++ b/css/configs.css
@@ -368,10 +368,12 @@ html {
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 0;
-  width: min(640px, 95vw);
+  width: min(900px, 95vw);
+  min-width: 700px;
   max-height: 80vh;
   overflow: hidden;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  margin: auto;
 }
 
 .config-detail-dialog[open] {
@@ -450,7 +452,7 @@ html {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--text-secondary);
+  color: var(--text);
   margin: 0 0 6px;
 }
 
@@ -490,6 +492,36 @@ html {
   color: var(--host-authoring);
   vertical-align: middle;
   white-space: nowrap;
+}
+
+.copy-btn {
+  all: unset;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  padding: 1px 5px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  vertical-align: middle;
+  line-height: 1.6;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.copy-btn:hover {
+  color: var(--text);
+  border-color: var(--text-secondary);
+  background: var(--bg);
+}
+
+.copy-btn.copied {
+  color: var(--host-delivery);
+  border-color: var(--host-delivery);
 }
 
 .detail-json {

--- a/css/modals.css
+++ b/css/modals.css
@@ -365,6 +365,31 @@
   margin-bottom: 12px;
 }
 
+.detail-filter-btn {
+  all: unset;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  padding: 1px 5px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  vertical-align: middle;
+  line-height: 1.6;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.detail-filter-btn:hover {
+  color: var(--text);
+  border-color: var(--text-secondary);
+  background: var(--bg);
+}
+
 /* More Actions Dropdown Menu */
 #moreMenu {
   padding: 4px;

--- a/js/configs-main.js
+++ b/js/configs-main.js
@@ -213,6 +213,7 @@ function renderTable() {
       <td class="source-type-cell">${escapeHtml(row.content_source_type || '—')}</td>
       <td class="profile-cell">${escapeHtml(row.profile || '—')}</td>
       <td class="date-cell">${escapeHtml(row.last_modified_date || '—')}</td>
+      <td class="date-cell">${escapeHtml(row.created_date || '—')}</td>
     </tr>`;
   }).join('');
 
@@ -270,6 +271,14 @@ function formatJson(raw) {
   }
 }
 
+function detailRowResolvedWithCopy(label, rawVal, resolvedVal, profileSrc) {
+  const isEmpty = resolvedVal === null || resolvedVal === undefined || resolvedVal === '';
+  const display = isEmpty ? '—' : escapeHtml(String(resolvedVal));
+  const btn = isEmpty ? '' : ` <button type="button" class="copy-btn" data-copy="${escapeHtml(String(resolvedVal))}" title="Copy to clipboard">copy</button>`;
+  return `<div class="detail-label">${escapeHtml(label)}</div>
+          <div class="detail-value${isEmpty ? ' empty' : ''}" style="white-space: nowrap">${display}${profileBadge(rawVal, resolvedVal, profileSrc)}${btn}</div>`;
+}
+
 function detailRow(label, value) {
   const isEmpty = value === null || value === undefined || value === '';
   const display = isEmpty ? '—' : escapeHtml(String(value));
@@ -281,6 +290,12 @@ function foldersLabel(v) {
   return (v === 1 || v === true || v === '1') ? 'Yes' : 'No';
 }
 
+function jsonBadge(json, rawJson, profileSrc) {
+  return (json && json !== rawJson)
+    ? ` <span class="profile-badge" title="merged with profile">&#8593;&nbsp;${escapeHtml(profileSrc)}</span>`
+    : '';
+}
+
 function showDetail(row) {
   const key = `${row.org}/${row.site}`;
   // res = the resolved (effective) row; rawRow = the raw site-only row
@@ -289,22 +304,25 @@ function showDetail(row) {
   const profileSrc = row.profile || 'default';
   const dr = (label, field) => detailRowResolved(label, rawRow[field], res[field], profileSrc);
 
-  const configLink = `<a href="https://admin.hlx.page/config/${encodeURIComponent(row.org)}/sites/${encodeURIComponent(row.site)}.json" target="_blank" rel="noopener" class="detail-config-link">config JSON</a>`;
+  const configLink = `<a href="https://admin.hlx.page/config/${encodeURIComponent(row.org)}/sites/${encodeURIComponent(row.site)}.json" target="_blank" rel="noopener" class="detail-config-link">config</a>`;
+  const previewLink = `<a href="https://main--${encodeURIComponent(row.site)}--${encodeURIComponent(row.org)}.aem.page/" target="_blank" rel="noopener" class="detail-config-link">preview</a>`;
+  const s3Link = res.content_bus_id
+    ? ` &mdash; <a href="https://us-east-1.console.aws.amazon.com/s3/buckets/helix-content-bus?prefix=${encodeURIComponent(res.content_bus_id)}/" target="_blank" rel="noopener" class="detail-config-link">content bus</a>`
+    : '';
+  const codeBusLink = (res.code_owner && res.code_repo)
+    ? ` &mdash; <a href="https://us-east-1.console.aws.amazon.com/s3/buckets/helix-code-bus?prefix=${encodeURIComponent(res.code_owner)}/${encodeURIComponent(res.code_repo)}" target="_blank" rel="noopener" class="detail-config-link">code bus</a>`
+    : '';
   els.detailTitle.textContent = `${row.org} / ${row.site}`;
   els.detailSubtitle.innerHTML = res.cdn_prod_host
-    ? `${escapeHtml(res.cdn_prod_host)} &mdash; ${configLink}`
-    : configLink;
+    ? `${escapeHtml(res.cdn_prod_host)} &mdash; ${configLink} &mdash; ${previewLink}${s3Link}${codeBusLink}`
+    : `${configLink} &mdash; ${previewLink}${s3Link}${codeBusLink}`;
 
   const featuresJson = formatJson(res.features);
   const rawFeaturesJson = formatJson(rawRow.features);
   const limitsJson = formatJson(res.limits);
   const rawLimitsJson = formatJson(rawRow.limits);
-  const featuresBadge = featuresJson && featuresJson !== rawFeaturesJson
-    ? ` <span class="profile-badge" title="merged with profile">&#8593;&nbsp;${escapeHtml(profileSrc)}</span>`
-    : '';
-  const limitsBadge = limitsJson && limitsJson !== rawLimitsJson
-    ? ` <span class="profile-badge" title="merged with profile">&#8593;&nbsp;${escapeHtml(profileSrc)}</span>`
-    : '';
+  const featuresBadge = jsonBadge(featuresJson, rawFeaturesJson, profileSrc);
+  const limitsBadge = jsonBadge(limitsJson, rawLimitsJson, profileSrc);
 
   els.detailBody.innerHTML = `
     <div class="detail-group">
@@ -326,7 +344,7 @@ function showDetail(row) {
     <div class="detail-group">
       <div class="detail-group-title">Content Source</div>
       <div class="detail-rows">
-        ${detailRowResolved('Content bus ID', rawRow.content_bus_id, res.content_bus_id, profileSrc)}
+        ${detailRowResolvedWithCopy('Content bus ID', rawRow.content_bus_id, res.content_bus_id, profileSrc)}
         ${dr('Source type', 'content_source_type')}
         ${dr('Source URL', 'content_source_url')}
         ${dr('Overlay type', 'content_source_overlay_type')}
@@ -513,6 +531,20 @@ els.configsBody.addEventListener('click', (e) => {
   const { org, site } = tr.dataset;
   const row = s.rows.find((r) => r.org === org && r.site === site);
   if (row) { showDetail(row); }
+});
+
+// Copy-to-clipboard buttons inside detail dialog
+els.detailBody.addEventListener('click', (e) => {
+  const btn = e.target.closest('.copy-btn');
+  if (!btn) { return; }
+  navigator.clipboard.writeText(btn.dataset.copy).then(() => {
+    btn.textContent = '✓';
+    btn.classList.add('copied');
+    setTimeout(() => {
+      btn.textContent = 'copy';
+      btn.classList.remove('copied');
+    }, 1500);
+  });
 });
 
 // Close detail dialog

--- a/js/logs.js
+++ b/js/logs.js
@@ -246,9 +246,12 @@ function renderLogDetailContent(row) {
         const value = row[col];
         const { html: valueHtml, className } = formatDetailValue(col, value);
         const displayCol = col.includes('.') ? col.split('.').slice(1).join('.') : col;
+        const filterBtn = (col === 'request_id' && value)
+          ? ` <button type="button" class="detail-filter-btn" data-action="search-by-request-id" data-value="${escapeHtml(String(value))}" title="Search by this request ID">search</button>`
+          : '';
         html += `<tr>
         <th title="${escapeHtml(col)}">${escapeHtml(displayCol)}</th>
-        <td class="${className}">${valueHtml}</td>
+        <td class="${className}">${valueHtml}${filterBtn}</td>
       </tr>`;
       }
 
@@ -299,6 +302,18 @@ export function openLogDetailModal(rowIdx) {
     if (closeBtn) {
       closeBtn.addEventListener('click', closeLogDetailModal);
     }
+
+    // Search-by-request-id button handler
+    logDetailModal.addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-action="search-by-request-id"]');
+      if (!btn) { return; }
+      const searchInput = document.getElementById('searchFilter');
+      if (searchInput) {
+        searchInput.value = btn.dataset.value;
+        searchInput.dispatchEvent(new Event('change'));
+      }
+      closeLogDetailModal();
+    });
   }
 
   renderLogDetailContent(row);


### PR DESCRIPTION
## Summary

**Config detail dialog**
- Added a **copy** button inline on the `contentBusId` value (copies to clipboard, briefly shows ✓)
- Added `white-space: nowrap` on `contentBusId` so it never wraps mid-value
- Added **preview** link (`https://main--{site}--{org}.aem.page/`) in the subtitle
- Added **content bus** S3 link (shown when `contentBusId` is set)
- Added **code bus** S3 link (shown when `codeOwner` + `codeRepo` are set)
- Renamed "config JSON" link to "config"
- Widened dialog to `min-width: 700px` (up from max 640px) and made it always centered
- Made detail group titles brighter (`var(--text)` instead of `var(--text-secondary)`)

**Config list table**
- Added a sortable **Created** date column as the last column

**Lambda log detail**
- Added a **search** button on the `request_id` row; clicking it populates `#searchFilter` with the request ID, closes the modal, and triggers a dashboard reload filtered to that invocation

## Testing Done

- `npm test` — 904 tests passed, 0 failed (92.98% coverage)
- `npm run lint` — no errors
- Manually verified config detail dialog links, copy button, and layout
- Manually verified lambda log detail search button flow

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)