### PR TITLE
feat: add overlay filter to the dashboard and fix existing bug in resolving overlay information

### DIFF
--- a/configs.html
+++ b/configs.html
@@ -109,6 +109,12 @@
             <tbody id="codeSourceTypeBody"></tbody>
           </table>
         </div>
+        <div class="type-breakdown">
+          <h3>Overlay</h3>
+          <table class="type-table" id="overlayTypeTable">
+            <tbody id="overlayTypeBody"></tbody>
+          </table>
+        </div>
       </section>
 
       <!-- Site configs table -->

--- a/js/configs-main.js
+++ b/js/configs-main.js
@@ -30,10 +30,11 @@ const s = {
   typeRowsData: [],
   contentTypeRowsData: [],
   codeSourceTypeRowsData: [],
+  overlayTypeRowsData: [],
   statsData: {},
   // chip (boolean presence) filters
   chipFilters: {
-    cdn_host: false, cdn_type: false, folders: false, profile: false,
+    cdn_host: false, cdn_type: false, folders: false, profile: false, overlay: false,
   },
   sortCol: 'org',
   sortAsc: true,
@@ -41,6 +42,7 @@ const s = {
   cdnTypeFilter: null,
   contentTypeFilter: null,
   codeSourceTypeFilter: null,
+  overlayTypeFilter: null,
   resolvedView: false,
 };
 
@@ -61,6 +63,7 @@ const els = {
   typeBody: document.getElementById('typeBody'),
   contentTypeBody: document.getElementById('contentTypeBody'),
   codeSourceTypeBody: document.getElementById('codeSourceTypeBody'),
+  overlayTypeBody: document.getElementById('overlayTypeBody'),
   pagination: document.getElementById('pagination'),
   pageInfo: document.getElementById('pageInfo'),
   prevBtn: document.getElementById('prevBtn'),
@@ -117,6 +120,12 @@ function renderStats(stats, total) {
       value: formatNumber(Number(stats.with_profile)),
       pct: pct(Number(stats.with_profile)),
       key: 'profile',
+    },
+    {
+      label: 'With overlay',
+      value: formatNumber(Number(stats.with_overlay)),
+      pct: pct(Number(stats.with_overlay)),
+      key: 'overlay',
     },
   ];
 
@@ -178,17 +187,23 @@ function matchesFacets(row) {
     const want = s.codeSourceTypeFilter === '(none)' ? '' : s.codeSourceTypeFilter;
     if (row.code_source_type !== want) { return false; }
   }
+  if (s.overlayTypeFilter) {
+    const want = s.overlayTypeFilter === '(none)' ? '' : s.overlayTypeFilter;
+    if ((row.content_source_overlay_type || '') !== want) { return false; }
+  }
   return true;
 }
 
 function matchesChips(row) {
   const {
     cdn_host: fCdnHost, cdn_type: fCdnType, folders: fFolders, profile: fProfile,
+    overlay: fOverlay,
   } = s.chipFilters;
   if (fCdnHost && !row.cdn_prod_host) { return false; }
   if (fCdnType && !row.cdn_prod_type) { return false; }
   if (fFolders && row.folders !== '1' && row.folders !== true) { return false; }
   if (fProfile && !row.profile) { return false; }
+  if (fOverlay && !row.content_source_overlay_url) { return false; }
   return true;
 }
 
@@ -234,6 +249,7 @@ function renderTable() {
   }).join('');
 
   const anyFilter = filterText || s.cdnTypeFilter || s.contentTypeFilter
+    || s.codeSourceTypeFilter || s.overlayTypeFilter
     || Object.values(s.chipFilters).some(Boolean);
   els.rowCount.textContent = anyFilter
     ? `${formatNumber(filtered.length)} of ${formatNumber(s.rows.length)} sites`
