### PR TITLE
Add DA Worker Logs dashboard with ray_id resolution

### DIFF
--- a/css/modals.css
+++ b/css/modals.css
@@ -365,6 +365,33 @@
   margin-bottom: 12px;
 }
 
+/* Ray ID resolution result (nested inside .log-detail-table, so widths/padding
+   need to be reset rather than inherited from the outer key/value layout). */
+.ray-id-result-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 4px;
+}
+
+.ray-id-result-table th,
+.ray-id-result-table td {
+  width: auto;
+  padding: 4px 8px;
+  text-align: left;
+  white-space: nowrap;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+}
+
+.ray-id-result-table th {
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.ray-id-result-table tr:last-child td {
+  border-bottom: none;
+}
+
 .detail-filter-btn {
   all: unset;
   cursor: pointer;

--- a/da-workers.html
+++ b/da-workers.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DA Worker Logs - CDN Analytics</title>
+  <script>
+    window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
+  </script>
+  <script defer type="text/javascript" src="https://ot.aem.live/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
+  <link rel="canonical" href="https://klickhaus.aemstatus.net/da-workers.html">
+
+  <!-- Favicon Icons -->
+  <link rel="apple-touch-icon" href="/icons/icon-180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/icon-32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png">
+
+  <link rel="stylesheet" href="dashboard.css">
+</head>
+<body>
+  <!-- Login Form -->
+  <div id="login">
+    <div class="login-card">
+      <h1>DA Worker Logs</h1>
+      <p>Sign in to view DA worker log analytics</p>
+      <div id="loginError" class="error-message"></div>
+      <form id="loginForm" method="post" action="">
+        <div class="form-group">
+          <label for="username">Email or username</label>
+          <input type="text" id="username" name="username" required autocomplete="username email" inputmode="email">
+        </div>
+        <div class="form-group">
+          <label for="password">Password</label>
+          <input type="password" id="password" name="password" required autocomplete="current-password">
+        </div>
+        <div class="form-group form-option">
+          <label class="checkbox-label">
+            <input type="checkbox" id="forgetMe" name="forgetMe">
+            Forget me on this device
+          </label>
+        </div>
+        <button type="submit" class="btn btn-primary">Sign In</button>
+      </form>
+    </div>
+  </div>
+
+  <!-- Dashboard -->
+  <div id="dashboard">
+    <header>
+      <div class="header-left">
+        <button id="menuBtn" class="menu-btn" title="Quick Links">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <rect y="3" width="20" height="2" rx="1"/>
+            <rect y="9" width="20" height="2" rx="1"/>
+            <rect y="15" width="20" height="2" rx="1"/>
+          </svg>
+        </button>
+        <h1><span id="dashboardTitle">DA Worker Logs</span> <span id="totalCount" class="total-count"></span> <span id="queryTimer" class="query-timer"></span></h1>
+        <div id="activeFilters"></div>
+      </div>
+      <div class="header-right">
+        <span class="kbd-control"><kbd class="kbd-hint" id="timeRangeHint">2</kbd><select id="timeRange"></select></span>
+        <select id="topN"></select>
+        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by worker..." list="hostSuggestions" autocomplete="off"></span>
+        <datalist id="hostSuggestions"></datalist>
+        <input type="text" id="searchFilter" placeholder="Ray ID or URL..." autocomplete="off">
+        <span class="kbd-control">
+          <kbd class="kbd-hint">t</kbd>
+          <button id="viewCycleBtn" class="menu-btn" title="Switch to Logs view">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="1" y="1" width="14" height="14" rx="2"/>
+              <line x1="4" y1="5" x2="12" y2="5"/>
+              <line x1="4" y1="8" x2="12" y2="8"/>
+              <line x1="4" y1="11" x2="9" y2="11"/>
+            </svg>
+          </button>
+        </span>
+        <button id="refreshBtn" class="menu-btn" title="Refresh">
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M15 9A6 6 0 1 0 13.2 13.2"/>
+            <polyline points="15,5 15,9 11,9"/>
+          </svg>
+        </button>
+        <button id="manageColumnsBtn" class="menu-btn" title="Manage Columns">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="2" width="3" height="12"/>
+            <rect x="6.5" y="2" width="3" height="12"/>
+            <rect x="11" y="2" width="3" height="12"/>
+          </svg>
+        </button>
+        <button id="themeBtn" class="menu-btn" title="Theme: Device">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="2" width="14" height="10" rx="1.5"/><line x1="5" y1="15" x2="11" y2="15"/><line x1="8" y1="12" x2="8" y2="15"/></svg>
+        </button>
+        <button id="logoutBtn" class="menu-btn" title="Logout">
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M7 3H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h3"/>
+            <polyline points="11,6 15,9 11,12"/>
+            <line x1="15" y1="9" x2="7" y2="9"/>
+          </svg>
+        </button>
+        <button id="moreBtn" class="menu-btn" title="More actions">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <circle cx="10" cy="4" r="1.5"/>
+            <circle cx="10" cy="10" r="1.5"/>
+            <circle cx="10" cy="16" r="1.5"/>
+          </svg>
+        </button>
+      </div>
+    </header>
+
+    <main id="dashboardContent">
+      <!-- Time Series Chart -->
+      <section class="chart-section">
+        <h2>Events over time</h2>
+        <div class="chart-container">
+          <canvas id="chart"></canvas>
+        </div>
+      </section>
+
+
+      <div id="contentArea">
+      <!-- Filters View (Breakdowns) -->
+      <div id="filtersView" class="visible">
+        <!-- Breakdown Tables -->
+        <section class="breakdowns breakdowns-pinned" id="breakdowns-pinned"></section>
+        <section class="breakdowns" id="breakdowns">
+        <div class="breakdown-card" id="breakdown-outcome">
+          <h3>Outcome</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-status">
+          <h3>Status</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-script-name">
+          <h3>Worker</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-method">
+          <h3>Method</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-url">
+          <h3>URL</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-script-version">
+          <h3>Version</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-ray-id">
+          <h3>Ray ID</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-logs">
+          <h3>Logs</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-exceptions">
+          <h3>Exceptions</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+      </section>
+      <section class="breakdowns breakdowns-hidden" id="breakdowns-hidden"></section>
+      </div>
+
+      <!-- Logs View -->
+      <div id="logsView">
+        <div class="logs-table-container">
+          <div class="logs-loading"><div class="spinner"></div>Loading logs...</div>
+        </div>
+      </div>
+      </div><!-- end #contentArea -->
+    </main>
+  </div>
+
+  <!-- Quick Links Modal -->
+  <dialog id="quickLinksModal">
+    <div class="modal-header">
+      <h2>Quick Links</h2>
+      <button class="modal-close" data-action="close-quick-links">&times;</button>
+    </div>
+    <iframe id="quickLinksFrame" src="index.html"></iframe>
+  </dialog>
+
+  <!-- More Actions Menu -->
+  <dialog id="moreMenu" class="dropdown-menu">
+    <button class="menu-item" id="moreViewToggleItem">
+      <span class="menu-item-label">Switch to Logs view</span>
+      <kbd class="menu-item-kbd">t</kbd>
+    </button>
+    <button class="menu-item" id="moreRefreshItem">
+      <span class="menu-item-label">Refresh</span>
+      <kbd class="menu-item-kbd">r</kbd>
+    </button>
+    <div class="menu-divider"></div>
+    <button class="menu-item" id="moreLogoutItem">
+      <span class="menu-item-label">Logout</span>
+    </button>
+  </dialog>
+
+  <!-- Keyboard Help Dialog -->
+  <dialog id="keyboardHelp" role="dialog" aria-labelledby="keyboardHelpTitle">
+    <div class="keyboard-help-content">
+      <h2 id="keyboardHelpTitle">Keyboard Shortcuts <button data-action="close-dialog" aria-label="Close">&times;</button></h2>
+      <div class="keyboard-help-grid">
+        <div class="key-group"><kbd>j</kbd> <kbd>k</kbd></div>
+        <div class="key-desc">Navigate between values</div>
+
+        <div class="key-group"><kbd>h</kbd> <kbd>l</kbd></div>
+        <div class="key-desc">Navigate between facets</div>
+
+        <div class="key-group"><kbd>Tab</kbd></div>
+        <div class="key-desc">Next value (wraps to next facet)</div>
+
+        <div class="key-group"><kbd>i</kbd> <kbd>c</kbd> <kbd>Space</kbd></div>
+        <div class="key-desc">Toggle filter on value (Shift+click for exclude; tap value to reveal Filter/Exclude on touch)</div>
+
+        <div class="key-group"><kbd>e</kbd> <kbd>x</kbd></div>
+        <div class="key-desc">Toggle exclude on value</div>
+
+        <div class="key-group"><kbd>c</kbd><kbd>c</kbd></div>
+        <div class="key-desc">Clear all filters</div>
+
+        <div class="key-group"><kbd>.</kbd></div>
+        <div class="key-desc">Expand (other) / show more</div>
+
+        <div class="key-group"><kbd>o</kbd></div>
+        <div class="key-desc">Open link in new tab</div>
+
+        <div class="key-group"><kbd>p</kbd></div>
+        <div class="key-desc">Pin/unpin facet</div>
+
+        <div class="key-group"><kbd>d</kbd></div>
+        <div class="key-desc">Hide/show facet</div>
+
+        <div class="key-group"><kbd>g</kbd></div>
+        <div class="key-desc">Go to facet (quick navigation)</div>
+
+        <div class="key-group"><kbd>r</kbd></div>
+        <div class="key-desc">Refresh data</div>
+
+        <div class="key-group"><kbd>f</kbd></div>
+        <div class="key-desc">Focus function filter</div>
+
+        <div class="key-group"><kbd>t</kbd></div>
+        <div class="key-desc">Cycle view</div>
+
+        <div class="key-group"><kbd>1</kbd>-<kbd>5</kbd></div>
+        <div class="key-desc">Zoom to anomaly by rank</div>
+
+        <div class="key-group"><kbd>+</kbd></div>
+        <div class="key-desc">Zoom timeframe to most prominent anomaly</div>
+
+        <div class="key-group"><kbd>-</kbd></div>
+        <div class="key-desc">Zoom timeframe out to larger period</div>
+
+        <div class="key-group"><kbd>?</kbd></div>
+        <div class="key-desc">Show this help</div>
+
+        <div class="key-group"><kbd>Esc</kbd></div>
+        <div class="key-desc">Exit keyboard mode</div>
+      </div>
+    </div>
+  </dialog>
+
+  <!-- Log Detail Modal -->
+  <dialog id="logDetailModal" role="dialog" aria-labelledby="logDetailTitle">
+    <div class="log-detail-header">
+      <h2 id="logDetailTitle">Log Entry Details</h2>
+      <button class="modal-close" data-action="close-log-detail">&times;</button>
+    </div>
+    <div class="log-detail-content">
+      <table class="log-detail-table" id="logDetailTable"></table>
+    </div>
+  </dialog>
+
+  <!-- Facet Command Palette (VS Code-style goto) -->
+  <dialog id="facetPalette" role="dialog" aria-labelledby="facetPaletteTitle">
+    <div class="palette-header">
+      <input type="text" id="facetPaletteInput" placeholder="Go to facet..." aria-label="Search facets">
+    </div>
+    <div id="facetPaletteList" role="listbox" aria-label="Facet list"></div>
+  </dialog>
+
+  <!-- Facet Value Search Popover -->
+  <dialog id="facetSearchPopover" role="dialog" aria-labelledby="facetSearchTitle">
+    <div class="facet-search-header">
+      <h4 id="facetSearchTitle">Search</h4>
+      <input type="text" id="facetSearchInput" placeholder="Search values..." aria-label="Search facet values">
+    </div>
+    <div id="facetSearchResults" role="listbox" aria-label="Search results"></div>
+  </dialog>
+
+  <script type="module" src="js/da-workers-main.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -63,6 +63,12 @@
         </a>
       </li>
       <li>
+        <a href="da-workers.html">
+          <div class="title">DA Worker Logs</div>
+          <div class="description">Cloudflare Workers trace logs for the DA workers: console/error output, outcome, ray_id resolution to CDN access logs</div>
+        </a>
+      </li>
+      <li>
         <a href="domains.html">
           <div class="title">Domain Explorer</div>
           <div class="description">Map AEM Edge Delivery hostnames to customer domains via x-forwarded-host</div>

--- a/js/breakdowns/definitions-da-workers.js
+++ b/js/breakdowns/definitions-da-workers.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { COLUMN_DEFS } from '../columns.js';
+
+/**
+ * Breakdown (facet) definitions for the da_worker_logs table
+ * (Cloudflare Workers Trace Events for the DA workers: da-admin, da-collab, da-content, ...).
+ */
+export const daWorkerBreakdowns = [
+  {
+    id: 'breakdown-outcome',
+    col: '`outcome`',
+    summaryCountIf: "`outcome` IN ('exception', 'exceeded')",
+    summaryLabel: 'error rate',
+    summaryColor: 'error',
+  },
+  {
+    id: 'breakdown-status',
+    col: COLUMN_DEFS.status.facetCol,
+  },
+  {
+    id: 'breakdown-script-name',
+    col: '`script_name`',
+  },
+  {
+    id: 'breakdown-method',
+    col: COLUMN_DEFS.method.facetCol,
+  },
+  {
+    id: 'breakdown-url',
+    col: COLUMN_DEFS.url.facetCol,
+    highCardinality: true,
+  },
+  {
+    id: 'breakdown-script-version',
+    col: '`script_version`',
+    highCardinality: true,
+  },
+  {
+    id: 'breakdown-ray-id',
+    col: '`ray_id`',
+    highCardinality: true,
+    // "0" marks internal service-binding calls (da-collab -> da-admin, etc.) that
+    // never appear in the `da` access-log table, so they're not a useful breakdown value.
+    extraFilter: "AND `ray_id` != '' AND `ray_id` != '0'",
+  },
+  {
+    id: 'breakdown-logs',
+    col: 'arrayJoin(`logs`)',
+    filterCol: '`logs`',
+    filterOp: 'HAS',
+    highCardinality: true,
+    maxTimeRangeHours: 24,
+  },
+  {
+    id: 'breakdown-exceptions',
+    col: 'arrayJoin(`exceptions`)',
+    filterCol: '`exceptions`',
+    filterOp: 'HAS',
+    highCardinality: true,
+    maxTimeRangeHours: 24,
+  },
+];

--- a/js/breakdowns/definitions-da-workers.test.js
+++ b/js/breakdowns/definitions-da-workers.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { daWorkerBreakdowns } from './definitions-da-workers.js';
+
+describe('daWorkerBreakdowns', () => {
+  it('has nine facets', () => {
+    assert.strictEqual(daWorkerBreakdowns.length, 9);
+  });
+
+  it('each facet has a unique id and a col (string or function)', () => {
+    const ids = new Set();
+    daWorkerBreakdowns.forEach((b) => {
+      assert.ok(typeof b.col === 'string' || typeof b.col === 'function');
+      assert.isFalse(ids.has(b.id), `duplicate id: ${b.id}`);
+      ids.add(b.id);
+    });
+  });
+
+  it('outcome facet flags exception/exceeded as the error-rate summary', () => {
+    const outcome = daWorkerBreakdowns.find((b) => b.id === 'breakdown-outcome');
+    assert.ok(outcome);
+    assert.strictEqual(outcome.summaryCountIf, "`outcome` IN ('exception', 'exceeded')");
+    assert.strictEqual(outcome.summaryLabel, 'error rate');
+    assert.strictEqual(outcome.summaryColor, 'error');
+  });
+
+  it('ray-id facet excludes empty and internal service-binding ("0") values', () => {
+    const rayId = daWorkerBreakdowns.find((b) => b.id === 'breakdown-ray-id');
+    assert.ok(rayId);
+    assert.include(rayId.extraFilter, "`ray_id` != ''");
+    assert.include(rayId.extraFilter, "`ray_id` != '0'");
+  });
+
+  it('logs and exceptions facets arrayJoin their column and cap the time range', () => {
+    const logs = daWorkerBreakdowns.find((b) => b.id === 'breakdown-logs');
+    const exceptions = daWorkerBreakdowns.find((b) => b.id === 'breakdown-exceptions');
+    assert.strictEqual(logs.col, 'arrayJoin(`logs`)');
+    assert.strictEqual(logs.filterOp, 'HAS');
+    assert.strictEqual(logs.maxTimeRangeHours, 24);
+    assert.strictEqual(exceptions.col, 'arrayJoin(`exceptions`)');
+    assert.strictEqual(exceptions.filterOp, 'HAS');
+    assert.strictEqual(exceptions.maxTimeRangeHours, 24);
+  });
+
+  it('url and script-version facets are marked high cardinality', () => {
+    const url = daWorkerBreakdowns.find((b) => b.id === 'breakdown-url');
+    const version = daWorkerBreakdowns.find((b) => b.id === 'breakdown-script-version');
+    assert.strictEqual(url.highCardinality, true);
+    assert.strictEqual(version.highCardinality, true);
+  });
+});

--- a/js/colors/definitions.js
+++ b/js/colors/definitions.js
@@ -339,6 +339,18 @@ export const colorRules = {
     },
   },
 
+  // DA worker logs dashboard facets
+  workerOutcome: {
+    patterns: ['`outcome`'],
+    getColor: (value) => {
+      if (!value) { return ''; }
+      const v = value.toUpperCase();
+      if (v === 'EXCEPTION' || v === 'EXCEEDED') { return 'var(--status-server-error)'; }
+      if (v === 'CANCELED') { return 'var(--status-client-error)'; }
+      return 'var(--status-ok)';
+    },
+  },
+
   lambdaAdminMethod: {
     patterns: ['admin.method', 'message_json.admin'],
     getColor: (value) => {

--- a/js/columns.js
+++ b/js/columns.js
@@ -161,6 +161,13 @@ export const COLUMN_DEFS = {
 };
 
 /**
+ * da_worker_logs Array(String) columns that read as one log/exception entry per line,
+ * rather than lambda_logs' urls/paths/hostnames/emails/ips/refs (kept as JSON arrays).
+ * @type {Set<string>}
+ */
+export const MULTILINE_ARRAY_COLUMNS = new Set(['logs', 'exceptions']);
+
+/**
  * Log columns in preferred display order (also used for color-coding priority).
  * @type {string[]}
  */
@@ -220,4 +227,11 @@ export const LOG_COLUMN_SHORT_LABELS = {
   app_name: 'App',
   log_group: 'Log Group',
   log_stream: 'Log Stream',
+  // DA worker log column labels
+  script_name: 'Worker',
+  ray_id: 'Ray ID',
+  cpu_ms: 'CPU ms',
+  wall_ms: 'Wall ms',
+  script_version: 'Version',
+  outcome: 'Outcome',
 };

--- a/js/da-workers-main.js
+++ b/js/da-workers-main.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { initDashboard } from './dashboard-init.js';
+import { daWorkerBreakdowns } from './breakdowns/definitions-da-workers.js';
+
+const LOG_COLUMN_ORDER = [
+  'timestamp',
+  'outcome',
+  'response.status',
+  'script_name',
+  'request.method',
+  'request.url',
+  'ray_id',
+  'logs',
+  'exceptions',
+  'cpu_ms',
+  'wall_ms',
+  'script_version',
+];
+
+const DEFAULT_HIDDEN_FACETS = [
+  'breakdown-script-version',
+  'breakdown-ray-id',
+];
+
+// outcome and response.status are independent signals here: status is 0 for
+// service-binding calls and WebSocket upgrades even when the invocation succeeded,
+// so "ok" must not require status < 400.
+const WORKER_AGGREGATIONS = {
+  aggTotal: 'count()',
+  aggOk: "countIf(outcome NOT IN ('exception', 'exceeded') AND (`response.status` = 0 OR `response.status` < 400))",
+  agg4xx: 'countIf(`response.status` >= 400 AND `response.status` < 500)',
+  agg5xx: "countIf(outcome IN ('exception', 'exceeded') OR `response.status` >= 500)",
+};
+
+initDashboard({
+  title: 'DA Worker Logs',
+  tableName: 'da_worker_logs',
+  timeSeriesTemplate: 'time-series-da-workers',
+  aggregations: WORKER_AGGREGATIONS,
+  hostFilterColumn: 'script_name',
+  requestIdColumn: 'ray_id',
+  messageColumn: 'request.url',
+  defaultTimeRange: '24h',
+  logColumnOrder: LOG_COLUMN_ORDER,
+  defaultHiddenFacets: DEFAULT_HIDDEN_FACETS,
+  breakdowns: daWorkerBreakdowns,
+});

--- a/js/logs.js
+++ b/js/logs.js
@@ -20,11 +20,12 @@ import { escapeHtml } from './utils.js';
 import { formatBytes } from './format.js';
 import { getColorForColumn } from './colors/index.js';
 import { getRequestContext, isRequestCurrent } from './request-context.js';
-import { LOG_COLUMN_ORDER, LOG_COLUMN_SHORT_LABELS } from './columns.js';
+import { LOG_COLUMN_ORDER, LOG_COLUMN_SHORT_LABELS, MULTILINE_ARRAY_COLUMNS } from './columns.js';
 import { loadSql } from './sql-loader.js';
 import { buildLogRowHtml, buildLogTableHeaderHtml } from './templates/logs-table.js';
 import { attachColumnResize } from './column-resize.js';
 import { PAGE_SIZE, PaginationState } from './pagination.js';
+import { shouldShowResolveButton, buildResolveButtonHtml, initRayIdLookup } from './ray-id-lookup.js';
 
 /**
  * Build ordered log column list from available columns.
@@ -194,6 +195,25 @@ function groupColumnsByPrefix(columns) {
   return groups;
 }
 
+function isEmptyMultilineArray(col, value) {
+  return MULTILINE_ARRAY_COLUMNS.has(col) && Array.isArray(value) && value.length === 0;
+}
+
+function formatStatusValue(value) {
+  const status = parseInt(value, 10);
+  let className = 'status-ok';
+  if (status >= 500) {
+    className = 'status-5xx';
+  } else if (status >= 400) {
+    className = 'status-4xx';
+  }
+  return { displayValue: String(status), className };
+}
+
+function joinMultilineArray(value) {
+  return value.map((v) => (typeof v === 'string' ? v : JSON.stringify(v))).join('\n');
+}
+
 /**
  * Format a value for display in the detail modal.
  * @param {string} col
@@ -201,28 +221,25 @@ function groupColumnsByPrefix(columns) {
  * @returns {{ html: string, className: string }}
  */
 function formatDetailValue(col, value) {
-  if (value === null || value === undefined || value === '') {
+  if (value === null || value === undefined || value === '' || isEmptyMultilineArray(col, value)) {
     return { html: '(empty)', className: 'empty-value' };
   }
 
   let className = '';
   let displayValue = '';
+  let isMultiline = false;
 
   if (col === 'timestamp') {
-    const date = new Date(value);
-    displayValue = date.toLocaleString();
+    displayValue = new Date(value).toLocaleString();
   } else if (col === 'response.status') {
-    const status = parseInt(value, 10);
-    displayValue = String(status);
-    if (status >= 500) {
-      className = 'status-5xx';
-    } else if (status >= 400) {
-      className = 'status-4xx';
-    } else {
-      className = 'status-ok';
-    }
+    ({ displayValue, className } = formatStatusValue(value));
   } else if (col === 'response.body_size') {
     displayValue = formatBytes(parseInt(value, 10));
+  } else if (MULTILINE_ARRAY_COLUMNS.has(col) && Array.isArray(value)) {
+    // One entry per line (logs/exceptions on da_worker_logs) rather than a
+    // single JSON-stringified array on one line.
+    displayValue = joinMultilineArray(value);
+    isMultiline = true;
   } else if (typeof value === 'object') {
     displayValue = JSON.stringify(value, null, 2);
   } else {
@@ -232,7 +249,10 @@ function formatDetailValue(col, value) {
   const color = getColorForColumn(`\`${col}\``, value);
   const colorIndicator = color ? `<span class="log-color" style="background:${color}"></span>` : '';
 
-  return { html: colorIndicator + escapeHtml(displayValue), className };
+  const escaped = escapeHtml(displayValue);
+  const valueHtml = isMultiline ? escaped.replace(/\n/g, '<br>') : escaped;
+
+  return { html: colorIndicator + valueHtml, className };
 }
 
 /**
@@ -274,9 +294,12 @@ function renderLogDetailContent(row) {
         const value = row[col];
         const { html: valueHtml, className } = formatDetailValue(col, value);
         const displayCol = col.includes('.') ? col.split('.').slice(1).join('.') : col;
-        const filterBtn = (col === 'request_id' && value)
-          ? ` <button type="button" class="detail-filter-btn" data-action="search-by-request-id" data-value="${escapeHtml(String(value))}" title="Search by this request ID">search</button>`
-          : '';
+        let filterBtn = '';
+        if (col === 'request_id' && value) {
+          filterBtn = ` <button type="button" class="detail-filter-btn" data-action="search-by-request-id" data-value="${escapeHtml(String(value))}" title="Search by this request ID">search</button>`;
+        } else if (shouldShowResolveButton(col, value)) {
+          filterBtn = buildResolveButtonHtml(String(value));
+        }
         html += `<tr>
         <th title="${escapeHtml(col)}">${escapeHtml(displayCol)}</th>
         <td class="${className}">${valueHtml}${filterBtn}</td>
@@ -342,6 +365,8 @@ export function openLogDetailModal(rowIdx) {
       }
       closeLogDetailModal();
     });
+
+    initRayIdLookup(logDetailModal);
   }
 
   renderLogDetailContent(row);

--- a/js/logs.test.js
+++ b/js/logs.test.js
@@ -1,0 +1,459 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { state } from './state.js';
+import {
+  openLogDetailModal, closeLogDetailModal, renderLogsTable, setLogsElements, copyLogRow,
+  applyViewMode, setViewMode, cycleViewMode, toggleLogsView,
+  setOnShowFiltersView, setOnShowLogsView, loadLogs,
+} from './logs.js';
+
+function ensureModal() {
+  let modal = document.getElementById('logDetailModal');
+  if (!modal) {
+    modal = document.createElement('dialog');
+    modal.id = 'logDetailModal';
+    modal.innerHTML = '<button data-action="close-log-detail"></button>'
+      + '<table id="logDetailTable"></table>';
+    document.body.appendChild(modal);
+  }
+  return modal;
+}
+
+describe('openLogDetailModal - Array(String) fields (e.g. da_worker_logs logs/exceptions)', () => {
+  let savedLogsData;
+
+  beforeEach(() => {
+    ensureModal();
+    savedLogsData = state.logsData;
+    state.logsData = [{
+      logs: [
+        '[worker] Unable to get resource https://admin.da.live/x: 403 - Forbidden',
+        '[worker] second log line',
+      ],
+      exceptions: [],
+    }];
+  });
+
+  afterEach(() => {
+    closeLogDetailModal();
+    state.logsData = savedLogsData;
+  });
+
+  it('renders each logs[] entry on its own line instead of a single JSON array line', () => {
+    openLogDetailModal(0);
+    const table = document.getElementById('logDetailTable');
+    assert.notInclude(table.innerHTML, '[ &quot;[worker]');
+    assert.include(table.innerHTML, 'Forbidden<br>[worker] second log line');
+  });
+
+  it('does not lose or reorder entries when joining lines', () => {
+    openLogDetailModal(0);
+    const table = document.getElementById('logDetailTable');
+    const logsRow = [...table.querySelectorAll('tr')]
+      .find((r) => r.querySelector('th')?.textContent === 'logs');
+    const lines = logsRow.querySelector('td').innerHTML.split('<br>');
+    assert.strictEqual(lines.length, 2);
+    assert.include(lines[0], 'Unable to get resource');
+    assert.include(lines[1], 'second log line');
+  });
+
+  it('shows "(empty)" for an empty array field rather than "[]"', () => {
+    openLogDetailModal(0);
+    const table = document.getElementById('logDetailTable');
+    const exceptionsRow = [...table.querySelectorAll('tr')]
+      .find((r) => r.querySelector('th')?.textContent === 'exceptions');
+    assert.include(exceptionsRow.querySelector('td').textContent, '(empty)');
+  });
+});
+
+describe('openLogDetailModal - other field types and modal interactions', () => {
+  let savedLogsData;
+  let searchInput;
+
+  beforeEach(() => {
+    ensureModal();
+    searchInput = document.getElementById('searchFilter');
+    if (!searchInput) {
+      searchInput = document.createElement('input');
+      searchInput.id = 'searchFilter';
+      document.body.appendChild(searchInput);
+    }
+    savedLogsData = state.logsData;
+  });
+
+  afterEach(() => {
+    closeLogDetailModal();
+    state.logsData = savedLogsData;
+  });
+
+  function statusCellClass() {
+    const table = document.getElementById('logDetailTable');
+    const row = [...table.querySelectorAll('tr')].find((r) => r.querySelector('th')?.textContent === 'status');
+    return row.querySelector('td').className;
+  }
+
+  it('color-codes response.status as ok/4xx/5xx', () => {
+    state.logsData = [
+      { 'response.status': 200 },
+      { 'response.status': 404 },
+      { 'response.status': 500 },
+    ];
+    openLogDetailModal(0);
+    assert.include(statusCellClass(), 'status-ok');
+    openLogDetailModal(1);
+    assert.include(statusCellClass(), 'status-4xx');
+    openLogDetailModal(2);
+    assert.include(statusCellClass(), 'status-5xx');
+  });
+
+  it('groups an unrecognized dotted column prefix under its own titled section', () => {
+    state.logsData = [{ 'foo.bar': 'baz' }];
+    openLogDetailModal(0);
+    const table = document.getElementById('logDetailTable');
+    assert.include(table.textContent, 'Foo');
+    assert.include(table.textContent, 'bar');
+  });
+
+  it('renders a search button for request_id and wires it to the search filter input', () => {
+    state.logsData = [{ request_id: 'abc-123' }];
+    openLogDetailModal(0);
+    const btn = document.querySelector('[data-action="search-by-request-id"]');
+    assert.ok(btn);
+    btn.click();
+    assert.strictEqual(searchInput.value, 'abc-123');
+    assert.isFalse(document.getElementById('logDetailModal').open);
+  });
+
+  it('closes on backdrop click, Escape, and the close button', () => {
+    state.logsData = [{ script_name: 'da-admin' }];
+    const modal = document.getElementById('logDetailModal');
+
+    openLogDetailModal(0);
+    modal.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    assert.isFalse(modal.open);
+
+    openLogDetailModal(0);
+    modal.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    assert.isFalse(modal.open);
+
+    openLogDetailModal(0);
+    modal.querySelector('[data-action="close-log-detail"]').click();
+    assert.isFalse(modal.open);
+  });
+});
+
+describe('openLogDetailModal - lambda_logs Array(String) fields stay untouched', () => {
+  let savedLogsData;
+
+  beforeEach(() => {
+    ensureModal();
+    savedLogsData = state.logsData;
+    state.logsData = [{
+      urls: ['https://a.example.com', 'https://b.example.com'],
+    }];
+  });
+
+  afterEach(() => {
+    closeLogDetailModal();
+    state.logsData = savedLogsData;
+  });
+
+  it('still renders lambda_logs array columns (urls/paths/...) as a single JSON array line', () => {
+    openLogDetailModal(0);
+    const table = document.getElementById('logDetailTable');
+    const urlsRow = [...table.querySelectorAll('tr')]
+      .find((r) => r.querySelector('th')?.textContent === 'urls');
+    const cellHtml = urlsRow.querySelector('td').innerHTML;
+    assert.notInclude(cellHtml, '<br>');
+    assert.strictEqual(
+      urlsRow.querySelector('td').textContent,
+      JSON.stringify(['https://a.example.com', 'https://b.example.com'], null, 2),
+    );
+  });
+});
+
+// Builds the DOM fixture setLogsElements/renderLogsTable/applyViewMode expect
+// (mirrors the #logsView/#filtersView/#contentArea/#viewCycleBtn/#moreViewToggleItem
+// markup in da-workers.html and the other dashboard shells).
+function buildDashboardFixture() {
+  const logsView = document.createElement('div');
+  logsView.id = 'logsView';
+  const container = document.createElement('div');
+  container.className = 'logs-table-container';
+  logsView.appendChild(container);
+
+  const filtersView = document.createElement('div');
+  filtersView.id = 'filtersView';
+
+  const contentArea = document.createElement('div');
+  contentArea.id = 'contentArea';
+
+  const viewCycleBtn = document.createElement('button');
+  viewCycleBtn.id = 'viewCycleBtn';
+
+  const moreItem = document.createElement('div');
+  moreItem.id = 'moreViewToggleItem';
+  const moreLabel = document.createElement('span');
+  moreLabel.className = 'menu-item-label';
+  moreItem.appendChild(moreLabel);
+
+  document.body.append(logsView, filtersView, contentArea, viewCycleBtn, moreItem);
+  return {
+    logsView, filtersView, contentArea, container,
+  };
+}
+
+function removeDashboardFixture(fixture) {
+  fixture.logsView.remove();
+  fixture.filtersView.remove();
+  fixture.contentArea.remove();
+  document.getElementById('viewCycleBtn')?.remove();
+  document.getElementById('moreViewToggleItem')?.remove();
+}
+
+describe('renderLogsTable', () => {
+  let fixture;
+  let savedPinnedColumns;
+  let savedLogColumnWidths;
+
+  beforeEach(() => {
+    fixture = buildDashboardFixture();
+    setLogsElements(fixture.logsView, fixture.filtersView, fixture.contentArea);
+    savedPinnedColumns = state.pinnedColumns;
+    savedLogColumnWidths = state.logColumnWidths;
+    state.pinnedColumns = [];
+    state.logColumnWidths = {};
+  });
+
+  afterEach(() => {
+    removeDashboardFixture(fixture);
+    state.pinnedColumns = savedPinnedColumns;
+    state.logColumnWidths = savedLogColumnWidths;
+  });
+
+  it('shows an empty-state message when there is no data', () => {
+    renderLogsTable([]);
+    assert.include(fixture.container.textContent, 'No logs matching current filters');
+  });
+
+  it('renders one row per log entry with the row values visible', () => {
+    renderLogsTable([
+      { timestamp: '2026-07-08T12:00:00.000Z', 'response.status': 200, script_name: 'da-admin' },
+      { timestamp: '2026-07-08T12:01:00.000Z', 'response.status': 500, script_name: 'da-collab' },
+    ]);
+    const rows = fixture.container.querySelectorAll('tbody tr');
+    assert.strictEqual(rows.length, 2);
+    assert.include(fixture.container.textContent, 'da-admin');
+    assert.include(fixture.container.textContent, 'da-collab');
+  });
+
+  it('sticks pinned columns to the left with computed offsets', async () => {
+    state.pinnedColumns = ['timestamp'];
+    renderLogsTable([
+      { timestamp: '2026-07-08T12:00:00.000Z', script_name: 'da-admin' },
+      { timestamp: '2026-07-08T12:01:00.000Z', script_name: 'da-collab' },
+    ]);
+    await new Promise((resolve) => { requestAnimationFrame(resolve); });
+    const headerCell = fixture.container.querySelector('thead th.pinned');
+    const bodyCell = fixture.container.querySelector('tbody td.pinned');
+    assert.ok(headerCell);
+    assert.ok(bodyCell);
+    assert.strictEqual(headerCell.style.left, '0px');
+    assert.strictEqual(bodyCell.style.left, '0px');
+  });
+
+  it('opens the log detail modal when a row background is clicked', () => {
+    ensureModal();
+    state.logsData = [{ timestamp: '2026-07-08T12:00:00.000Z', script_name: 'da-admin' }];
+    renderLogsTable(state.logsData);
+    fixture.container.querySelector('tbody tr').click();
+    assert.isTrue(document.getElementById('logDetailModal').open);
+    closeLogDetailModal();
+  });
+});
+
+describe('applyViewMode / setViewMode / cycleViewMode / toggleLogsView', () => {
+  let fixture;
+  let savedViewMode;
+
+  beforeEach(() => {
+    fixture = buildDashboardFixture();
+    setLogsElements(fixture.logsView, fixture.filtersView, fixture.contentArea);
+    savedViewMode = state.viewMode;
+  });
+
+  afterEach(() => {
+    removeDashboardFixture(fixture);
+    state.viewMode = savedViewMode;
+  });
+
+  it('shows the logs view and hides the filters view in "logs" mode', () => {
+    state.viewMode = 'logs';
+    applyViewMode(true);
+    assert.isTrue(fixture.logsView.classList.contains('visible'));
+    assert.isFalse(fixture.filtersView.classList.contains('visible'));
+  });
+
+  it('shows both views and marks contentArea split in "split" mode', () => {
+    state.viewMode = 'split';
+    applyViewMode(true);
+    assert.isTrue(fixture.logsView.classList.contains('visible'));
+    assert.isTrue(fixture.filtersView.classList.contains('visible'));
+    assert.isTrue(fixture.contentArea.classList.contains('split'));
+  });
+
+  it('setViewMode updates state, persists the view mode, and calls the saveStateToURL callback', () => {
+    let saved = false;
+    setViewMode('logs', () => { saved = true; });
+    assert.strictEqual(state.viewMode, 'logs');
+    assert.isTrue(saved);
+  });
+
+  it('cycleViewMode and its deprecated toggleLogsView alias advance to a different mode', () => {
+    state.viewMode = 'filters';
+    let saved = false;
+    cycleViewMode(() => { saved = true; });
+    assert.notStrictEqual(state.viewMode, 'filters');
+    assert.isTrue(saved);
+
+    const modeAfterCycle = state.viewMode;
+    toggleLogsView(() => {});
+    assert.notStrictEqual(state.viewMode, modeAfterCycle);
+  });
+
+  it('invokes the registered onShowLogsView callback via requestAnimationFrame when switching to logs', async () => {
+    let called = false;
+    setOnShowLogsView(() => { called = true; });
+    state.viewMode = 'logs';
+    state.logsReady = false;
+    applyViewMode(false);
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    });
+    assert.isTrue(called);
+    setOnShowLogsView(null);
+  });
+
+  it('invokes the registered onShowFiltersView callback via requestAnimationFrame when not in logs mode', async () => {
+    let called = false;
+    setOnShowFiltersView(() => { called = true; });
+    state.viewMode = 'filters';
+    applyViewMode(false);
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    });
+    assert.isTrue(called);
+    setOnShowFiltersView(null);
+  });
+});
+
+describe('copyLogRow', () => {
+  let savedLogsData;
+  let originalWriteText;
+
+  beforeEach(() => {
+    savedLogsData = state.logsData;
+    originalWriteText = navigator.clipboard.writeText;
+  });
+
+  afterEach(() => {
+    state.logsData = savedLogsData;
+    navigator.clipboard.writeText = originalWriteText;
+  });
+
+  it('copies the row as nested JSON, expanding dotted columns and dropping empty values', async () => {
+    let copied = '';
+    navigator.clipboard.writeText = async (text) => { copied = text; };
+    state.logsData = [{
+      timestamp: '2026-07-08T12:00:00.000Z',
+      'request.host': 'admin.da.live',
+      'request.url': '',
+      script_name: 'da-admin',
+    }];
+
+    copyLogRow(0);
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+
+    const parsed = JSON.parse(copied);
+    assert.strictEqual(parsed.request.host, 'admin.da.live');
+    assert.strictEqual(parsed.script_name, 'da-admin');
+    assert.notProperty(parsed.request, 'url');
+  });
+
+  it('does nothing for an out-of-range row index', () => {
+    state.logsData = [{ script_name: 'da-admin' }];
+    assert.doesNotThrow(() => copyLogRow(5));
+  });
+
+  it('logs an error instead of throwing when the clipboard write is rejected', async () => {
+    navigator.clipboard.writeText = async () => { throw new Error('clipboard blocked'); };
+    state.logsData = [{ script_name: 'da-admin' }];
+
+    assert.doesNotThrow(() => copyLogRow(0));
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+  });
+});
+
+describe('loadLogs', () => {
+  let fixture;
+  let originalFetch;
+  let savedCredentials;
+  let savedLogsData;
+
+  beforeEach(() => {
+    fixture = buildDashboardFixture();
+    setLogsElements(fixture.logsView, fixture.filtersView, fixture.contentArea);
+    originalFetch = window.fetch;
+    savedCredentials = state.credentials;
+    savedLogsData = state.logsData;
+    state.credentials = { user: 'testuser', password: 'testpass' };
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    state.credentials = savedCredentials;
+    state.logsData = savedLogsData;
+    removeDashboardFixture(fixture);
+  });
+
+  it('renders fetched rows into the logs table', async () => {
+    window.fetch = async (url) => {
+      if (url.endsWith('.sql')) {
+        return { ok: true, status: 200, text: async () => 'SELECT * FROM logs' };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [{ timestamp: '2026-07-08T12:00:00.000Z', script_name: 'da-admin' }] }),
+      };
+    };
+
+    await loadLogs();
+
+    assert.include(fixture.container.textContent, 'da-admin');
+    assert.isTrue(state.logsReady);
+  });
+
+  it('shows an error message when the query fails', async () => {
+    window.fetch = async (url) => {
+      if (url.endsWith('.sql')) {
+        return { ok: true, status: 200, text: async () => 'SELECT * FROM logs' };
+      }
+      return { ok: false, status: 500, text: async () => 'DB::Exception: boom' };
+    };
+
+    await loadLogs();
+
+    assert.include(fixture.container.textContent, 'Error loading logs');
+  });
+});

--- a/js/ray-id-lookup.js
+++ b/js/ray-id-lookup.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { DATABASE } from './config.js';
+import { query } from './api.js';
+import { loadSql } from './sql-loader.js';
+import { escapeHtml } from './utils.js';
+
+/**
+ * "0" marks an internal service-binding call (da-collab -> da-admin, etc.) that never
+ * appears in the `da` CDN access-log table, so it's never worth offering to resolve it.
+ * @param {string} col
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function shouldShowResolveButton(col, value) {
+  return col === 'ray_id' && !!value && value !== '0';
+}
+
+/**
+ * Build the "resolve" button HTML shown next to a ray_id value in the log detail modal.
+ * @param {string} rayId
+ * @returns {string}
+ */
+export function buildResolveButtonHtml(rayId) {
+  return ' <button type="button" class="detail-filter-btn" data-action="resolve-ray-id" '
+    + `data-value="${escapeHtml(rayId)}" title="Find the matching CDN access log">resolve</button>`;
+}
+
+const RESULT_ROW_ID = 'rayIdResolveResult';
+
+/**
+ * Render the matched `da` rows (or an empty-state message) as a tbody to append
+ * after the ray_id row in the log detail table.
+ * @param {Array<Object>} rows
+ * @returns {string}
+ */
+export function renderRayIdResultHtml(rows) {
+  if (!rows || rows.length === 0) {
+    return `<tbody class="log-detail-group" id="${RESULT_ROW_ID}">`
+      + '<tr><td colspan="2" class="empty-value">No matching CDN access log found</td></tr>'
+      + '</tbody>';
+  }
+
+  const rowsHtml = rows.map((row) => {
+    const fields = [
+      new Date(row.timestamp).toLocaleString(),
+      row['request.method'],
+      row['request.host'],
+      row['request.url'],
+      row['response.status'],
+      row['cdn.cache_status'],
+      row['cdn.script_name'],
+    ].filter((v) => v !== undefined && v !== null && v !== '');
+    return `<tr><td colspan="2">${escapeHtml(fields.join(' · '))}</td></tr>`;
+  }).join('');
+
+  return `<tbody class="log-detail-group" id="${RESULT_ROW_ID}">`
+    + '<tr><td colspan="2" class="log-detail-group-title">Matched CDN access log (da)</td></tr>'
+    + `${rowsHtml}</tbody>`;
+}
+
+function renderLoadingHtml() {
+  return `<tbody class="log-detail-group" id="${RESULT_ROW_ID}">`
+    + '<tr><td colspan="2">Resolving…</td></tr></tbody>';
+}
+
+function renderErrorHtml(message) {
+  return `<tbody class="log-detail-group" id="${RESULT_ROW_ID}">`
+    + `<tr><td colspan="2" class="empty-value">Lookup failed: ${escapeHtml(message)}</td></tr></tbody>`;
+}
+
+async function resolveRayId(rayId) {
+  const escaped = rayId.replace(/'/g, "''");
+  const sql = await loadSql('ray-id-lookup', { database: DATABASE, rayId: escaped });
+  const result = await query(sql);
+  return result.data;
+}
+
+/**
+ * Wire up the "resolve" button inside the log detail modal: on click, query the `da`
+ * table for rows matching the clicked ray_id and append the result inline.
+ * @param {HTMLElement} modal - the #logDetailModal dialog element
+ */
+export function initRayIdLookup(modal) {
+  modal.addEventListener('click', async (e) => {
+    const btn = e.target.closest('[data-action="resolve-ray-id"]');
+    if (!btn) { return; }
+
+    const table = document.getElementById('logDetailTable');
+    if (!table) { return; }
+
+    document.getElementById(RESULT_ROW_ID)?.remove();
+    table.insertAdjacentHTML('beforeend', renderLoadingHtml());
+
+    try {
+      const rows = await resolveRayId(btn.dataset.value);
+      document.getElementById(RESULT_ROW_ID)?.remove();
+      table.insertAdjacentHTML('beforeend', renderRayIdResultHtml(rows));
+    } catch (err) {
+      document.getElementById(RESULT_ROW_ID)?.remove();
+      table.insertAdjacentHTML('beforeend', renderErrorHtml(err.message || String(err)));
+    }
+  });
+}

--- a/js/ray-id-lookup.js
+++ b/js/ray-id-lookup.js
@@ -13,6 +13,46 @@ import { DATABASE } from './config.js';
 import { query } from './api.js';
 import { loadSql } from './sql-loader.js';
 import { escapeHtml } from './utils.js';
+import { state } from './state.js';
+
+/**
+ * ray_id joins two tables in opposite directions depending on which dashboard is
+ * open. Each side lists only the fields not already visible on the *other* side's
+ * row (e.g. request.method/url are redundant when resolving from `da`, since the
+ * access-log row already shows them).
+ */
+const RESOLVE_TARGETS = {
+  da_worker_logs: {
+    sqlTemplate: 'ray-id-lookup',
+    label: 'CDN access log (da)',
+    fields: [
+      { key: 'request.host', label: 'Host' },
+      { key: 'request.url', label: 'URL' },
+      { key: 'request.method', label: 'Method' },
+      { key: 'response.status', label: 'Status' },
+      { key: 'cdn.script_name', label: 'Worker' },
+      { key: 'cdn.time_elapsed_msec', label: 'Elapsed (ms)' },
+      { key: 'response.headers.x_error', label: 'Error' },
+    ],
+  },
+  da: {
+    sqlTemplate: 'ray-id-lookup-worker',
+    label: 'worker log (da_worker_logs)',
+    fields: [
+      { key: 'script_name', label: 'Worker' },
+      { key: 'outcome', label: 'Outcome' },
+      { key: 'response.status', label: 'Status' },
+      { key: 'cpu_ms', label: 'CPU (ms)' },
+      { key: 'wall_ms', label: 'Wall (ms)' },
+      { key: 'logs', label: 'Logs' },
+      { key: 'exceptions', label: 'Exceptions' },
+    ],
+  },
+};
+
+function getResolveTarget() {
+  return RESOLVE_TARGETS[state.tableName];
+}
 
 /**
  * "0" marks an internal service-binding call (da-collab -> da-admin, etc.) that never
@@ -22,7 +62,7 @@ import { escapeHtml } from './utils.js';
  * @returns {boolean}
  */
 export function shouldShowResolveButton(col, value) {
-  return col === 'ray_id' && !!value && value !== '0';
+  return col === 'ray_id' && !!value && value !== '0' && !!getResolveTarget();
 }
 
 /**
@@ -31,41 +71,61 @@ export function shouldShowResolveButton(col, value) {
  * @returns {string}
  */
 export function buildResolveButtonHtml(rayId) {
+  const target = getResolveTarget();
+  const title = target ? `Find the matching ${target.label}` : 'Find the matching row';
   return ' <button type="button" class="detail-filter-btn" data-action="resolve-ray-id" '
-    + `data-value="${escapeHtml(rayId)}" title="Find the matching CDN access log">resolve</button>`;
+    + `data-value="${escapeHtml(rayId)}" title="${escapeHtml(title)}">resolve</button>`;
 }
 
 const RESULT_ROW_ID = 'rayIdResolveResult';
 
+function formatFieldValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((v) => (typeof v === 'string' ? v : JSON.stringify(v))).join(' | ');
+  }
+  if (value === undefined || value === null || value === '') {
+    return '';
+  }
+  return String(value);
+}
+
+function defaultFieldsFromRow(row) {
+  return Object.keys(row).filter((key) => key !== 'timestamp').map((key) => ({ key, label: key }));
+}
+
 /**
- * Render the matched `da` rows (or an empty-state message) as a tbody to append
- * after the ray_id row in the log detail table.
+ * Render the matched rows from the other table (or an empty-state message) as a
+ * tbody to append after the ray_id row in the log detail table.
  * @param {Array<Object>} rows
  * @returns {string}
  */
 export function renderRayIdResultHtml(rows) {
+  const target = getResolveTarget();
+  const label = target ? target.label : 'row';
+
   if (!rows || rows.length === 0) {
     return `<tbody class="log-detail-group" id="${RESULT_ROW_ID}">`
-      + '<tr><td colspan="2" class="empty-value">No matching CDN access log found</td></tr>'
+      + `<tr><td colspan="2" class="empty-value">No matching ${escapeHtml(label)} found</td></tr>`
       + '</tbody>';
   }
 
-  const rowsHtml = rows.map((row) => {
-    const fields = [
+  const fields = target ? target.fields : defaultFieldsFromRow(rows[0]);
+  const headerHtml = ['Time', ...fields.map((f) => f.label)]
+    .map((h) => `<th>${escapeHtml(h)}</th>`).join('');
+
+  const bodyRowsHtml = rows.map((row) => {
+    const cells = [
       new Date(row.timestamp).toLocaleString(),
-      row['request.method'],
-      row['request.host'],
-      row['request.url'],
-      row['response.status'],
-      row['cdn.cache_status'],
-      row['cdn.script_name'],
-    ].filter((v) => v !== undefined && v !== null && v !== '');
-    return `<tr><td colspan="2">${escapeHtml(fields.join(' · '))}</td></tr>`;
+      ...fields.map((f) => formatFieldValue(row[f.key])),
+    ].map((v) => `<td>${escapeHtml(v)}</td>`).join('');
+    return `<tr>${cells}</tr>`;
   }).join('');
 
   return `<tbody class="log-detail-group" id="${RESULT_ROW_ID}">`
-    + '<tr><td colspan="2" class="log-detail-group-title">Matched CDN access log (da)</td></tr>'
-    + `${rowsHtml}</tbody>`;
+    + `<tr><td colspan="2" class="log-detail-group-title">Matched ${escapeHtml(label)}</td></tr>`
+    + '<tr><td colspan="2"><table class="ray-id-result-table">'
+    + `<thead><tr>${headerHtml}</tr></thead><tbody>${bodyRowsHtml}</tbody></table></td></tr>`
+    + '</tbody>';
 }
 
 function renderLoadingHtml() {
@@ -79,15 +139,17 @@ function renderErrorHtml(message) {
 }
 
 async function resolveRayId(rayId) {
+  const target = getResolveTarget();
   const escaped = rayId.replace(/'/g, "''");
-  const sql = await loadSql('ray-id-lookup', { database: DATABASE, rayId: escaped });
+  const sql = await loadSql(target.sqlTemplate, { database: DATABASE, rayId: escaped });
   const result = await query(sql);
   return result.data;
 }
 
 /**
- * Wire up the "resolve" button inside the log detail modal: on click, query the `da`
- * table for rows matching the clicked ray_id and append the result inline.
+ * Wire up the "resolve" button inside the log detail modal: on click, query the
+ * other ray_id-joinable table (da <-> da_worker_logs, per state.tableName) for rows
+ * matching the clicked ray_id and append the result inline.
  * @param {HTMLElement} modal - the #logDetailModal dialog element
  */
 export function initRayIdLookup(modal) {

--- a/js/ray-id-lookup.test.js
+++ b/js/ray-id-lookup.test.js
@@ -23,7 +23,7 @@ function makeFetchMock({
 } = {}) {
   return async (url) => {
     if (url.endsWith('.sql')) {
-      return { ok: true, status: 200, text: async () => "SELECT * FROM da WHERE ray_id = '{{rayId}}'" };
+      return { ok: true, status: 200, text: async () => "SELECT * FROM t WHERE ray_id = '{{rayId}}'" };
     }
     if (!ok) {
       return { ok: false, status, text: async () => errorText };
@@ -36,21 +36,51 @@ function waitForMicrotasks() {
   return new Promise((resolve) => { setTimeout(resolve, 0); });
 }
 
+function withTableName(tableName, fn) {
+  const saved = state.tableName;
+  state.tableName = tableName;
+  try {
+    fn();
+  } finally {
+    state.tableName = saved;
+  }
+}
+
 describe('shouldShowResolveButton', () => {
-  it('shows the button for a real ray_id value', () => {
-    assert.isTrue(shouldShowResolveButton('ray_id', 'a1495b1e6d10c17f'));
+  it('shows the button on the da_worker_logs dashboard for a real ray_id value', () => {
+    withTableName('da_worker_logs', () => {
+      assert.isTrue(shouldShowResolveButton('ray_id', 'a1495b1e6d10c17f'));
+    });
+  });
+
+  it('shows the button on the da dashboard for a real ray_id value', () => {
+    withTableName('da', () => {
+      assert.isTrue(shouldShowResolveButton('ray_id', 'a1495b1e6d10c17f'));
+    });
+  });
+
+  it('hides the button on dashboards with no ray_id-joinable counterpart', () => {
+    withTableName('delivery', () => {
+      assert.isFalse(shouldShowResolveButton('ray_id', 'a1495b1e6d10c17f'));
+    });
   });
 
   it('hides the button for the internal service-binding sentinel "0"', () => {
-    assert.isFalse(shouldShowResolveButton('ray_id', '0'));
+    withTableName('da_worker_logs', () => {
+      assert.isFalse(shouldShowResolveButton('ray_id', '0'));
+    });
   });
 
   it('hides the button for an empty value', () => {
-    assert.isFalse(shouldShowResolveButton('ray_id', ''));
+    withTableName('da_worker_logs', () => {
+      assert.isFalse(shouldShowResolveButton('ray_id', ''));
+    });
   });
 
   it('hides the button for any other column', () => {
-    assert.isFalse(shouldShowResolveButton('request_id', 'a1495b1e6d10c17f'));
+    withTableName('da_worker_logs', () => {
+      assert.isFalse(shouldShowResolveButton('request_id', 'a1495b1e6d10c17f'));
+    });
   });
 });
 
@@ -65,38 +95,99 @@ describe('buildResolveButtonHtml', () => {
     const html = buildResolveButtonHtml('"><script>');
     assert.notInclude(html, '<script>');
   });
-});
 
-describe('renderRayIdResultHtml', () => {
-  it('shows an empty-state message when no rows match', () => {
-    const html = renderRayIdResultHtml([]);
-    assert.include(html, 'No matching CDN access log found');
+  it('points the tooltip at the da access log from the da_worker_logs dashboard', () => {
+    withTableName('da_worker_logs', () => {
+      assert.include(buildResolveButtonHtml('abc'), 'CDN access log (da)');
+    });
   });
 
-  it('renders the matched access log fields for a single row', () => {
-    const html = renderRayIdResultHtml([{
-      timestamp: '2026-07-08T12:00:00.000Z',
-      'request.method': 'GET',
-      'request.host': 'admin.da.live',
-      'request.url': '/source/adobecom/da-playground/x.html',
-      'response.status': 200,
-      'cdn.cache_status': 'MISS',
-      'cdn.script_name': 'da-admin',
-    }]);
-    assert.include(html, 'Matched CDN access log (da)');
-    assert.include(html, 'admin.da.live');
-    assert.include(html, '/source/adobecom/da-playground/x.html');
-    assert.include(html, '200');
-    assert.include(html, 'da-admin');
+  it('points the tooltip at the worker log from the da dashboard', () => {
+    withTableName('da', () => {
+      assert.include(buildResolveButtonHtml('abc'), 'worker log (da_worker_logs)');
+    });
+  });
+});
+
+describe('renderRayIdResultHtml - da_worker_logs -> da', () => {
+  it('shows an empty-state message when no rows match', () => {
+    withTableName('da_worker_logs', () => {
+      assert.include(renderRayIdResultHtml([]), 'No matching CDN access log (da) found');
+    });
+  });
+
+  it('renders only the configured access-log fields for a single row', () => {
+    withTableName('da_worker_logs', () => {
+      const html = renderRayIdResultHtml([{
+        timestamp: '2026-07-08T12:00:00.000Z',
+        'request.method': 'GET',
+        'request.host': 'admin.da.live',
+        'request.url': '/source/adobecom/da-playground/x.html',
+        'response.status': 200,
+        'cdn.cache_status': 'MISS',
+        'cdn.script_name': 'da-admin',
+        'cdn.time_elapsed_msec': 42,
+        'response.headers.x_error': '',
+      }]);
+      assert.include(html, 'Matched CDN access log (da)');
+      assert.include(html, '<th>Time</th>');
+      assert.include(html, '<th>Host</th>');
+      assert.include(html, '<th>URL</th>');
+      assert.include(html, '<th>Elapsed (ms)</th>');
+      assert.include(html, '<th>Error</th>');
+      assert.include(html, 'admin.da.live');
+      assert.include(html, '/source/adobecom/da-playground/x.html');
+      assert.include(html, '200');
+      assert.include(html, 'da-admin');
+      assert.include(html, '42');
+      // cdn.cache_status was deliberately dropped from the field list
+      assert.notInclude(html, 'MISS');
+    });
   });
 
   it('renders one row per match when multiple rows are returned', () => {
-    const html = renderRayIdResultHtml([
-      { 'request.host': 'admin.da.live', 'request.url': '/a' },
-      { 'request.host': 'admin.da.live', 'request.url': '/b' },
-    ]);
-    assert.include(html, '/a');
-    assert.include(html, '/b');
+    withTableName('da_worker_logs', () => {
+      const html = renderRayIdResultHtml([
+        { 'request.host': 'admin.da.live', 'request.url': '/a' },
+        { 'request.host': 'admin.da.live', 'request.url': '/b' },
+      ]);
+      assert.include(html, '/a');
+      assert.include(html, '/b');
+    });
+  });
+});
+
+describe('renderRayIdResultHtml - da -> da_worker_logs', () => {
+  it('shows an empty-state message when no rows match', () => {
+    withTableName('da', () => {
+      assert.include(renderRayIdResultHtml([]), 'No matching worker log (da_worker_logs) found');
+    });
+  });
+
+  it('renders only the configured worker-log fields, joining logs[]/exceptions[] with a pipe', () => {
+    withTableName('da', () => {
+      const html = renderRayIdResultHtml([{
+        timestamp: '2026-07-08T12:00:00.000Z',
+        script_name: 'da-admin',
+        outcome: 'exception',
+        'response.status': 500,
+        cpu_ms: 12,
+        wall_ms: 34,
+        logs: ['fetching resource from admin', 'https://x'],
+        exceptions: ['TypeError: x is not a function'],
+      }]);
+      assert.include(html, 'Matched worker log (da_worker_logs)');
+      assert.include(html, '<th>Time</th>');
+      assert.include(html, '<th>Worker</th>');
+      assert.include(html, '<th>Outcome</th>');
+      assert.include(html, '<th>CPU (ms)</th>');
+      assert.include(html, '<th>Logs</th>');
+      assert.include(html, '<th>Exceptions</th>');
+      assert.include(html, 'da-admin');
+      assert.include(html, 'exception');
+      assert.include(html, 'fetching resource from admin | https://x');
+      assert.include(html, 'TypeError: x is not a function');
+    });
   });
 });
 
@@ -105,12 +196,15 @@ describe('initRayIdLookup', () => {
   let table;
   let originalFetch;
   let savedCredentials;
+  let savedTableName;
 
   beforeEach(() => {
     modal = document.createElement('div');
     document.body.appendChild(modal);
     table = document.createElement('table');
     table.id = 'logDetailTable';
+    savedTableName = state.tableName;
+    state.tableName = 'da_worker_logs';
     table.innerHTML = `<tbody><tr><th>ray_id</th><td>abc123${buildResolveButtonHtml('abc123')}</td></tr></tbody>`;
     modal.appendChild(table);
     initRayIdLookup(modal);
@@ -123,6 +217,7 @@ describe('initRayIdLookup', () => {
   afterEach(() => {
     window.fetch = originalFetch;
     state.credentials = savedCredentials;
+    state.tableName = savedTableName;
     modal.remove();
   });
 
@@ -142,7 +237,7 @@ describe('initRayIdLookup', () => {
     table.querySelector('[data-action="resolve-ray-id"]').click();
     await waitForMicrotasks();
     await waitForMicrotasks();
-    assert.include(table.textContent, 'No matching CDN access log found');
+    assert.include(table.textContent, 'No matching CDN access log');
   });
 
   it('shows a lookup-failed message when the query errors', async () => {
@@ -157,5 +252,16 @@ describe('initRayIdLookup', () => {
     table.click();
     await waitForMicrotasks();
     assert.isNull(document.getElementById('rayIdResolveResult'));
+  });
+
+  it('resolves the other direction (da -> da_worker_logs) when on the da dashboard', async () => {
+    state.tableName = 'da';
+    table.innerHTML = `<tbody><tr><th>ray_id</th><td>abc123${buildResolveButtonHtml('abc123')}</td></tr></tbody>`;
+    window.fetch = makeFetchMock({ rows: [{ script_name: 'da-admin', outcome: 'ok' }] });
+    table.querySelector('[data-action="resolve-ray-id"]').click();
+    await waitForMicrotasks();
+    await waitForMicrotasks();
+    assert.include(table.textContent, 'Matched worker log');
+    assert.include(table.textContent, 'da-admin');
   });
 });

--- a/js/ray-id-lookup.test.js
+++ b/js/ray-id-lookup.test.js
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { state } from './state.js';
+import {
+  shouldShowResolveButton, buildResolveButtonHtml, renderRayIdResultHtml, initRayIdLookup,
+} from './ray-id-lookup.js';
+
+// Returns a fetch mock that routes based on URL:
+//  - .sql requests  → return the raw SQL template text
+//  - ClickHouse URL → return { data: rows } (or a failure response)
+function makeFetchMock({
+  rows = [], ok = true, status = 200, errorText = '',
+} = {}) {
+  return async (url) => {
+    if (url.endsWith('.sql')) {
+      return { ok: true, status: 200, text: async () => "SELECT * FROM da WHERE ray_id = '{{rayId}}'" };
+    }
+    if (!ok) {
+      return { ok: false, status, text: async () => errorText };
+    }
+    return { ok: true, status: 200, json: async () => ({ data: rows }) };
+  };
+}
+
+function waitForMicrotasks() {
+  return new Promise((resolve) => { setTimeout(resolve, 0); });
+}
+
+describe('shouldShowResolveButton', () => {
+  it('shows the button for a real ray_id value', () => {
+    assert.isTrue(shouldShowResolveButton('ray_id', 'a1495b1e6d10c17f'));
+  });
+
+  it('hides the button for the internal service-binding sentinel "0"', () => {
+    assert.isFalse(shouldShowResolveButton('ray_id', '0'));
+  });
+
+  it('hides the button for an empty value', () => {
+    assert.isFalse(shouldShowResolveButton('ray_id', ''));
+  });
+
+  it('hides the button for any other column', () => {
+    assert.isFalse(shouldShowResolveButton('request_id', 'a1495b1e6d10c17f'));
+  });
+});
+
+describe('buildResolveButtonHtml', () => {
+  it('embeds the ray id as the button data-value', () => {
+    const html = buildResolveButtonHtml('a1495b1e6d10c17f');
+    assert.include(html, 'data-action="resolve-ray-id"');
+    assert.include(html, 'data-value="a1495b1e6d10c17f"');
+  });
+
+  it('escapes HTML-sensitive characters in the ray id', () => {
+    const html = buildResolveButtonHtml('"><script>');
+    assert.notInclude(html, '<script>');
+  });
+});
+
+describe('renderRayIdResultHtml', () => {
+  it('shows an empty-state message when no rows match', () => {
+    const html = renderRayIdResultHtml([]);
+    assert.include(html, 'No matching CDN access log found');
+  });
+
+  it('renders the matched access log fields for a single row', () => {
+    const html = renderRayIdResultHtml([{
+      timestamp: '2026-07-08T12:00:00.000Z',
+      'request.method': 'GET',
+      'request.host': 'admin.da.live',
+      'request.url': '/source/adobecom/da-playground/x.html',
+      'response.status': 200,
+      'cdn.cache_status': 'MISS',
+      'cdn.script_name': 'da-admin',
+    }]);
+    assert.include(html, 'Matched CDN access log (da)');
+    assert.include(html, 'admin.da.live');
+    assert.include(html, '/source/adobecom/da-playground/x.html');
+    assert.include(html, '200');
+    assert.include(html, 'da-admin');
+  });
+
+  it('renders one row per match when multiple rows are returned', () => {
+    const html = renderRayIdResultHtml([
+      { 'request.host': 'admin.da.live', 'request.url': '/a' },
+      { 'request.host': 'admin.da.live', 'request.url': '/b' },
+    ]);
+    assert.include(html, '/a');
+    assert.include(html, '/b');
+  });
+});
+
+describe('initRayIdLookup', () => {
+  let modal;
+  let table;
+  let originalFetch;
+  let savedCredentials;
+
+  beforeEach(() => {
+    modal = document.createElement('div');
+    document.body.appendChild(modal);
+    table = document.createElement('table');
+    table.id = 'logDetailTable';
+    table.innerHTML = `<tbody><tr><th>ray_id</th><td>abc123${buildResolveButtonHtml('abc123')}</td></tr></tbody>`;
+    modal.appendChild(table);
+    initRayIdLookup(modal);
+
+    savedCredentials = state.credentials;
+    state.credentials = { user: 'testuser', password: 'testpass' };
+    originalFetch = window.fetch;
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    state.credentials = savedCredentials;
+    modal.remove();
+  });
+
+  it('resolves a clicked ray_id and renders the matched CDN access log row', async () => {
+    window.fetch = makeFetchMock({
+      rows: [{ 'request.host': 'admin.da.live', 'request.url': '/x' }],
+    });
+    table.querySelector('[data-action="resolve-ray-id"]').click();
+    await waitForMicrotasks();
+    await waitForMicrotasks();
+    assert.include(table.textContent, 'Matched CDN access log');
+    assert.include(table.textContent, 'admin.da.live');
+  });
+
+  it('shows an empty-state message when no rows match', async () => {
+    window.fetch = makeFetchMock({ rows: [] });
+    table.querySelector('[data-action="resolve-ray-id"]').click();
+    await waitForMicrotasks();
+    await waitForMicrotasks();
+    assert.include(table.textContent, 'No matching CDN access log found');
+  });
+
+  it('shows a lookup-failed message when the query errors', async () => {
+    window.fetch = makeFetchMock({ ok: false, status: 500, errorText: 'DB::Exception: boom' });
+    table.querySelector('[data-action="resolve-ray-id"]').click();
+    await waitForMicrotasks();
+    await waitForMicrotasks();
+    assert.include(table.textContent, 'Lookup failed');
+  });
+
+  it('ignores clicks that are not on the resolve button', async () => {
+    table.click();
+    await waitForMicrotasks();
+    assert.isNull(document.getElementById('rayIdResolveResult'));
+  });
+});

--- a/js/sql-loader.js
+++ b/js/sql-loader.js
@@ -64,6 +64,7 @@ const ALL_TEMPLATES = [
   'time-series-backend',
   'time-series-da-workers',
   'ray-id-lookup',
+  'ray-id-lookup-worker',
   'logs',
   'logs-more',
   'breakdown',

--- a/js/sql-loader.js
+++ b/js/sql-loader.js
@@ -62,6 +62,8 @@ const ALL_TEMPLATES = [
   'time-series',
   'time-series-delivery',
   'time-series-backend',
+  'time-series-da-workers',
+  'ray-id-lookup',
   'logs',
   'logs-more',
   'breakdown',

--- a/js/templates/logs-table.js
+++ b/js/templates/logs-table.js
@@ -12,7 +12,7 @@
 import { escapeHtml } from '../utils.js';
 import { formatBytes } from '../format.js';
 import { getColorForColumn } from '../colors/index.js';
-import { LOG_COLUMN_SHORT_LABELS, LOG_COLUMN_TO_FACET } from '../columns.js';
+import { LOG_COLUMN_SHORT_LABELS, LOG_COLUMN_TO_FACET, MULTILINE_ARRAY_COLUMNS } from '../columns.js';
 
 /**
  * Format timestamp - short format on mobile.
@@ -39,8 +39,13 @@ function formatStatusCell(value) {
 /**
  * Format generic value
  */
-function formatGenericValue(value) {
+function formatGenericValue(col, value) {
   if (value === null || value === undefined || value === '') { return ''; }
+  if (MULTILINE_ARRAY_COLUMNS.has(col) && Array.isArray(value)) {
+    // Single-line preview for the compact logs table (full entries, one per line,
+    // are shown in the log detail modal instead) — no JSON array brackets/quotes.
+    return value.map((v) => (typeof v === 'string' ? v : JSON.stringify(v))).join(' | ');
+  }
   if (typeof value === 'object') { return JSON.stringify(value); }
   return String(value);
 }
@@ -65,7 +70,7 @@ export function formatLogCell(col, value) {
     displayValue = value || '';
     cellClass = 'method';
   } else {
-    displayValue = formatGenericValue(value);
+    displayValue = formatGenericValue(col, value);
   }
 
   const color = value ? getColorForColumn(`\`${col}\``, value) : '';

--- a/js/templates/logs-table.test.js
+++ b/js/templates/logs-table.test.js
@@ -78,6 +78,26 @@ describe('formatLogCell', () => {
     assert.strictEqual(displayValue, '42');
   });
 
+  it('joins da_worker_logs logs[] entries with a pipe instead of JSON-stringifying the array', () => {
+    const { displayValue } = formatLogCell('logs', ['[worker] first line', '[worker] second line']);
+    assert.strictEqual(displayValue, '[worker] first line | [worker] second line');
+  });
+
+  it('joins da_worker_logs exceptions[] entries with a pipe as well', () => {
+    const { displayValue } = formatLogCell('exceptions', ['TypeError: x is not a function']);
+    assert.strictEqual(displayValue, 'TypeError: x is not a function');
+  });
+
+  it('renders an empty logs[] array as an empty cell, not "[]"', () => {
+    const { displayValue } = formatLogCell('logs', []);
+    assert.strictEqual(displayValue, '');
+  });
+
+  it('still JSON-stringifies non-multiline array columns like lambda_logs urls[]', () => {
+    const { displayValue } = formatLogCell('urls', ['https://a.example.com', 'https://b.example.com']);
+    assert.strictEqual(displayValue, '["https://a.example.com","https://b.example.com"]');
+  });
+
   it('returns color indicator for values with color rules', () => {
     const { colorIndicator } = formatLogCell('response.status', '500');
     assert.include(colorIndicator, 'log-color');

--- a/scripts/add-user.mjs
+++ b/scripts/add-user.mjs
@@ -19,7 +19,7 @@
 const CLICKHOUSE_HOST = 's2p5b8wmt5.eastus2.azure.clickhouse.cloud';
 const CLICKHOUSE_PORT = 443;
 const DATABASE = 'helix_logs_production';
-const TABLES = ['delivery', 'delivery_errors', 'admin', 'backend', 'da', 'cdn_facet_minutes', 'releases', 'oncall_shifts', 'lambda_logs', 'lambda_facet_minutes', 'optel_admin', 'user_shifts', 'site_configs', 'profile_configs', 'org_configs', 'site_configs_resolved'];
+const TABLES = ['delivery', 'delivery_errors', 'admin', 'backend', 'da', 'da_worker_logs', 'cdn_facet_minutes', 'releases', 'oncall_shifts', 'lambda_logs', 'lambda_facet_minutes', 'optel_admin', 'user_shifts', 'site_configs', 'profile_configs', 'org_configs', 'site_configs_resolved'];
 const DICTIONARIES = ['asn_dict'];
 
 function generatePassword(length = 16) {

--- a/scripts/grant-da-worker-logs.mjs
+++ b/scripts/grant-da-worker-logs.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/**
+ * Backfill: grant SELECT on da_worker_logs to all existing *_adobe_com read-only users.
+ * (da_worker_logs was added to add-user.mjs's TABLES list after these users were created,
+ * so they never received the grant.)
+ *
+ * Usage: node scripts/grant-da-worker-logs.mjs <admin-user> <admin-password> [-x]
+ * Dry-run by default (prints the GRANT statements); pass -x to actually execute them.
+ */
+
+const CLICKHOUSE_HOST = 's2p5b8wmt5.eastus2.azure.clickhouse.cloud';
+const CLICKHOUSE_PORT = 443;
+const DATABASE = 'helix_logs_production';
+const TABLE = 'da_worker_logs';
+
+async function runQuery(sql, adminUser, adminPassword) {
+  const url = `https://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${adminUser}:${adminPassword}`).toString('base64')}`,
+      'Content-Type': 'text/plain',
+    },
+    body: sql,
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(text.trim());
+  }
+  return text;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const execute = args.includes('-x');
+  const [adminUser, adminPassword] = args.filter((a) => a !== '-x');
+
+  if (!adminUser || !adminPassword) {
+    console.error('Usage: node scripts/grant-da-worker-logs.mjs <admin-user> <admin-password> [-x]');
+    process.exit(1);
+  }
+
+  const listSql = "SELECT name FROM system.users WHERE endsWith(name, '_adobe_com') FORMAT TSV";
+  const result = await runQuery(listSql, adminUser, adminPassword);
+  const users = result.trim().split('\n').filter(Boolean);
+
+  if (users.length === 0) {
+    console.log('No *_adobe_com users found.');
+    return;
+  }
+
+  console.log(`Found ${users.length} user(s): ${users.join(', ')}\n`);
+
+  if (!execute) {
+    console.log('Dry run (pass -x to execute). Would run:\n');
+    for (const user of users) {
+      console.log(`  GRANT SELECT ON ${DATABASE}.${TABLE} TO ${user};`);
+    }
+    return;
+  }
+
+  for (const user of users) {
+    const grantSql = `GRANT SELECT ON ${DATABASE}.${TABLE} TO ${user}`;
+    // eslint-disable-next-line no-await-in-loop -- Sequential grants to avoid race conditions
+    await runQuery(grantSql, adminUser, adminPassword);
+    console.log(`  GRANT SELECT ON ${TABLE} TO ${user}`);
+  }
+
+  console.log('\nDone.');
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/sql/queries/ray-id-lookup-worker.sql
+++ b/sql/queries/ray-id-lookup-worker.sql
@@ -1,0 +1,13 @@
+SELECT
+  timestamp,
+  script_name,
+  outcome,
+  `response.status`,
+  cpu_ms,
+  wall_ms,
+  logs,
+  exceptions
+FROM {{database}}.da_worker_logs
+WHERE ray_id = '{{rayId}}'
+ORDER BY timestamp
+LIMIT 5

--- a/sql/queries/ray-id-lookup.sql
+++ b/sql/queries/ray-id-lookup.sql
@@ -1,0 +1,12 @@
+SELECT
+  timestamp,
+  `request.host`,
+  `request.url`,
+  `request.method`,
+  `response.status`,
+  `cdn.cache_status`,
+  `cdn.script_name`
+FROM {{database}}.da
+WHERE ray_id = '{{rayId}}'
+ORDER BY timestamp
+LIMIT 5

--- a/sql/queries/ray-id-lookup.sql
+++ b/sql/queries/ray-id-lookup.sql
@@ -4,8 +4,9 @@ SELECT
   `request.url`,
   `request.method`,
   `response.status`,
-  `cdn.cache_status`,
-  `cdn.script_name`
+  `cdn.script_name`,
+  `cdn.time_elapsed_msec`,
+  `response.headers.x_error`
 FROM {{database}}.da
 WHERE ray_id = '{{rayId}}'
 ORDER BY timestamp

--- a/sql/queries/time-series-da-workers.sql
+++ b/sql/queries/time-series-da-workers.sql
@@ -1,0 +1,9 @@
+SELECT
+  {{bucket}} as t,
+  countIf(outcome NOT IN ('exception', 'exceeded') AND (`response.status` = 0 OR `response.status` < 400)) as cnt_ok,
+  countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+  countIf(outcome IN ('exception', 'exceeded') OR `response.status` >= 500) as cnt_5xx
+FROM {{database}}.{{table}}
+WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{additionalWhereClause}}
+GROUP BY t
+ORDER BY t WITH FILL FROM {{rangeStart}} TO {{rangeEnd}} STEP {{step}}

--- a/sql/writer_users.sql
+++ b/sql/writer_users.sql
@@ -34,6 +34,8 @@ GRANT INSERT, ALTER DELETE ON helix_logs_production.backend         TO logpush_w
 GRANT INSERT, ALTER DELETE ON helix_logs_production.delivery        TO logpush_writer;
 GRANT INSERT             ON helix_logs_production.delivery_errors TO logpush_writer;
 GRANT SELECT, INSERT     ON helix_logs_production.da              TO logpush_writer;
+-- da_worker_logs is a plain MergeTree with no chained MV reading it, so INSERT is enough:
+GRANT INSERT             ON helix_logs_production.da_worker_logs  TO logpush_writer;
 GRANT INSERT             ON helix_logs_production.asn_mapping     TO logpush_writer;
 
 -- delivery: INSERT plus ALTER DELETE for retention; SELECT on the specific


### PR DESCRIPTION
## Summary
- New `da-workers.html` dashboard for the `da_worker_logs` table (Cloudflare Workers Trace Events for da-admin/da-collab/da-content etc, added by [helix-gcs2clickhouse-ingestor#14](https://github.com/adobe/helix-gcs2clickhouse-ingestor/pull/14)), modeled on the Lambda Logs dashboard: outcome/status/worker/method/url/version/ray_id facets, plus `logs`/`exceptions` breakdowns.
- Ray ID resolution: clicking "resolve" next to a `ray_id` in the log detail modal queries the `da` table (indexed on `ray_id`) and shows the matching CDN access-log row inline — skipped for `ray_id = '0'` (internal service-binding calls).
- `logs[]`/`exceptions[]` now render one entry per line (detail modal) / pipe-joined single line (compact logs table) instead of a raw JSON array — scoped to just those two columns so `lambda_logs`' array columns (urls/paths/hostnames/emails/ips/refs) are unaffected.
- Supporting changes: `time-series-da-workers`/`ray-id-lookup` SQL templates, `outcome` color-coding, short column labels, quick-link on `index.html`, `da_worker_logs` added to `add-user.mjs`/`writer_users.sql` for grants, plus `scripts/grant-da-worker-logs.mjs` to backfill the SELECT grant to existing `*_adobe_com` users (dry-run by default, `-x` to execute).

## Testing Done
- `npm run lint` clean.
- `npm test`: 950/950 passing, 93.5% coverage (raised `js/logs.js` from 0% test coverage to exercising nearly all of it, since it had no prior test file).
- Verified in-browser via `playwright-cli`: dashboard loads with no console errors, quick link renders and links correctly.
- Manually cross-checked ray_id resolution against ClickHouse (`da_worker_logs` ⋈ `da` on `ray_id`).

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)