### PR TITLE
Add Helix Mixer dashboard

### DIFF
--- a/helix-mixer.html
+++ b/helix-mixer.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Helix Mixer Logs - CDN Analytics</title>
+  <script>
+    window.SAMPLE_PAGEVIEWS_AT_RATE = 'high';
+  </script>
+  <script defer type="text/javascript" src="https://ot.aem.live/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
+  <link rel="canonical" href="https://klickhaus.aemstatus.net/helix-mixer.html">
+
+  <!-- Favicon Icons -->
+  <link rel="apple-touch-icon" href="/icons/icon-180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/icon-32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png">
+
+  <link rel="stylesheet" href="dashboard.css">
+</head>
+<body>
+  <!-- Login Form -->
+  <div id="login">
+    <div class="login-card">
+      <h1>Helix Mixer Logs</h1>
+      <p>Sign in to view Helix Mixer log analytics</p>
+      <div id="loginError" class="error-message"></div>
+      <form id="loginForm" method="post" action="">
+        <div class="form-group">
+          <label for="username">Email or username</label>
+          <input type="text" id="username" name="username" required autocomplete="username email" inputmode="email">
+        </div>
+        <div class="form-group">
+          <label for="password">Password</label>
+          <input type="password" id="password" name="password" required autocomplete="current-password">
+        </div>
+        <div class="form-group form-option">
+          <label class="checkbox-label">
+            <input type="checkbox" id="forgetMe" name="forgetMe">
+            Forget me on this device
+          </label>
+        </div>
+        <button type="submit" class="btn btn-primary">Sign In</button>
+      </form>
+    </div>
+  </div>
+
+  <!-- Dashboard -->
+  <div id="dashboard">
+    <header>
+      <div class="header-left">
+        <button id="menuBtn" class="menu-btn" title="Quick Links">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <rect y="3" width="20" height="2" rx="1"/>
+            <rect y="9" width="20" height="2" rx="1"/>
+            <rect y="15" width="20" height="2" rx="1"/>
+          </svg>
+        </button>
+        <h1><span id="dashboardTitle">Helix Mixer Logs</span> <span id="totalCount" class="total-count"></span> <span id="queryTimer" class="query-timer"></span></h1>
+        <div id="activeFilters"></div>
+      </div>
+      <div class="header-right">
+        <span class="kbd-control"><kbd class="kbd-hint" id="timeRangeHint">2</kbd><select id="timeRange"></select></span>
+        <select id="topN"></select>
+        <span class="kbd-control"><kbd class="kbd-hint">f</kbd><input type="text" id="hostFilter" placeholder="Filter by worker..." list="hostSuggestions" autocomplete="off"></span>
+        <datalist id="hostSuggestions"></datalist>
+        <input type="text" id="searchFilter" placeholder="Ray ID or URL..." autocomplete="off">
+        <span class="kbd-control">
+          <kbd class="kbd-hint">t</kbd>
+          <button id="viewCycleBtn" class="menu-btn" title="Switch to Logs view">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="1" y="1" width="14" height="14" rx="2"/>
+              <line x1="4" y1="5" x2="12" y2="5"/>
+              <line x1="4" y1="8" x2="12" y2="8"/>
+              <line x1="4" y1="11" x2="9" y2="11"/>
+            </svg>
+          </button>
+        </span>
+        <button id="refreshBtn" class="menu-btn" title="Refresh">
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M15 9A6 6 0 1 0 13.2 13.2"/>
+            <polyline points="15,5 15,9 11,9"/>
+          </svg>
+        </button>
+        <button id="manageColumnsBtn" class="menu-btn" title="Manage Columns">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="2" width="3" height="12"/>
+            <rect x="6.5" y="2" width="3" height="12"/>
+            <rect x="11" y="2" width="3" height="12"/>
+          </svg>
+        </button>
+        <button id="themeBtn" class="menu-btn" title="Theme: Device">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="2" width="14" height="10" rx="1.5"/><line x1="5" y1="15" x2="11" y2="15"/><line x1="8" y1="12" x2="8" y2="15"/></svg>
+        </button>
+        <button id="logoutBtn" class="menu-btn" title="Logout">
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M7 3H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h3"/>
+            <polyline points="11,6 15,9 11,12"/>
+            <line x1="15" y1="9" x2="7" y2="9"/>
+          </svg>
+        </button>
+        <button id="moreBtn" class="menu-btn" title="More actions">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <circle cx="10" cy="4" r="1.5"/>
+            <circle cx="10" cy="10" r="1.5"/>
+            <circle cx="10" cy="16" r="1.5"/>
+          </svg>
+        </button>
+      </div>
+    </header>
+
+    <main id="dashboardContent">
+      <!-- Time Series Chart -->
+      <section class="chart-section">
+        <h2>Events over time</h2>
+        <div class="chart-container">
+          <canvas id="chart"></canvas>
+        </div>
+      </section>
+
+
+      <div id="contentArea">
+      <!-- Filters View (Breakdowns) -->
+      <div id="filtersView" class="visible">
+        <!-- Breakdown Tables -->
+        <section class="breakdowns breakdowns-pinned" id="breakdowns-pinned"></section>
+        <section class="breakdowns" id="breakdowns">
+        <div class="breakdown-card" id="breakdown-outcome">
+          <h3>Outcome</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-status">
+          <h3>Status</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-script-name">
+          <h3>Worker</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-method">
+          <h3>Method</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-url">
+          <h3>URL</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-script-version">
+          <h3>Version</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-ray-id">
+          <h3>Ray ID</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-logs">
+          <h3>Logs</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+        <div class="breakdown-card" id="breakdown-exceptions">
+          <h3>Exceptions</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
+      </section>
+      <section class="breakdowns breakdowns-hidden" id="breakdowns-hidden"></section>
+      </div>
+
+      <!-- Logs View -->
+      <div id="logsView">
+        <div class="logs-table-container">
+          <div class="logs-loading"><div class="spinner"></div>Loading logs...</div>
+        </div>
+      </div>
+      </div><!-- end #contentArea -->
+    </main>
+  </div>
+
+  <!-- Quick Links Modal -->
+  <dialog id="quickLinksModal">
+    <div class="modal-header">
+      <h2>Quick Links</h2>
+      <button class="modal-close" data-action="close-quick-links">&times;</button>
+    </div>
+    <iframe id="quickLinksFrame" src="index.html"></iframe>
+  </dialog>
+
+  <!-- More Actions Menu -->
+  <dialog id="moreMenu" class="dropdown-menu">
+    <button class="menu-item" id="moreViewToggleItem">
+      <span class="menu-item-label">Switch to Logs view</span>
+      <kbd class="menu-item-kbd">t</kbd>
+    </button>
+    <button class="menu-item" id="moreRefreshItem">
+      <span class="menu-item-label">Refresh</span>
+      <kbd class="menu-item-kbd">r</kbd>
+    </button>
+    <div class="menu-divider"></div>
+    <button class="menu-item" id="moreLogoutItem">
+      <span class="menu-item-label">Logout</span>
+    </button>
+  </dialog>
+
+  <!-- Keyboard Help Dialog -->
+  <dialog id="keyboardHelp" role="dialog" aria-labelledby="keyboardHelpTitle">
+    <div class="keyboard-help-content">
+      <h2 id="keyboardHelpTitle">Keyboard Shortcuts <button data-action="close-dialog" aria-label="Close">&times;</button></h2>
+      <div class="keyboard-help-grid">
+        <div class="key-group"><kbd>j</kbd> <kbd>k</kbd></div>
+        <div class="key-desc">Navigate between values</div>
+
+        <div class="key-group"><kbd>h</kbd> <kbd>l</kbd></div>
+        <div class="key-desc">Navigate between facets</div>
+
+        <div class="key-group"><kbd>Tab</kbd></div>
+        <div class="key-desc">Next value (wraps to next facet)</div>
+
+        <div class="key-group"><kbd>i</kbd> <kbd>c</kbd> <kbd>Space</kbd></div>
+        <div class="key-desc">Toggle filter on value (Shift+click for exclude; tap value to reveal Filter/Exclude on touch)</div>
+
+        <div class="key-group"><kbd>e</kbd> <kbd>x</kbd></div>
+        <div class="key-desc">Toggle exclude on value</div>
+
+        <div class="key-group"><kbd>c</kbd><kbd>c</kbd></div>
+        <div class="key-desc">Clear all filters</div>
+
+        <div class="key-group"><kbd>.</kbd></div>
+        <div class="key-desc">Expand (other) / show more</div>
+
+        <div class="key-group"><kbd>o</kbd></div>
+        <div class="key-desc">Open link in new tab</div>
+
+        <div class="key-group"><kbd>p</kbd></div>
+        <div class="key-desc">Pin/unpin facet</div>
+
+        <div class="key-group"><kbd>d</kbd></div>
+        <div class="key-desc">Hide/show facet</div>
+
+        <div class="key-group"><kbd>g</kbd></div>
+        <div class="key-desc">Go to facet (quick navigation)</div>
+
+        <div class="key-group"><kbd>r</kbd></div>
+        <div class="key-desc">Refresh data</div>
+
+        <div class="key-group"><kbd>f</kbd></div>
+        <div class="key-desc">Focus function filter</div>
+
+        <div class="key-group"><kbd>t</kbd></div>
+        <div class="key-desc">Cycle view</div>
+
+        <div class="key-group"><kbd>1</kbd>-<kbd>5</kbd></div>
+        <div class="key-desc">Zoom to anomaly by rank</div>
+
+        <div class="key-group"><kbd>+</kbd></div>
+        <div class="key-desc">Zoom timeframe to most prominent anomaly</div>
+
+        <div class="key-group"><kbd>-</kbd></div>
+        <div class="key-desc">Zoom timeframe out to larger period</div>
+
+        <div class="key-group"><kbd>?</kbd></div>
+        <div class="key-desc">Show this help</div>
+
+        <div class="key-group"><kbd>Esc</kbd></div>
+        <div class="key-desc">Exit keyboard mode</div>
+      </div>
+    </div>
+  </dialog>
+
+  <!-- Log Detail Modal -->
+  <dialog id="logDetailModal" role="dialog" aria-labelledby="logDetailTitle">
+    <div class="log-detail-header">
+      <h2 id="logDetailTitle">Log Entry Details</h2>
+      <button class="modal-close" data-action="close-log-detail">&times;</button>
+    </div>
+    <div class="log-detail-content">
+      <table class="log-detail-table" id="logDetailTable"></table>
+    </div>
+  </dialog>
+
+  <!-- Facet Command Palette (VS Code-style goto) -->
+  <dialog id="facetPalette" role="dialog" aria-labelledby="facetPaletteTitle">
+    <div class="palette-header">
+      <input type="text" id="facetPaletteInput" placeholder="Go to facet..." aria-label="Search facets">
+    </div>
+    <div id="facetPaletteList" role="listbox" aria-label="Facet list"></div>
+  </dialog>
+
+  <!-- Facet Value Search Popover -->
+  <dialog id="facetSearchPopover" role="dialog" aria-labelledby="facetSearchTitle">
+    <div class="facet-search-header">
+      <h4 id="facetSearchTitle">Search</h4>
+      <input type="text" id="facetSearchInput" placeholder="Search values..." aria-label="Search facet values">
+    </div>
+    <div id="facetSearchResults" role="listbox" aria-label="Search results"></div>
+  </dialog>
+
+  <script type="module" src="js/helix-mixer-main.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -69,6 +69,12 @@
         </a>
       </li>
       <li>
