### PR TITLE
feat: search Site Configs by content bus ID and org/site pairs

### DIFF
--- a/configs.html
+++ b/configs.html
@@ -68,7 +68,7 @@
           <button class="view-opt" data-view="raw" aria-pressed="true">Raw</button>
           <button class="view-opt" data-view="resolved" aria-pressed="false">Resolved</button>
         </div>
-        <input type="text" id="searchInput" placeholder="Filter by org or site...">
+        <input type="text" id="searchInput" placeholder="Filter by org, site, or content bus ID...">
         <button id="moreBtn" class="menu-btn" title="More actions">
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
             <circle cx="10" cy="4" r="1.5"/>

--- a/js/configs-main.js
+++ b/js/configs-main.js
@@ -152,9 +152,17 @@ function renderFacetBreakdown(tbodyEl, data, activeFilter) {
 
 function matchesText(row, filterText) {
   if (!filterText) { return true; }
+  const slashIdx = filterText.indexOf('/');
+  if (slashIdx !== -1) {
+    const orgPart = filterText.slice(0, slashIdx).trim();
+    const sitePart = filterText.slice(slashIdx + 1).trim();
+    return row.org.toLowerCase().includes(orgPart)
+      && row.site.toLowerCase().includes(sitePart);
+  }
   return row.org.toLowerCase().includes(filterText)
     || row.site.toLowerCase().includes(filterText)
-    || row.cdn_prod_host.toLowerCase().includes(filterText);
+    || row.cdn_prod_host.toLowerCase().includes(filterText)
+    || (row.content_bus_id || '').toLowerCase().includes(filterText);
 }
 
 function matchesFacets(row) {


### PR DESCRIPTION
## Summary
- Extends the Site Configs search box to also match against `content_bus_id`, so pasting a 59-char hex content bus ID finds the org/site it belongs to.
- When the search text contains a `/` (e.g. `org/site`), splits on the slash and requires the org part to match `org` and the site part to match `site`, instead of OR'ing a single substring across all fields.
- Updated the search input placeholder to reflect the new capability.

No SQL/backend changes were needed — `content_bus_id` was already selected by the existing `configs-list.sql`/`configs-resolved-list.sql` queries and present on every in-memory row; filtering in this view is entirely client-side.

## Testing Done
- Ran the full suite (`npm test`): 963/963 tests passed.
- Ran `npm run lint`: clean.
- Manually verified end-to-end in a live browser session against production ClickHouse data (via `playwright-cli`):
  - Copied a real site's content bus ID from the detail dialog, pasted it into the search box, and confirmed it correctly narrowed the full result set down to only the sites sharing that ID.
  - Verified partial/substring content-bus-ID search also narrows results.
  - Verified the feature works in both Raw and Resolved views.
  - Searched a slash-delimited `org/site` query and confirmed results were correctly restricted to rows where org and site each matched their respective half of the query.

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable) — N/A, no docs needed for this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)