@@ -405,22 +421,24 @@ async function loadData(refresh = false) {
     const params = { database: DATABASE, source };
     const compareParams = { database: DATABASE, source: compareSource };
     // eslint-disable-next-line max-len
-    const [sqlStats, sqlByType, sqlByContentType, sqlByCodeSourceType, sqlList, sqlCompare] = await Promise.all([
+    const [sqlStats, sqlByType, sqlByContentType, sqlByCodeSourceType, sqlByOverlayType, sqlList, sqlCompare] = await Promise.all([
       loadSql('configs-stats', params),
       loadSql('configs-by-type', params),
       loadSql('configs-by-content-type', params),
       loadSql('configs-by-code-source-type', params),
+      loadSql('configs-by-overlay-type', params),
       loadSql('configs-list', params),
       loadSql('configs-resolved-list', compareParams),
     ]);
 
     const start = performance.now();
     // eslint-disable-next-line max-len
-    const [statsResult, typeResult, contentTypeResult, codeSourceTypeResult, listResult, compareResult] = await Promise.all([
+    const [statsResult, typeResult, contentTypeResult, codeSourceTypeResult, overlayTypeResult, listResult, compareResult] = await Promise.all([
       query(sqlStats, { cacheTtl: 300 }),
       query(sqlByType, { cacheTtl: 300 }),
       query(sqlByContentType, { cacheTtl: 300 }),
       query(sqlByCodeSourceType, { cacheTtl: 300 }),
+      query(sqlByOverlayType, { cacheTtl: 300 }),
       query(sqlList, { cacheTtl: 300 }),
       query(sqlCompare, { cacheTtl: 300 }),
     ]);
@@ -441,6 +459,8 @@ async function loadData(refresh = false) {
     renderFacetBreakdown(els.contentTypeBody, s.contentTypeRowsData, s.contentTypeFilter);
     s.codeSourceTypeRowsData = codeSourceTypeResult.data || [];
     renderFacetBreakdown(els.codeSourceTypeBody, s.codeSourceTypeRowsData, s.codeSourceTypeFilter);
+    s.overlayTypeRowsData = overlayTypeResult.data || [];
+    renderFacetBreakdown(els.overlayTypeBody, s.overlayTypeRowsData, s.overlayTypeFilter);
     els.statsSection.style.display = '';
     els.loadingState.style.display = 'none';
     els.tableContainer.style.display = '';
@@ -469,6 +489,8 @@ document.getElementById('viewToggle').addEventListener('click', (e) => {
   s.resolvedView = wantResolved;
   s.cdnTypeFilter = null;
   s.contentTypeFilter = null;
+  s.codeSourceTypeFilter = null;
+  s.overlayTypeFilter = null;
   Object.keys(s.chipFilters).forEach((k) => { s.chipFilters[k] = false; });
   s.currentPage = 1;
   updateViewToggle();
@@ -537,6 +559,16 @@ document.getElementById('codeSourceTypeTable').addEventListener('click', (e) => 
   s.codeSourceTypeFilter = s.codeSourceTypeFilter === tr.dataset.type ? null : tr.dataset.type;
   s.currentPage = 1;
   renderFacetBreakdown(els.codeSourceTypeBody, s.codeSourceTypeRowsData, s.codeSourceTypeFilter);
+  renderTable();
+});
+
+// Overlay type facet — click to filter, click again to clear
+document.getElementById('overlayTypeTable').addEventListener('click', (e) => {
+  const tr = e.target.closest('tr.type-row');
+  if (!tr) { return; }
+  s.overlayTypeFilter = s.overlayTypeFilter === tr.dataset.type ? null : tr.dataset.type;
+  s.currentPage = 1;
+  renderFacetBreakdown(els.overlayTypeBody, s.overlayTypeRowsData, s.overlayTypeFilter);
   renderTable();
 });
 

--- a/scripts/import-helix-configs.mjs
+++ b/scripts/import-helix-configs.mjs
@@ -89,6 +89,11 @@ function resolveContentType(url, fallback) {
   return fallback;
 }
 
+function resolveOverlayType(url, fallback) {
+  if (url.includes('json2html')) { return 'json2html'; }
+  return resolveContentType(url, fallback);
+}
+
 function resolveCodeSourceType(codeSource) {
   const url = str(codeSource.url);
   if (!url) { return str(codeSource.type); }
@@ -124,7 +129,7 @@ function siteRow(org, site, data) {
     content_bus_id: str(content.contentBusId),
     content_source_type: resolveContentType(contentSourceUrl, str(contentSource.type)),
     content_source_url: contentSourceUrl,
-    content_source_overlay_type: resolveContentType(contentOverlayUrl, str(contentOverlay.type)),
+    content_source_overlay_type: resolveOverlayType(contentOverlayUrl, str(contentOverlay.type)),
     content_source_overlay_url: contentOverlayUrl,
     cdn_prod_host: str(cdnProd.host),
     cdn_prod_type: str(cdnProd.type),
@@ -157,7 +162,7 @@ function profileRow(org, profile, data) {
     content_bus_id: str(content.contentBusId),
     content_source_type: resolveContentType(contentSourceUrl, str(contentSource.type)),
     content_source_url: contentSourceUrl,
-    content_source_overlay_type: resolveContentType(contentOverlayUrl, str(contentOverlay.type)),
+    content_source_overlay_type: resolveOverlayType(contentOverlayUrl, str(contentOverlay.type)),
     content_source_overlay_url: contentOverlayUrl,
     cdn_prod_host: str(cdnProd.host),
     cdn_prod_type: str(cdnProd.type),

--- a/scripts/import-helix-configs.mjs
+++ b/scripts/import-helix-configs.mjs
@@ -106,7 +106,7 @@ function siteRow(org, site, data) {
   const codeSource = code.source || {};
   const content = data.content || {};
   const contentSource = content.source || {};
-  const contentOverlay = contentSource.overlay || {};
+  const contentOverlay = content.overlay || {};
   const cdnProd = (data.cdn && data.cdn.prod) || {};
   const contentSourceUrl = str(contentSource.url);
   const contentOverlayUrl = str(contentOverlay.url);
@@ -140,7 +140,7 @@ function profileRow(org, profile, data) {
   const codeSource = code.source || {};
   const content = data.content || {};
   const contentSource = content.source || {};
-  const contentOverlay = contentSource.overlay || {};
+  const contentOverlay = content.overlay || {};
   const cdnProd = (data.cdn && data.cdn.prod) || {};
   const contentSourceUrl = str(contentSource.url);
   const contentOverlayUrl = str(contentOverlay.url);

--- a/sql/queries/configs-by-overlay-type.sql
+++ b/sql/queries/configs-by-overlay-type.sql
@@ -1,0 +1,6 @@
+SELECT
+  if(content_source_overlay_type = '', '(none)', content_source_overlay_type) AS type,
+  count() AS cnt
+FROM {{database}}.{{source}}
+GROUP BY type
+ORDER BY cnt DESC

--- a/sql/queries/configs-stats.sql
+++ b/sql/queries/configs-stats.sql
@@ -3,5 +3,6 @@ SELECT
   countIf(cdn_prod_host != '')   AS with_cdn_host,
   countIf(cdn_prod_type != '')   AS with_cdn_type,
   countIf(folders)               AS with_folders,
-  countIf(profile != '')         AS with_profile
+  countIf(profile != '')         AS with_profile,
+  countIf(content_source_overlay_url != '') AS with_overlay
 FROM {{database}}.{{source}}


### PR DESCRIPTION
## Summary

Site configs never captured content-source overlays: the detail view always showed "—" for Overlay type/URL, and there was no way to report on overlay usage.

**Root cause:** the importer read the overlay from `content.source.overlay`, but in the config JSON `overlay` is a sibling of `source` (`content.overlay`). That path was always `undefined`, so all 62,582 rows had empty overlay columns.

This PR:
- **Fixes the import path** — read overlays from `content.overlay` in both `siteRow` and `profileRow` (`scripts/import-helix-configs.mjs`).
- **Classifies overlays by tool** — new `resolveOverlayType()` labels any overlay URL containing `json2html` (covers `json2html.adobeaem.workers.dev` and `json2html-ci…`) as `json2html`, otherwise falls back to the existing content-source detection (`da`/`xwalk`/`source`/raw type).
- **Adds overlay reporting to the dashboard:**
  - New **"Overlay"** facet breakdown table (clickable to filter the site list), mirroring the Content/Code Source breakdowns.
  - New **"With overlay"** presence stat chip (count + % of sites with any overlay).
  - New `sql/queries/configs-by-overlay-type.sql` and a `with_overlay` count in `configs-stats.sql`.
  - Both new filters reset correctly on the raw/resolved view toggle.

Note: existing rows stay empty until the next config import backfills them.

## Testing Done

- **Confirmed root cause against production:** `SELECT count(), countIf(content_source_overlay_type != ''), countIf(content_source_overlay_url != '')` on `site_configs FINAL` returned `62582 / 0 / 0`; a real config (`amol-anand/demo`) has its overlay at `content.overlay`, not `content.source.overlay`.
- **Verified classification** of `resolveOverlayType`: both `json2html.adobeaem.workers.dev/...` and `json2html-ci.adobeaem.workers.dev/...` → `json2html`; `content.da.live` → `da`; `.adobeaemcloud.com` → `xwalk`; empty URL → `''` (no overlay).
- **Confirmed the render path** was never the problem — Overlay rows are always emitted in the detail modal (showing "—" when empty).
- `npm test` → 963 passed, 0 failed (93.53% coverage).
- `npm run lint` → clean.

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [ ] Documentation updated (if applicable)
