### PR TITLE
feat: add hidden Restarts filter to Backend view

### DIFF
--- a/backend.html
+++ b/backend.html
@@ -225,6 +225,10 @@
           <h3>Resource path</h3>
           <div class="loading"><div class="spinner"></div>Loading...</div>
         </div>
+        <div class="breakdown-card" id="breakdown-restarts">
+          <h3>Restarts</h3>
+          <div class="loading"><div class="spinner"></div>Loading...</div>
+        </div>
       </section>
       <section class="breakdowns breakdowns-hidden" id="breakdowns-hidden"></section>
       </div>

--- a/js/backend-main.js
+++ b/js/backend-main.js
@@ -25,6 +25,7 @@ const DEFAULT_HIDDEN_FACETS = [
   'breakdown-helix-owner',
   'breakdown-helix-repo',
   'breakdown-helix-path',
+  'breakdown-restarts',
 ];
 
 initDashboard({

--- a/js/breakdowns/definitions.js
+++ b/js/breakdowns/definitions.js
@@ -130,6 +130,7 @@ export const allBreakdowns = [
     id: 'breakdown-rso', col: COLUMN_DEFS.rso.facetCol, extraFilter: "AND `helix.rso` != ''",
   },
   { id: 'breakdown-cdn-version', col: '`cdn.version`', extraFilter: "AND `cdn.version` != ''" },
+  { id: 'breakdown-restarts', col: COLUMN_DEFS.restarts.facetCol },
   { id: 'breakdown-helix-route', col: '`helix.route`', extraFilter: "AND `helix.route` != ''" },
   { id: 'breakdown-severity', col: COLUMN_DEFS.severity.facetCol, extraFilter: "AND `response.headers.x_severity` != ''" },
   { id: 'breakdown-helix-topic', col: '`helix.topic`', extraFilter: "AND `helix.topic` != ''" },

--- a/js/columns.js
+++ b/js/columns.js
@@ -33,6 +33,13 @@ export const COLUMN_DEFS = {
     label: 'Method',
     shortLabel: 'method',
   },
+  restarts: {
+    logKey: 'request.restarts',
+    facetCol: 'toString(`request.restarts`)',
+    label: 'Restarts',
+    shortLabel: 'restarts',
+    filterTransform: (value) => String(value),
+  },
   host: {
     logKey: 'request.host',
     facetCol: '`request.host`',


### PR DESCRIPTION
## Summary
Adds a **Restarts** breakdown/filter (`request.restarts`) to the Backend view. The column is a `UInt8` with low cardinality (values 0–3), so it queries the raw `backend` table directly (no facet-table entry needed). It is **initially hidden** — added to `DEFAULT_HIDDEN_FACETS` in `backend-main.js` — and appears in the hidden facets section where users can reveal it.

Changes:
- `js/columns.js` — new `COLUMN_DEFS.restarts` entry, modeled on `status` (numeric column wrapped in `toString(...)`, `filterTransform` coerces to string).
- `js/breakdowns/definitions.js` — new `breakdown-restarts` definition.
- `backend.html` — new `breakdown-card` for Restarts (Backend view only; not added to `delivery.html`).
- `js/backend-main.js` — `breakdown-restarts` added to `DEFAULT_HIDDEN_FACETS`.

## Testing Done
- `npm test` — all 963 tests pass.
- `npm run lint` — edited files lint clean. (The one remaining error, `dotenv` unresolved in `scripts/import-helix-configs.mjs`, is pre-existing and unrelated to this change.)
- Verified `backend.html` serves the `breakdown-restarts` card via the dev server.

## Checklist
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`) — edited files clean; pre-existing unrelated `dotenv` error remains
- [ ] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)