### PR TITLE
feat: normalize code_source_type to github/byogit and add config breakdown

### DIFF
--- a/configs.html
+++ b/configs.html
@@ -102,6 +102,12 @@
             <tbody id="contentTypeBody"></tbody>
           </table>
         </div>
+        <div class="type-breakdown">
+          <h3>Code Source</h3>
+          <table class="type-table" id="codeSourceTypeTable">
+            <tbody id="codeSourceTypeBody"></tbody>
+          </table>
+        </div>
       </section>
 
       <!-- Site configs table -->

--- a/js/configs-main.js
+++ b/js/configs-main.js
@@ -28,6 +28,7 @@ const s = {
   rawMap: new Map(),
   typeRowsData: [],
   contentTypeRowsData: [],
+  codeSourceTypeRowsData: [],
   statsData: {},
   // chip (boolean presence) filters
   chipFilters: {
@@ -38,6 +39,7 @@ const s = {
   currentPage: 1,
   cdnTypeFilter: null,
   contentTypeFilter: null,
+  codeSourceTypeFilter: null,
   resolvedView: false,
 };
 
@@ -57,6 +59,7 @@ const els = {
   statsChips: document.getElementById('statsChips'),
   typeBody: document.getElementById('typeBody'),
   contentTypeBody: document.getElementById('contentTypeBody'),
+  codeSourceTypeBody: document.getElementById('codeSourceTypeBody'),
   pagination: document.getElementById('pagination'),
   pageInfo: document.getElementById('pageInfo'),
   prevBtn: document.getElementById('prevBtn'),
@@ -161,6 +164,10 @@ function matchesFacets(row) {
   if (s.contentTypeFilter) {
     const want = s.contentTypeFilter === '(none)' ? '' : s.contentTypeFilter;
     if (row.content_source_type !== want) { return false; }
+  }
+  if (s.codeSourceTypeFilter) {
+    const want = s.codeSourceTypeFilter === '(none)' ? '' : s.codeSourceTypeFilter;
+    if (row.code_source_type !== want) { return false; }
   }
   return true;
 }
@@ -388,20 +395,23 @@ async function loadData(refresh = false) {
     const compareSource = s.resolvedView ? 'site_configs FINAL' : 'site_configs_resolved';
     const params = { database: DATABASE, source };
     const compareParams = { database: DATABASE, source: compareSource };
-    const [sqlStats, sqlByType, sqlByContentType, sqlList, sqlCompare] = await Promise.all([
+    // eslint-disable-next-line max-len
+    const [sqlStats, sqlByType, sqlByContentType, sqlByCodeSourceType, sqlList, sqlCompare] = await Promise.all([
       loadSql('configs-stats', params),
       loadSql('configs-by-type', params),
       loadSql('configs-by-content-type', params),
+      loadSql('configs-by-code-source-type', params),
       loadSql('configs-list', params),
       loadSql('configs-resolved-list', compareParams),
     ]);
 
     const start = performance.now();
     // eslint-disable-next-line max-len
-    const [statsResult, typeResult, contentTypeResult, listResult, compareResult] = await Promise.all([
+    const [statsResult, typeResult, contentTypeResult, codeSourceTypeResult, listResult, compareResult] = await Promise.all([
       query(sqlStats, { cacheTtl: 300 }),
       query(sqlByType, { cacheTtl: 300 }),
       query(sqlByContentType, { cacheTtl: 300 }),
+      query(sqlByCodeSourceType, { cacheTtl: 300 }),
       query(sqlList, { cacheTtl: 300 }),
       query(sqlCompare, { cacheTtl: 300 }),
     ]);
@@ -420,6 +430,8 @@ async function loadData(refresh = false) {
     renderFacetBreakdown(els.typeBody, s.typeRowsData, s.cdnTypeFilter);
     s.contentTypeRowsData = contentTypeResult.data || [];
     renderFacetBreakdown(els.contentTypeBody, s.contentTypeRowsData, s.contentTypeFilter);
+    s.codeSourceTypeRowsData = codeSourceTypeResult.data || [];
+    renderFacetBreakdown(els.codeSourceTypeBody, s.codeSourceTypeRowsData, s.codeSourceTypeFilter);
     els.statsSection.style.display = '';
     els.loadingState.style.display = 'none';
     els.tableContainer.style.display = '';
@@ -506,6 +518,16 @@ document.getElementById('contentTypeTable').addEventListener('click', (e) => {
   s.contentTypeFilter = s.contentTypeFilter === tr.dataset.type ? null : tr.dataset.type;
   s.currentPage = 1;
   renderFacetBreakdown(els.contentTypeBody, s.contentTypeRowsData, s.contentTypeFilter);
+  renderTable();
+});
+
+// Code source type facet — click to filter, click again to clear
+document.getElementById('codeSourceTypeTable').addEventListener('click', (e) => {
+  const tr = e.target.closest('tr.type-row');
+  if (!tr) { return; }
+  s.codeSourceTypeFilter = s.codeSourceTypeFilter === tr.dataset.type ? null : tr.dataset.type;
+  s.currentPage = 1;
+  renderFacetBreakdown(els.codeSourceTypeBody, s.codeSourceTypeRowsData, s.codeSourceTypeFilter);
   renderTable();
 });
 

--- a/scripts/import-helix-configs.mjs
+++ b/scripts/import-helix-configs.mjs
@@ -89,6 +89,18 @@ function resolveContentType(url, fallback) {
   return fallback;
 }
 
+function resolveCodeSourceType(codeSource) {
+  const url = str(codeSource.url);
+  if (!url) { return str(codeSource.type); }
+  try {
+    const { hostname } = new URL(url);
+    if (hostname === 'github.com' || hostname === 'www.github.com') { return 'github'; }
+    return 'byogit';
+  } catch {
+    return str(codeSource.type);
+  }
+}
+
 function siteRow(org, site, data) {
   const code = data.code || {};
   const codeSource = code.source || {};
@@ -107,7 +119,7 @@ function siteRow(org, site, data) {
     last_modified: ts(data.lastModified),
     code_owner: str(code.owner),
     code_repo: str(code.repo),
-    code_source_type: str(codeSource.url) === 'https://cm-repo.adobe.io/api' ? 'byogit' : str(codeSource.type),
+    code_source_type: resolveCodeSourceType(codeSource),
     code_source_url: str(codeSource.url),
     content_bus_id: str(content.contentBusId),
     content_source_type: resolveContentType(contentSourceUrl, str(contentSource.type)),
@@ -140,7 +152,7 @@ function profileRow(org, profile, data) {
     last_modified: ts(data.lastModified),
     code_owner: str(code.owner),
     code_repo: str(code.repo),
-    code_source_type: str(codeSource.url) === 'https://cm-repo.adobe.io/api' ? 'byogit' : str(codeSource.type),
+    code_source_type: resolveCodeSourceType(codeSource),
     code_source_url: str(codeSource.url),
     content_bus_id: str(content.contentBusId),
     content_source_type: resolveContentType(contentSourceUrl, str(contentSource.type)),

--- a/sql/migrations/backfill_code_source_type.sql
+++ b/sql/migrations/backfill_code_source_type.sql
@@ -1,0 +1,17 @@
+-- Backfill code_source_type for site_configs and profile_configs.
+-- Sets 'github' for github.com/www.github.com URLs, 'byogit' for all other non-empty URLs.
+-- Rows with no code_source_url are left unchanged.
+
+ALTER TABLE helix_logs_production.site_configs
+UPDATE code_source_type = multiIf(
+    domain(code_source_url) IN ('github.com', 'www.github.com'), 'github',
+    'byogit'
+)
+WHERE code_source_url != '';
+
+ALTER TABLE helix_logs_production.profile_configs
+UPDATE code_source_type = multiIf(
+    domain(code_source_url) IN ('github.com', 'www.github.com'), 'github',
+    'byogit'
+)
+WHERE code_source_url != '';

--- a/sql/queries/configs-by-code-source-type.sql
+++ b/sql/queries/configs-by-code-source-type.sql
@@ -1,0 +1,6 @@
+SELECT
+  if(code_source_type = '', '(none)', code_source_type) AS type,
+  count() AS cnt
+FROM {{database}}.{{source}}
+GROUP BY type
+ORDER BY cnt DESC


### PR DESCRIPTION
## Summary

- **Import normalization**: `resolveCodeSourceType()` helper replaces the narrow hard-coded check for `cm-repo.adobe.io`. Now any `code.source.url` with hostname `github.com` or `www.github.com` → `'github'`; any other hostname → `'byogit'`; no URL → falls back to the raw `code.source.type`. Applied to both `siteRow()` and `profileRow()` in `scripts/import-helix-configs.mjs`.
- **Backfill migration**: `sql/migrations/backfill_code_source_type.sql` — two `ALTER TABLE … UPDATE` mutations to fix existing `site_configs` and `profile_configs` rows without a full re-import.
- **Config page breakdown**: New "Code Source" facet panel on `configs.html`, backed by `sql/queries/configs-by-code-source-type.sql`. Follows the exact same pattern as the existing CDN Type and Content Source breakdowns — clickable rows filter the config table, click again to clear.
- **Related**: filed [helix-s3-config-listener#5](https://github.com/adobe/helix-s3-config-listener/issues/5) to apply the same normalization to live config-bus updates.

## Testing Done

- [x] 904 unit tests pass (`npm test`, 92.98% coverage)
- [x] Lint passes (`npm run lint`)
- [x] Verified `resolveCodeSourceType` logic handles github.com, www.github.com, cm-repo.adobe.io, missing URL, and invalid URL cases

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)