+        <a href="helix-mixer.html">
+          <div class="title">Helix Mixer Logs</div>
+          <div class="description">Cloudflare Workers trace logs for the helix3--helix-mixer worker: console/error output, outcome, ray_id</div>
+        </a>
+      </li>
+      <li>
         <a href="domains.html">
           <div class="title">Domain Explorer</div>
           <div class="description">Map AEM Edge Delivery hostnames to customer domains via x-forwarded-host</div>

--- a/js/breakdowns/definitions-helix-mixer.js
+++ b/js/breakdowns/definitions-helix-mixer.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { COLUMN_DEFS } from '../columns.js';
+
+/**
+ * Breakdown (facet) definitions for the helix_mixer_logs table
+ * (Cloudflare Workers Trace Events for the helix3--helix-mixer worker).
+ */
+export const helixMixerBreakdowns = [
+  {
+    id: 'breakdown-outcome',
+    col: '`outcome`',
+    summaryCountIf: "`outcome` IN ('exception', 'exceeded')",
+    summaryLabel: 'error rate',
+    summaryColor: 'error',
+  },
+  {
+    id: 'breakdown-status',
+    col: COLUMN_DEFS.status.facetCol,
+  },
+  {
+    id: 'breakdown-script-name',
+    col: '`script_name`',
+  },
+  {
+    id: 'breakdown-method',
+    col: COLUMN_DEFS.method.facetCol,
+  },
+  {
+    id: 'breakdown-url',
+    col: COLUMN_DEFS.url.facetCol,
+    highCardinality: true,
+  },
+  {
+    id: 'breakdown-script-version',
+    col: '`script_version`',
+    highCardinality: true,
+  },
+  {
+    id: 'breakdown-ray-id',
+    col: '`ray_id`',
+    highCardinality: true,
+    // "0" marks internal service-binding calls that never appear in a CDN access-log
+    // table, so it's not a useful breakdown value.
+    extraFilter: "AND `ray_id` != '' AND `ray_id` != '0'",
+  },
+  {
+    id: 'breakdown-logs',
+    col: 'arrayJoin(`logs`)',
+    filterCol: '`logs`',
+    filterOp: 'HAS',
+    highCardinality: true,
+    maxTimeRangeHours: 24,
+  },
+  {
+    id: 'breakdown-exceptions',
+    col: 'arrayJoin(`exceptions`)',
+    filterCol: '`exceptions`',
+    filterOp: 'HAS',
+    highCardinality: true,
+    maxTimeRangeHours: 24,
+  },
+];

--- a/js/breakdowns/definitions-helix-mixer.test.js
+++ b/js/breakdowns/definitions-helix-mixer.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { assert } from 'chai';
+import { helixMixerBreakdowns } from './definitions-helix-mixer.js';
+
+describe('helixMixerBreakdowns', () => {
+  it('has nine facets', () => {
+    assert.strictEqual(helixMixerBreakdowns.length, 9);
+  });
+
+  it('each facet has a unique id and a col (string or function)', () => {
+    const ids = new Set();
+    helixMixerBreakdowns.forEach((b) => {
+      assert.ok(typeof b.col === 'string' || typeof b.col === 'function');
+      assert.isFalse(ids.has(b.id), `duplicate id: ${b.id}`);
+      ids.add(b.id);
+    });
+  });
+
+  it('outcome facet flags exception/exceeded as the error-rate summary', () => {
+    const outcome = helixMixerBreakdowns.find((b) => b.id === 'breakdown-outcome');
+    assert.ok(outcome);
+    assert.strictEqual(outcome.summaryCountIf, "`outcome` IN ('exception', 'exceeded')");
+    assert.strictEqual(outcome.summaryLabel, 'error rate');
+    assert.strictEqual(outcome.summaryColor, 'error');
+  });
+
+  it('ray-id facet excludes empty and internal service-binding ("0") values', () => {
+    const rayId = helixMixerBreakdowns.find((b) => b.id === 'breakdown-ray-id');
+    assert.ok(rayId);
+    assert.include(rayId.extraFilter, "`ray_id` != ''");
+    assert.include(rayId.extraFilter, "`ray_id` != '0'");
+  });
+
+  it('logs and exceptions facets arrayJoin their column and cap the time range', () => {
+    const logs = helixMixerBreakdowns.find((b) => b.id === 'breakdown-logs');
+    const exceptions = helixMixerBreakdowns.find((b) => b.id === 'breakdown-exceptions');
+    assert.strictEqual(logs.col, 'arrayJoin(`logs`)');
+    assert.strictEqual(logs.filterOp, 'HAS');
+    assert.strictEqual(logs.maxTimeRangeHours, 24);
+    assert.strictEqual(exceptions.col, 'arrayJoin(`exceptions`)');
+    assert.strictEqual(exceptions.filterOp, 'HAS');
+    assert.strictEqual(exceptions.maxTimeRangeHours, 24);
+  });
+
+  it('url and script-version facets are marked high cardinality', () => {
+    const url = helixMixerBreakdowns.find((b) => b.id === 'breakdown-url');
+    const version = helixMixerBreakdowns.find((b) => b.id === 'breakdown-script-version');
+    assert.strictEqual(url.highCardinality, true);
+    assert.strictEqual(version.highCardinality, true);
+  });
+});

--- a/js/helix-mixer-main.js
+++ b/js/helix-mixer-main.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { initDashboard } from './dashboard-init.js';
+import { helixMixerBreakdowns } from './breakdowns/definitions-helix-mixer.js';
+
+const LOG_COLUMN_ORDER = [
+  'timestamp',
+  'outcome',
+  'response.status',
+  'script_name',
+  'request.method',
+  'request.url',
+  'ray_id',
+  'logs',
+  'exceptions',
+  'cpu_ms',
+  'wall_ms',
+  'script_version',
+];
+
+const DEFAULT_HIDDEN_FACETS = [
+  'breakdown-script-version',
+  'breakdown-ray-id',
+];
+
+// outcome and response.status are independent signals here: status is 0 for
+// service-binding calls and WebSocket upgrades even when the invocation succeeded,
+// so "ok" must not require status < 400.
+const MIXER_AGGREGATIONS = {
+  aggTotal: 'count()',
+  aggOk: "countIf(outcome NOT IN ('exception', 'exceeded') AND (`response.status` = 0 OR `response.status` < 400))",
+  agg4xx: 'countIf(`response.status` >= 400 AND `response.status` < 500)',
+  agg5xx: "countIf(outcome IN ('exception', 'exceeded') OR `response.status` >= 500)",
+};
+
+initDashboard({
+  title: 'Helix Mixer Logs',
+  tableName: 'helix_mixer_logs',
+  timeSeriesTemplate: 'time-series-helix-mixer',
+  aggregations: MIXER_AGGREGATIONS,
+  hostFilterColumn: 'script_name',
+  requestIdColumn: 'ray_id',
+  messageColumn: 'request.url',
+  defaultTimeRange: '24h',
+  logColumnOrder: LOG_COLUMN_ORDER,
+  defaultHiddenFacets: DEFAULT_HIDDEN_FACETS,
+  breakdowns: helixMixerBreakdowns,
+});

--- a/js/sql-loader.js
+++ b/js/sql-loader.js
@@ -63,6 +63,7 @@ const ALL_TEMPLATES = [
   'time-series-delivery',
   'time-series-backend',
   'time-series-da-workers',
+  'time-series-helix-mixer',
   'ray-id-lookup',
   'ray-id-lookup-worker',
   'logs',

--- a/sql/queries/time-series-helix-mixer.sql
+++ b/sql/queries/time-series-helix-mixer.sql
@@ -1,0 +1,9 @@
+SELECT
+  {{bucket}} as t,
+  countIf(outcome NOT IN ('exception', 'exceeded') AND (`response.status` = 0 OR `response.status` < 400)) as cnt_ok,
+  countIf(`response.status` >= 400 AND `response.status` < 500) as cnt_4xx,
+  countIf(outcome IN ('exception', 'exceeded') OR `response.status` >= 500) as cnt_5xx
+FROM {{database}}.{{table}}
+WHERE {{timeFilter}} {{hostFilter}} {{facetFilters}} {{additionalWhereClause}}
+GROUP BY t
+ORDER BY t WITH FILL FROM {{rangeStart}} TO {{rangeEnd}} STEP {{step}}


### PR DESCRIPTION
## Summary
- Isolated copy of the DA Worker Logs dashboard for the new `helix_mixer_logs` table introduced in [adobe/helix-gcs2clickhouse-ingestor#17](https://github.com/adobe/helix-gcs2clickhouse-ingestor/pull/17).
- `helix_mixer_logs` is a byte-for-byte schema/parser duplicate of `da_worker_logs` (same Workers Trace Events shape, same columns), for the `helix3--helix-mixer` worker instead of the DA workers.
- New files: `helix-mixer.html`, `js/helix-mixer-main.js`, `js/breakdowns/definitions-helix-mixer.js` (+ test), `sql/queries/time-series-helix-mixer.sql`.
- Registered the new SQL template in `js/sql-loader.js` and added a quick-link card in `index.html`.
- No ray_id cross-table resolve wired up (no known CDN-log join target for the mixer worker, same as `lambda_logs`).
- Out of scope: granting `helix_mixer_logs` SELECT to read-only users (`scripts/add-user.mjs`) — that's a separate infra change once the table exists in ClickHouse.

## Testing Done
- `npm run lint` clean
- `npm test` — 963 tests pass
- Verified `helix-mixer.html` loads with 0 console errors via playwright-cli against the local dev server

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Documentation updated (if applicable)